### PR TITLE
ExplicitInitialization removes initialization from final fields when using @Value

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
@@ -16,7 +16,9 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -41,6 +43,39 @@ class ExplicitInitializationTest implements RewriteTest {
               class Test {
                   @Builder.Default
                   private boolean b = false;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ignoreFinalField() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  private final boolean b = false;
+              }
+              """
+          )
+        );
+    }
+
+    @ExpectedToFail("Lombok @Value makes the field final, so the default value cannot be removed. The result will add the field to the default constructor,")
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/101")
+    @Test
+    void ignoreLombokValueField() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),
+          //language=java
+          java(
+            """
+              import lombok.Value;
+              @Value
+              class Test {
+                  boolean b = false;
               }
               """
           )


### PR DESCRIPTION
Add test with @ExpectedToFail
issue: https://github.com/openrewrite/rewrite-static-analysis/issues/101