### PR TITLE
`UseDiamondOperator` should also apply to anonymous classes in Java 9+

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -26,10 +26,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.*;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class ReplaceLambdaWithMethodReference extends Recipe {
@@ -144,11 +141,15 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                     JavaType.Method methodType = method.getMethodType();
                     if (methodType != null) {
                         JavaType.FullyQualified declaringType = methodType.getDeclaringType();
+                        JavaType.FullyQualified topLevelType = declaringType;
+                        while (topLevelType.getOwningClass() != null) {
+                            topLevelType = topLevelType.getOwningClass();
+                        }
                         if (methodType.hasFlags(Flag.Static) ||
                             methodSelectMatchesFirstLambdaParameter(method, lambda)) {
-                            maybeAddImport(declaringType);
+                            maybeAddImport(topLevelType.getFullyQualifiedName());
                             return l.withTemplate(JavaTemplate.builder(this::getCursor, "#{}::#{}")
-                                            .imports(declaringType.getFullyQualifiedName())
+                                            .imports(topLevelType.getFullyQualifiedName())
                                             .build(),
                                     l.getCoordinates().replace(), declaringType.getClassName(),
                                     method.getMethodType().getName());

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -1039,4 +1039,92 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
     }
 
 
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3071")
+    void nestedType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package foo;
+
+              import java.util.HashMap;
+
+              class A {
+                  void m() {
+                      Object o = new HashMap<>().entrySet().stream()
+                                                         .map(e -> e.getKey())
+                                                         .findFirst();
+                  }
+              }
+              """,
+            """
+              import java.net.URI;
+              import java.nio.file.Path;
+              import java.nio.file.Paths;
+              import java.util.Optional;
+
+              class A {
+                  void m() {
+                      URI uri = Optional.ofNullable("path")
+                            .map(Paths::get)
+                            .map(Path::toUri)
+                            .orElse(null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3071")
+    void nestedType2() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package foo;
+
+              import java.util.HashMap;
+
+              class A {
+                  B b() {
+                      return null;
+                  }
+                  static class B {
+                      Object m() { return null;
+                      }
+                  }
+                  void m() {
+                      Object o = java.util.Optional.of(new A())
+                                                         .map(a -> a.b())
+                                                         .map(b -> b.m())
+                                                         .orElse(null);
+                  }
+              }
+              """,
+            """
+              import java.net.URI;
+              import java.nio.file.Path;
+              import java.nio.file.Paths;
+              import java.util.Optional;
+
+              class A {
+                  void m() {
+                      URI uri = Optional.ofNullable("path")
+                            .map(Paths::get)
+                            .map(Path::toUri)
+                            .orElse(null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+
 }


### PR DESCRIPTION
Starting with Java 9 the diamond operator can also be used when instantiating anonymous subclasses.