### PR TITLE
Do not remove explicit init in case lombok.Value is present on enclosing class

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
@@ -63,7 +63,6 @@ class ExplicitInitializationTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Lombok @Value makes the field final, so the default value cannot be removed. The result will add the field to the default constructor,")
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/101")
     @Test
     void ignoreLombokValueField() {


### PR DESCRIPTION
fixes: https://github.com/openrewrite/rewrite-static-analysis/issues/101
Do not remove explicit init in case lombok.Value is present on enclosing class