### PR TITLE
added a failing test for LambdaBlockToExpression

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
@@ -21,6 +21,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.marker.SearchResult;
 
@@ -53,7 +54,12 @@ public class LambdaBlockToExpression extends Recipe {
                         if (lambda.getBody() instanceof J.Block) {
                             List<Statement> statements = ((J.Block) lambda.getBody()).getStatements();
                             if (statements.size() == 1 && statements.get(0) instanceof J.Return) {
-                                return l.withBody(((J.Return) statements.get(0)).getExpression());
+                                Space prefix = statements.get(0).getPrefix();
+                                if (prefix.getComments().isEmpty()) {
+                                    return l.withBody(((J.Return) statements.get(0)).getExpression());
+                                } else {
+                                    return l.withBody(((J.Return) statements.get(0)).getExpression().withPrefix(prefix));
+                                }
                             }
                         }
                         return l;

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -52,7 +52,7 @@ class LambdaBlockToExpressionTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
+//    @Disabled
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1")
     void simplifyLambdaBlockToExpressionWithComments() {
         rewriteRun(
@@ -72,8 +72,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
               import java.util.function.Function;
               class Test {
                   Function<Integer, Integer> f = n -> 
-                  // The buttonType will always be "cancel", even if we pressed one of the entry type buttons
-                  n + 1;
+                      // The buttonType will always be "cancel", even if we pressed one of the entry type buttons
+                      n + 1;
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -48,4 +48,31 @@ class LambdaBlockToExpressionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void simplifyLambdaBlockToExpressionWithComments() {
+        rewriteRun(
+          spec -> spec.recipe(new LambdaBlockToExpression()),
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+              class Test {
+                  Function<Integer, Integer> f = n -> {
+                      // The buttonType will always be "cancel", even if we pressed one of the entry type buttons
+                      return n + 1;
+                  };
+              }
+              """,
+            """
+              import java.util.function.Function;
+              class Test {
+                  Function<Integer, Integer> f = n -> 
+                  // The buttonType will always be "cancel", even if we pressed one of the entry type buttons
+                  n + 1;
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -52,7 +52,6 @@ class LambdaBlockToExpressionTest implements RewriteTest {
     }
 
     @Test
-//    @Disabled
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1")
     void simplifyLambdaBlockToExpressionWithComments() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -15,8 +15,10 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
@@ -50,6 +52,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
     }
 
     @Test
+    @Disabled
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1")
     void simplifyLambdaBlockToExpressionWithComments() {
         rewriteRun(
           spec -> spec.recipe(new LambdaBlockToExpression()),


### PR DESCRIPTION
## What's changed?
added a failing test for LambdaBlockToExpression

## What's your motivation?
#1 

## Anything in particular you'd like reviewers to focus on?
Not sure if the name of my unit test is okay

## Have you considered any alternatives or workarounds?
Still get myself familiar with LST, probably will have new discovery later

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
