### PR TITLE
Remove blank JavaDoc blocks after RemoveJavaDocAuthorTag

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTag.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTag.java
@@ -15,9 +15,8 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.JavadocVisitor;
 import org.openrewrite.java.tree.Javadoc;
@@ -72,6 +71,9 @@ public class RemoveJavaDocAuthorTag extends Recipe {
 
                         if (isChanged) {
                             Collections.reverse(newBody);
+                            if (isBlank(getCursor(), newBody)) {
+                                return null;
+                            }
                             dc = dc.withBody(newBody);
                         }
                         return dc;
@@ -79,5 +81,13 @@ public class RemoveJavaDocAuthorTag extends Recipe {
                 };
             }
         };
+    }
+
+    static boolean isBlank(Cursor cursor, List<Javadoc> newBody) {
+        return newBody.stream().allMatch(jd -> {
+            PrintOutputCapture<Object> p = new PrintOutputCapture<>(null);
+            jd.printer(cursor).visit(jd, p);
+            return StringUtils.isBlank(p.getOut());
+        });
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTagTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTagTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -40,8 +41,24 @@ class RemoveJavaDocAuthorTagTest implements RewriteTest {
               class Test {}
               """,
             """
+              class Test {}
+              """
+          )
+        );
+    }
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/119")
+    void tagOnSecondLine() {
+        rewriteRun(
+          //language=java
+          java(
+            """
               /**
+               * @author foo.bar
                */
+              class Test {}
+              """,
+            """
               class Test {}
               """
           )
@@ -50,6 +67,7 @@ class RemoveJavaDocAuthorTagTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/1640")
     @Test
+    @DocumentExample
     void preserveDocsBeforeTag() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What's changed?
Check if the remaining JavaDoc lines are all blank after removing author tag.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/119

## Anything in particular you'd like reviewers to focus on?
Usage of PrintOutputCapture & Cursor to check for blank lines; wasn't sure if there's any other mechanism.
 
## Have you considered any alternatives or workarounds?
We could pull `isBlank` into `JavaDoc`, if we want to also fix this for #98, which has a slightly broader scope: trim in addition to remove when fully empty.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
