### PR TITLE
new recipe that changes .equals() to .contentEquals() when comparing …

### DIFF
--- a/gradle/licenseHeader.txt
+++ b/gradle/licenseHeader.txt
@@ -1,4 +1,4 @@
-Copyright 2021 the original author or authors.
+Copyright 2023 the original author or authors.
 <p>
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -32,16 +32,14 @@ import java.util.stream.Stream;
 
 public class EqualsToContentEquals extends Recipe {
     private static final MethodMatcher equals_matcher = new MethodMatcher("java.lang.String equals(..)");
-    private static final List<String> TYPE_NAMES = Arrays.asList(
-            "java.lang.StringBuffer",
-            "java.lang.StringBuilder",
-            "java.lang.CharSequence"
-    );
-    @SuppressWarnings("unchecked")
-    private static final TreeVisitor<?, ExecutionContext> PRECONDITION =
-            Preconditions.or(TYPE_NAMES.stream().map(s -> new UsesType<>(s, false)).toArray(UsesType[]::new));
-    private static final List<MethodMatcher> toString_matchers = TYPE_NAMES.stream()
-            .map(obj -> new MethodMatcher(obj + " toString()")).collect(Collectors.toList());
+    private static final TreeVisitor<?, ExecutionContext> PRECONDITION = Preconditions.or(
+            new UsesType<>("java.lang.StringBuffer", false),
+            new UsesType<>("java.lang.StringBuilder", false),
+            new UsesType<>("java.lang.CharSequence", false));
+    private static final List<MethodMatcher> TOSTRING_MATCHERS = Arrays.asList(
+            new MethodMatcher("java.lang.String toString()"),
+            new MethodMatcher("java.lang.StringBuffer toString()"),
+            new MethodMatcher("java.lang.StringBuilder toString()"));
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.staticanalysis;
 
 import org.openrewrite.ExecutionContext;
@@ -13,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class EqualsToContentEquals extends Recipe {
     private static final MethodMatcher equals_matcher = new MethodMatcher("java.lang.String equals(..)");
@@ -55,15 +71,13 @@ public class EqualsToContentEquals extends Recipe {
                     Expression newArg = inv.getSelect();
                     if (inv.getSelect() == null) { return m; }
 
-                    JavaType sb_type = JavaType.buildType("java.lang.StringBuilder");
-                    JavaType string_buffer_type = JavaType.buildType("java.lang.StringBuffer");
-                    JavaType char_sq_type = JavaType.buildType("java.lang.CharSequence");
+                    Stream<JavaType> TYPES = Stream.of(
+                            JavaType.buildType("java.lang.StringBuilder"),
+                            JavaType.buildType("java.lang.StringBuffer"),
+                            JavaType.buildType("java.lang.CharSequence")
+                    );
 
-                    if (
-                            TypeUtils.isOfType(newArg.getType(), sb_type)            ||
-                            TypeUtils.isOfType(newArg.getType(), string_buffer_type) ||
-                            TypeUtils.isOfType(newArg.getType(), char_sq_type)
-                    ) {
+                    if (TYPES.anyMatch(type -> TypeUtils.isOfType(newArg.getType(), type))) {
                         // strip out the toString() on the argument
                         List<Expression> args = new ArrayList<>(1);
                         args.add(newArg);

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -58,7 +58,6 @@ public class EqualsToContentEquals extends Recipe {
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
             J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
-            J.Identifier methodName = m.getName();
             // create method matcher on equals(String)
             if (equals_matcher.matches(m)) {
                 Expression argument = m.getArguments().get(0);

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,8 @@ public class EqualsToContentEquals extends Recipe {
     private static final List<MethodMatcher> TOSTRING_MATCHERS = Arrays.asList(
             new MethodMatcher("java.lang.String toString()"),
             new MethodMatcher("java.lang.StringBuffer toString()"),
-            new MethodMatcher("java.lang.StringBuilder toString()"));
+            new MethodMatcher("java.lang.StringBuilder toString()"),
+            new MethodMatcher("java.lang.CharSequence toString()"));
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -86,7 +86,7 @@ public class EqualsToContentEquals extends Recipe {
                 }
             }
 
-            return m.withName(methodName);
+            return m;
         }
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -76,11 +76,8 @@ public class EqualsToContentEquals extends Recipe {
 
                     if (TYPES.anyMatch(type -> TypeUtils.isOfType(newArg.getType(), type))) {
                         // strip out the toString() on the argument
-                        List<Expression> args = new ArrayList<>(1);
-                        args.add(newArg);
-                        m = m.withArguments(args);
-                        // rename the method to contentEquals
-                        methodName = m.getName().withSimpleName("contentEquals");
+                        return m.withArguments(Collections.singletonList(newArg))
+                                .withName(m.getName().withSimpleName("contentEquals"));
                     }
                 }
             }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -22,32 +22,28 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
+import java.util.Set;
 
 public class EqualsToContentEquals extends Recipe {
-    private static final MethodMatcher equals_matcher = new MethodMatcher("java.lang.String equals(..)");
     private static final TreeVisitor<?, ExecutionContext> PRECONDITION = Preconditions.or(
+            new UsesType<>("java.lang.CharSequence", false),
             new UsesType<>("java.lang.StringBuffer", false),
-            new UsesType<>("java.lang.StringBuilder", false),
-            new UsesType<>("java.lang.CharSequence", false));
-    private static final List<MethodMatcher> TOSTRING_MATCHERS = Arrays.asList(
-            new MethodMatcher("java.lang.String toString()"),
-            new MethodMatcher("java.lang.StringBuffer toString()"),
-            new MethodMatcher("java.lang.StringBuilder toString()"),
-            new MethodMatcher("java.lang.CharSequence toString()"));
+            new UsesType<>("java.lang.StringBuilder", false)
+    );
 
     @Override
     public String getDisplayName() {
-        return "Use contentEquals to compare StringBuilder to a String";
+        return "Use `String.contentEquals(CharSequence)` instead of `String.equals(CharSequence.toString())`";
     }
+
     @Override
     public String getDescription() {
-        return "Use contentEquals to compare StringBuilder to a String.";
+        return "Use `String.contentEquals(CharSequence)` instead of `String.equals(CharSequence.toString())`.";
     }
 
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -55,34 +51,27 @@ public class EqualsToContentEquals extends Recipe {
     }
 
     private static class EqualsToContentEqualsVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private static final MethodMatcher EQUALS_MATCHER = new MethodMatcher("String equals(Object)");
+        private static final MethodMatcher TOSTRING_MATCHER = new MethodMatcher("java.lang.* toString()");
+
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
             J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
-            // create method matcher on equals(String)
-            if (equals_matcher.matches(m)) {
-                Expression argument = m.getArguments().get(0);
-
-                // checks whether the argument is a toString() method call on a StringBuffer or CharSequence
-                if (TOSTRING_MATCHERS.stream().anyMatch(matcher -> matcher.matches(argument))) {
-                    J.MethodInvocation inv = (J.MethodInvocation) argument;
-                    Expression newArg = inv.getSelect();
-                    if (inv.getSelect() == null) { return m; }
-
-                    Stream<JavaType> TYPES = Stream.of(
-                            JavaType.buildType("java.lang.StringBuilder"),
-                            JavaType.buildType("java.lang.StringBuffer"),
-                            JavaType.buildType("java.lang.CharSequence")
-                    );
-
-                    if (TYPES.anyMatch(type -> TypeUtils.isOfType(newArg.getType(), type))) {
-                        // strip out the toString() on the argument
-                        return m.withArguments(Collections.singletonList(newArg))
-                                .withName(m.getName().withSimpleName("contentEquals"));
-                    }
-                }
+            if (!EQUALS_MATCHER.matches(m)) {
+                return m;
             }
-
-            return m;
+            Expression equalsArgument = m.getArguments().get(0);
+            if (!TOSTRING_MATCHER.matches(equalsArgument)) {
+                return m;
+            }
+            J.MethodInvocation inv = (J.MethodInvocation) equalsArgument;
+            Expression toStringSelect = inv.getSelect();
+            if (toStringSelect == null || !TypeUtils.isAssignableTo("java.lang.CharSequence", toStringSelect.getType())) {
+                return m;
+            }
+            // Strip out the toString() on the argument and replace with contentEquals
+            return m.withArguments(Collections.singletonList(toStringSelect))
+                    .withName(m.getName().withSimpleName("contentEquals"));
         }
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -24,10 +24,9 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class EqualsToContentEquals extends Recipe {

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -1,0 +1,80 @@
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EqualsToContentEquals extends Recipe {
+    private static final MethodMatcher equals_matcher = new MethodMatcher("java.lang.String equals(..)");
+    private static final List<String> TYPE_NAMES = Arrays.asList(
+            "java.lang.StringBuffer",
+            "java.lang.StringBuilder",
+            "java.lang.CharSequence"
+    );
+    @SuppressWarnings("unchecked")
+    private static final TreeVisitor<?, ExecutionContext> PRECONDITION =
+            Preconditions.or(TYPE_NAMES.stream().map(s -> new UsesType<>(s, false)).toArray(UsesType[]::new));
+    private static final List<MethodMatcher> toString_matchers = TYPE_NAMES.stream()
+            .map(obj -> new MethodMatcher(obj + " toString()")).collect(Collectors.toList());
+
+    @Override
+    public String getDisplayName() {
+        return "Use contentEquals to compare StringBuilder to a String";
+    }
+    @Override
+    public String getDescription() {
+        return "Use contentEquals to compare StringBuilder to a String.";
+    }
+
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(PRECONDITION, new EqualsToContentEqualsVisitor());
+    }
+
+    private static class EqualsToContentEqualsVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+            J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
+            J.Identifier methodName = m.getName();
+            // create method matcher on equals(String)
+            if (equals_matcher.matches(m)) {
+                Expression argument = m.getArguments().get(0);
+
+                // checks whether the argument is a toString() method call on a StringBuffer or CharSequence
+                if (toString_matchers.stream().anyMatch(matcher -> matcher.matches(argument))) {
+                    J.MethodInvocation inv = (J.MethodInvocation) argument;
+                    Expression newArg = inv.getSelect();
+                    if (inv.getSelect() == null) { return m; }
+
+                    JavaType sb_type = JavaType.buildType("java.lang.StringBuilder");
+                    JavaType string_buffer_type = JavaType.buildType("java.lang.StringBuffer");
+                    JavaType char_sq_type = JavaType.buildType("java.lang.CharSequence");
+
+                    if (
+                            TypeUtils.isOfType(newArg.getType(), sb_type)            ||
+                            TypeUtils.isOfType(newArg.getType(), string_buffer_type) ||
+                            TypeUtils.isOfType(newArg.getType(), char_sq_type)
+                    ) {
+                        // strip out the toString() on the argument
+                        List<Expression> args = new ArrayList<>(1);
+                        args.add(newArg);
+                        m = m.withArguments(args);
+                        // rename the method to contentEquals
+                        methodName = m.getName().withSimpleName("contentEquals");
+                    }
+                }
+            }
+
+            return m.withName(methodName);
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -63,7 +63,7 @@ public class EqualsToContentEquals extends Recipe {
                 Expression argument = m.getArguments().get(0);
 
                 // checks whether the argument is a toString() method call on a StringBuffer or CharSequence
-                if (toString_matchers.stream().anyMatch(matcher -> matcher.matches(argument))) {
+                if (TOSTRING_MATCHERS.stream().anyMatch(matcher -> matcher.matches(argument))) {
                     J.MethodInvocation inv = (J.MethodInvocation) argument;
                     Expression newArg = inv.getSelect();
                     if (inv.getSelect() == null) { return m; }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -27,7 +27,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Collections;
-import java.util.Set;
 
 public class EqualsToContentEquals extends Recipe {
     private static final TreeVisitor<?, ExecutionContext> PRECONDITION = Preconditions.or(

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -32,6 +32,7 @@ public class EqualsToContentEqualsTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     public void replaceStringBuilder() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,37 @@ public class EqualsToContentEqualsTest implements RewriteTest {
               class SomeClass {
                   boolean foo(CharSequence cs, String str) {
                       return str.contentEquals(cs);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void runsOnNonStringVariablesAlso() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                  boolean foo(String str) {
+                      return str.equals(getMessage().toString());
+                  }
+                  
+                  StringBuilder getMessage() {
+                      return new StringBuilder("message");
+                  }
+              }
+              """,
+            """
+              class SomeClass {
+                  boolean foo(String str) {
+                      return str.contentEquals(getMessage());
+                  }
+                  
+                  StringBuilder getMessage() {
+                      return new StringBuilder("message");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -1,0 +1,105 @@
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class EqualsToContentEqualsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion())
+          .recipe(new EqualsToContentEquals());
+    }
+
+    @Test
+    public void replaceStringBuilder() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                  boolean foo(StringBuilder sb) {
+                      String str = "example string";
+                      return str.equals(sb.toString());
+                  }
+              }
+              """,
+            """
+              class SomeClass {
+                  boolean foo(StringBuilder sb) {
+                      String str = "example string";
+                      return str.contentEquals(sb);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    public void onlyRunsOnCorrectInvocations() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                  boolean foo(int number, String str) {
+                      return str.equals(number.toString());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void runsOnStringBuffer() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                  boolean foo(StringBuffer sb, String str) {
+                      return str.equals(sb.toString());
+                  }
+              }
+              """,
+            """
+              class SomeClass {
+                  boolean foo(StringBuffer sb, String str) {
+                      return str.contentEquals(sb);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void runsOnCharSequence() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                  boolean foo(CharSequence cs, String str) {
+                      return str.equals(cs.toString());
+                  }
+              }
+              """,
+            """
+              class SomeClass {
+                  boolean foo(CharSequence cs, String str) {
+                      return str.contentEquals(cs);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -64,7 +64,7 @@ public class EqualsToContentEqualsTest implements RewriteTest {
           java(
             """
               class SomeClass {
-                  boolean foo(int number, String str) {
+                  boolean foo(Integer number, String str) {
                       return str.equals(number.toString());
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class EqualsToContentEqualsTest implements RewriteTest {
+class EqualsToContentEqualsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -34,7 +34,7 @@ public class EqualsToContentEqualsTest implements RewriteTest {
 
     @Test
     @DocumentExample
-    public void replaceStringBuilder() {
+    void replaceStringBuilder() {
         //language=java
         rewriteRun(
           java(
@@ -59,7 +59,7 @@ public class EqualsToContentEqualsTest implements RewriteTest {
     }
 
     @Test
-    public void onlyRunsOnCorrectInvocations() {
+    void onlyRunsOnCorrectInvocations() {
         //language=java
         rewriteRun(
           java(


### PR DESCRIPTION
…a string with a StringBuilder

## What's changed?
This PR adds a new recipe that finds when `.equals()` is being used to compare a string and a `StringBuilder`, `StringBuffer` or `CharSequence`.

## What's your motivation?
[#22](https://github.com/openrewrite/rewrite-static-analysis/issues/22)

## Anything in particular you'd like reviewers to focus on?
I think the precondition checks should be correct but maybe they could be narrowing things down more. 

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
