### PR TITLE
Remove hashCode calls on arrays

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+public class RemoveHashCodeCallsFromArrayInstances extends Recipe {
+    private static final MethodMatcher HASHCODE_MATCHER = new MethodMatcher("java.lang.Object hashCode()");
+    @Override
+    public String getDisplayName() {
+        return "hashCode should not be called on array instances";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes hashCode method calls and replaces it with Arrays.hashCode(...) call.";
+    }
+
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(Preconditions.or(
+                new UsesMethod<>(HASHCODE_MATCHER)
+        ), new RemoveHashCodeCallsFromArrayInstancesVisitor());
+    }
+
+    private static class RemoveHashCodeCallsFromArrayInstancesVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+            J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
+
+            if (HASHCODE_MATCHER.matches(m)) {
+                String builder_string = "Arrays.hashCode(#{anyArray(java.lang.Object)})";
+                Expression select = m.getSelect();
+                assert select != null;
+
+                if (!(select.getType() instanceof JavaType.Array)) {
+                    return m;
+                }
+
+                J.MethodInvocation invocation = JavaTemplate.builder(builder_string)
+                        .imports("java.util.Arrays")
+                        .build()
+                        .apply(getCursor(), m.getCoordinates().replace(), select);
+                maybeAddImport("java.util.Arrays");
+
+                return invocation;
+            }
+
+            return m;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
@@ -31,12 +31,13 @@ public class RemoveHashCodeCallsFromArrayInstances extends Recipe {
     private static final MethodMatcher HASHCODE_MATCHER = new MethodMatcher("java.lang.Object hashCode()");
     @Override
     public String getDisplayName() {
-        return "hashCode should not be called on array instances";
+        return "`hashCode()` should not be called on array instances";
     }
 
     @Override
     public String getDescription() {
-        return "Removes hashCode method calls and replaces it with Arrays.hashCode(...) call.";
+        return "Removes `hashCode()` calls on arrays and replaces it with `Arrays.hashCode()` because the results from `hashCode()`" +
+                " are largely useless.";
     }
 
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings("ArrayHashCode")
+public class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion())
+          .recipe(new RemoveHashCodeCallsFromArrayInstances());
+    }
+
+    @Test
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/44")
+    void replaceHashCodeCalls() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                public static void main(String[] args) {
+                  int argHash = args.hashCode();
+                }
+              }
+              """,
+            """
+              import java.util.Arrays;
+              
+              class SomeClass {
+                public static void main(String[] args) {
+                  int argHash = Arrays.hashCode(args);
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void selectIsAMethod() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                public static void main(String[] args) {
+                  int hashCode = getArr().hashCode();
+                }
+                
+                public int[] getArr() {
+                  return new int[]{1, 2, 3};
+                }
+              }
+              """,
+            """
+              import java.util.Arrays;
+              
+              class SomeClass {
+                public static void main(String[] args) {
+                  int hashCode = Arrays.hashCode(getArr());
+                }
+                
+                public int[] getArr() {
+                  return new int[]{1, 2, 3};
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void onlyRunOnArrayInstances() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                public static void main(String[] args) {
+                  int name = "bill";
+                  int hashCode = name.hashCode();
+                }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
@@ -18,18 +18,16 @@ package org.openrewrite.staticanalysis;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
-import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings("ArrayHashCode")
-public class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
+class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec
-          .recipe(new RemoveHashCodeCallsFromArrayInstances());
+        spec.recipe(new RemoveHashCodeCallsFromArrayInstances());
     }
 
     @Test
@@ -38,24 +36,21 @@ public class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
     void replaceHashCodeCalls() {
         //language=java
         rewriteRun(
-          java(
-            """
-              class SomeClass {
-                public static void main(String[] args) {
-                  int argHash = args.hashCode();
-                }
+          java("""
+            class SomeClass {
+              public static void main(String[] args) {
+                int argHash = args.hashCode();
               }
-              """,
-            """
-              import java.util.Arrays;
-              
-              class SomeClass {
-                public static void main(String[] args) {
-                  int argHash = Arrays.hashCode(args);
-                }
+            }
+            """, """
+            import java.util.Arrays;
+            
+            class SomeClass {
+              public static void main(String[] args) {
+                int argHash = Arrays.hashCode(args);
               }
-              """
-          )
+            }
+            """)
         );
     }
 
@@ -63,32 +58,29 @@ public class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
     void selectIsAMethod() {
         //language=java
         rewriteRun(
-          java(
-            """
-              class SomeClass {
-                public static void main(String[] args) {
-                  int hashCode = getArr().hashCode();
-                }
-                
-                public int[] getArr() {
-                  return new int[]{1, 2, 3};
-                }
+          java("""
+            class SomeClass {
+              void foo() {
+                int hashCode = getArr().hashCode();
               }
-              """,
-            """
-              import java.util.Arrays;
               
-              class SomeClass {
-                public static void main(String[] args) {
-                  int hashCode = Arrays.hashCode(getArr());
-                }
-                
-                public int[] getArr() {
-                  return new int[]{1, 2, 3};
-                }
+              public int[] getArr() {
+                return new int[]{1, 2, 3};
               }
-              """
-          )
+            }
+            """, """
+            import java.util.Arrays;
+            
+            class SomeClass {
+              void foo() {
+                int hashCode = Arrays.hashCode(getArr());
+              }
+              
+              public int[] getArr() {
+                return new int[]{1, 2, 3};
+              }
+            }
+            """)
         );
     }
 
@@ -96,16 +88,14 @@ public class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
     void onlyRunOnArrayInstances() {
         //language=java
         rewriteRun(
-          java(
-            """
-              class SomeClass {
-                public static void main(String[] args) {
-                  int name = "bill";
-                  int hashCode = name.hashCode();
-                }
+          java("""
+            class SomeClass {
+              void foo() {
+                String name = "bill";
+                int hashCode = name.hashCode();
               }
-              """
-          )
+            }
+            """)
         );
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
@@ -29,7 +29,6 @@ public class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .parser(JavaParser.fromJavaVersion())
           .recipe(new RemoveHashCodeCallsFromArrayInstances());
     }
 


### PR DESCRIPTION
## What's changed?
This is related to [my other PR](https://github.com/openrewrite/rewrite-static-analysis/pull/126). @timtebeek suggested to me that I split the recipe because the `toString()` part required more checks since `toString()` is such a widely used method. This recipe basically does the same thing but on a smaller scale for `hashCode()` calls on array instances. 
 
## What's your motivation?
[#44](https://github.com/openrewrite/rewrite-static-analysis/issues/44)

## Anything in particular you'd like reviewers to focus on?
I think this recipe should be finished but maybe there are other edge case methods that implicitly call `hashCode()` I'm forgetting. 

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
[RSPEC-2116](https://rules.sonarsource.com/java/RSPEC-2116)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
