### PR TITLE
Better type attribution for `ReplaceLambdaWithMethodReference`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
+++ b/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
@@ -29,26 +29,23 @@ final class JavaElementFactory {
     static J.MemberReference newStaticMethodReference(JavaType.Method method, boolean qualified, @Nullable JavaType type) {
         JavaType.FullyQualified declaringType = method.getDeclaringType();
         Expression containing = null;
-        if (qualified) {
-            Scanner scanner = new Scanner(declaringType.getFullyQualifiedName().replace('$', '.')).useDelimiter("\\.");
-            for (int i = 0; scanner.hasNext(); i++) {
-                String part = scanner.next();
-                JavaType typeOfContaining = scanner.hasNext() ? null : declaringType;
-                if (i > 0) {
-                    containing = new J.FieldAccess(
-                            randomId(),
-                            Space.EMPTY,
-                            Markers.EMPTY,
-                            containing,
-                            new JLeftPadded<>(Space.EMPTY, new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, typeOfContaining, null), Markers.EMPTY),
-                            typeOfContaining
-                    );
-                } else {
-                    containing = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, declaringType, null);
-                }
+        String qualifiedName = qualified ? declaringType.getFullyQualifiedName() : declaringType.getClassName();
+        Scanner scanner = new Scanner(qualifiedName.replace('$', '.')).useDelimiter("\\.");
+        for (int i = 0; scanner.hasNext(); i++) {
+            String part = scanner.next();
+            JavaType typeOfContaining = scanner.hasNext() ? null : declaringType;
+            if (i > 0) {
+                containing = new J.FieldAccess(
+                        randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        containing,
+                        new JLeftPadded<>(Space.EMPTY, new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, typeOfContaining, null), Markers.EMPTY),
+                        typeOfContaining
+                );
+            } else {
+                containing = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, declaringType, null);
             }
-        } else {
-            containing = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, declaringType.getClassName(), declaringType, null);
         }
 
         assert containing != null;

--- a/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
+++ b/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+import java.util.Scanner;
+
+import static org.openrewrite.Tree.randomId;
+
+final class JavaElementFactory {
+
+    static J.MemberReference newStaticMethodReference(JavaType.Method method, boolean qualified, @Nullable JavaType type) {
+        JavaType.FullyQualified declaringType = method.getDeclaringType();
+        Expression containing = null;
+        if (qualified) {
+            Scanner scanner = new Scanner(declaringType.getFullyQualifiedName().replace('$', '.')).useDelimiter("\\.");
+            for (int i = 0; scanner.hasNext(); i++) {
+                String part = scanner.next();
+                JavaType typeOfContaining = scanner.hasNext() ? null : declaringType;
+                if (i > 0) {
+                    containing = new J.FieldAccess(
+                            randomId(),
+                            Space.EMPTY,
+                            Markers.EMPTY,
+                            containing,
+                            new JLeftPadded<>(Space.EMPTY, new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, typeOfContaining, null), Markers.EMPTY),
+                            typeOfContaining
+                    );
+                } else {
+                    containing = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, declaringType, null);
+                }
+            }
+        } else {
+            containing = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, declaringType.getClassName(), declaringType, null);
+        }
+
+        assert containing != null;
+        return newInstanceMethodReference(method, containing, type);
+    }
+
+    static J.MemberReference newInstanceMethodReference(JavaType.Method method, Expression containing, @Nullable JavaType type) {
+        return new J.MemberReference(
+                randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                new JRightPadded<>(containing, Space.EMPTY, Markers.EMPTY),
+                null,
+                new JLeftPadded<>(Space.EMPTY, new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, method.getName(), null, null), Markers.EMPTY),
+                type,
+                method,
+                null
+        );
+    }
+
+    @Nullable
+    static J.FieldAccess newClassLiteral(Expression typeReference) {
+        JavaType.Class classType = getClassType(typeReference.getType());
+        if (classType == null) {
+            return null;
+        }
+
+        JavaType.Parameterized parameterized = new JavaType.Parameterized(null, classType, Collections.singletonList(typeReference.getType()));
+        return new J.FieldAccess(
+                randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                typeReference,
+                new JLeftPadded<>(
+                        Space.EMPTY,
+                        new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, "class", parameterized, null),
+                        Markers.EMPTY
+                ),
+                parameterized
+        );
+    }
+
+    @Nullable
+    private static JavaType.Class getClassType(@Nullable JavaType type) {
+        if (type instanceof JavaType.Class) {
+            JavaType.Class classType = (JavaType.Class) type;
+            if (classType.getFullyQualifiedName().equals("java.lang.Class")) {
+                return classType;
+            } else if (classType.getFullyQualifiedName().equals("java.lang.Object")) {
+                for (JavaType.Method method : classType.getMethods()) {
+                    if (method.getName().equals("getClass")) {
+                        return getClassType(method.getReturnType());
+                    }
+                }
+                return null;
+            } else {
+                return getClassType(classType.getSupertype());
+            }
+        } else if (type instanceof JavaType.Parameterized) {
+            return getClassType(((JavaType.Parameterized) type).getType());
+        } else if (type instanceof JavaType.GenericTypeVariable) {
+            return getClassType(((JavaType.GenericTypeVariable) type).getBounds().get(0));
+        } else if (type instanceof JavaType.Array) {
+            return getClassType(((JavaType.Array) type).getElemType());
+        } else if (type instanceof JavaType.Variable) {
+            return getClassType(((JavaType.Variable) type).getOwner());
+        } else if (type instanceof JavaType.Method) {
+            return getClassType(((JavaType.Method) type).getDeclaringType());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
+++ b/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
@@ -28,28 +28,32 @@ final class JavaElementFactory {
 
     static J.MemberReference newStaticMethodReference(JavaType.Method method, boolean qualified, @Nullable JavaType type) {
         JavaType.FullyQualified declaringType = method.getDeclaringType();
-        Expression containing = null;
-        String qualifiedName = qualified ? declaringType.getFullyQualifiedName() : declaringType.getClassName();
+        Expression containing = className(declaringType, qualified);
+        return newInstanceMethodReference(method, containing, type);
+    }
+
+    static Expression className(JavaType.FullyQualified classType, boolean qualified) {
+        Expression name = null;
+        String qualifiedName = qualified ? classType.getFullyQualifiedName() : classType.getClassName();
         Scanner scanner = new Scanner(qualifiedName.replace('$', '.')).useDelimiter("\\.");
         for (int i = 0; scanner.hasNext(); i++) {
             String part = scanner.next();
-            JavaType typeOfContaining = scanner.hasNext() ? null : declaringType;
+            JavaType typeOfContaining = scanner.hasNext() ? null : classType;
             if (i > 0) {
-                containing = new J.FieldAccess(
+                name = new J.FieldAccess(
                         randomId(),
                         Space.EMPTY,
                         Markers.EMPTY,
-                        containing,
+                        name,
                         new JLeftPadded<>(Space.EMPTY, new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, typeOfContaining, null), Markers.EMPTY),
                         typeOfContaining
                 );
             } else {
-                containing = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, declaringType, null);
+                name = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, part, classType, null);
             }
         }
-
-        assert containing != null;
-        return newInstanceMethodReference(method, containing, type);
+        assert name != null;
+        return name;
     }
 
     static J.MemberReference newInstanceMethodReference(JavaType.Method method, Expression containing, @Nullable JavaType type) {

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -79,7 +79,7 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                     J j = instanceOf.getClazz();
                     if ((j instanceof J.Identifier || j instanceof J.FieldAccess) &&
                         instanceOf.getExpression() instanceof J.Identifier) {
-                        J.FieldAccess classLiteral = newClassLiteral(j.withPrefix(Space.EMPTY));
+                        J.FieldAccess classLiteral = newClassLiteral(((TypeTree) j).getType(), j instanceof J.FieldAccess);
                         if (classLiteral != null) {
                             //noinspection DataFlowIssue
                             JavaType.FullyQualified rawClassType = ((JavaType.Parameterized) classLiteral.getType()).getType();
@@ -95,7 +95,7 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                         J tree = j.getTree();
                         if ((tree instanceof J.Identifier || tree instanceof J.FieldAccess) &&
                             !(j.getType() instanceof JavaType.GenericTypeVariable)) {
-                            J.FieldAccess classLiteral = newClassLiteral(tree.withPrefix(Space.EMPTY));
+                            J.FieldAccess classLiteral = newClassLiteral(((Expression) tree).getType(), tree instanceof J.FieldAccess);
                             if (classLiteral != null) {
                                 //noinspection DataFlowIssue
                                 JavaType.FullyQualified classType = ((JavaType.Parameterized) classLiteral.getType()).getType();

--- a/src/test/java/org/openrewrite/staticanalysis/JavaElementFactoryTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/JavaElementFactoryTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.internal.JavaTypeCache;
+import org.openrewrite.java.search.SemanticallyEqual;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.staticanalysis.JavaElementFactory.newInstanceMethodReference;
+import static org.openrewrite.staticanalysis.JavaElementFactory.newStaticMethodReference;
+
+class JavaElementFactoryTest implements RewriteTest {
+
+    JavaTypeCache typeCache = new JavaTypeCache();
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().typeCache(typeCache));
+    }
+
+    @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    void instanceMethodReference() {
+        RecipeSpec spec = RecipeSpec.defaults();
+        defaults(spec);
+        SourceFile sourceFile = spec.getParsers().get(0).build().parse(
+          //language=java
+          """
+            package foo;
+            import java.util.function.Supplier;
+            class Foo {
+                int foo() {
+                    return 0;
+                }
+                Supplier<Integer> bar() {
+                    return this::foo;
+                }
+            }
+            """
+        ).findFirst().get();
+        JavaType.Class fooType = typeCache.get("foo.Foo");
+        assertThat(fooType).isNotNull();
+
+        JavaType.Method fooMethod = fooType.getMethods().stream().filter(m -> m.getName().equals("foo")).findFirst().get();
+        assertThat(fooMethod).isNotNull();
+
+        J.MemberReference reference = new JavaIsoVisitor<AtomicReference<J.MemberReference>>() {
+            @Override
+            public J.MemberReference visitMemberReference(J.MemberReference memberRef, AtomicReference<J.MemberReference> collector) {
+                collector.compareAndSet(null, memberRef);
+                return super.visitMemberReference(memberRef, collector);
+            }
+        }.reduce(sourceFile, new AtomicReference<>(null)).get();
+        assertThat(reference).isNotNull();
+
+        J.MemberReference methodReference = newInstanceMethodReference(fooMethod, reference.getContaining(), reference.getType());
+        assertThat(SemanticallyEqual.areEqual(reference, methodReference)).isTrue();
+    }
+
+    @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    void staticMethodReference() {
+        RecipeSpec spec = RecipeSpec.defaults();
+        defaults(spec);
+        SourceFile sourceFile = spec.getParsers().get(0).build().parse(
+          //language=java
+          """
+            package foo;
+            import java.util.stream.Stream;
+            class Foo {
+                int foo() {
+                    return 0;
+                }
+                long bar() {
+                    return Stream.of(new Foo()).map(Foo::foo).count();
+                }
+            }
+            """
+        ).findFirst().get();
+        JavaType.Class fooType = typeCache.get("foo.Foo");
+        assertThat(fooType).isNotNull();
+
+        JavaType.Method fooMethod = fooType.getMethods().stream().filter(m -> m.getName().equals("foo")).findFirst().get();
+        assertThat(fooMethod).isNotNull();
+
+        J.MemberReference reference = new JavaIsoVisitor<AtomicReference<J.MemberReference>>() {
+            @Override
+            public J.MemberReference visitMemberReference(J.MemberReference memberRef, AtomicReference<J.MemberReference> collector) {
+                collector.compareAndSet(null, memberRef);
+                return super.visitMemberReference(memberRef, collector);
+            }
+        }.reduce(sourceFile, new AtomicReference<>(null)).get();
+        assertThat(reference).isNotNull();
+
+        J.MemberReference methodReference = newStaticMethodReference(fooMethod, false, reference.getType());
+        assertThat(SemanticallyEqual.areEqual(reference, methodReference)).isTrue();
+    }
+
+    @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    void qualifiedStaticMethodReference() {
+        RecipeSpec spec = RecipeSpec.defaults();
+        defaults(spec);
+        SourceFile sourceFile = spec.getParsers().get(0).build().parse(
+          //language=java
+          """
+            package foo;
+            import java.util.stream.Stream;
+            class Foo {
+                long foo() {
+                    return Stream.of(new Foo()).map(java.lang.Object::toString).count();
+                }
+            }
+            """
+        ).findFirst().get();
+        JavaType.Class fooType = typeCache.get("foo.Foo");
+        assertThat(fooType).isNotNull();
+
+        J.MemberReference reference = new JavaIsoVisitor<AtomicReference<J.MemberReference>>() {
+            @Override
+            public J.MemberReference visitMemberReference(J.MemberReference memberRef, AtomicReference<J.MemberReference> collector) {
+                collector.compareAndSet(null, memberRef);
+                return super.visitMemberReference(memberRef, collector);
+            }
+        }.reduce(sourceFile, new AtomicReference<>(null)).get();
+        assertThat(reference).isNotNull();
+        assertThat(reference.getMethodType()).isNotNull();
+
+        J.MemberReference methodReference = newStaticMethodReference(reference.getMethodType(), true, reference.getType());
+        assertThat(SemanticallyEqual.areEqual(reference, methodReference)).isTrue();
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -134,8 +134,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
               }
               """
           ),
-          //language=java
           java(
+            //language=java
             """
               import java.util.List;
               import java.util.stream.Collectors;
@@ -164,6 +164,101 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                 @Override
                 public J.MemberReference visitMemberReference(J.MemberReference memberRef, Object o) {
                     assertThat(TypeUtils.isOfClassType(((J.FieldAccess) memberRef.getContaining()).getTarget().getType(),
+                      "org.test.CheckType")).isTrue();
+                    return memberRef;
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void qualifiedInstanceOf() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.test;
+              public class CheckType {
+              }
+              """
+          ),
+          java(
+            //language=java
+            """
+              import java.util.List;
+              import java.util.stream.Collectors;
+
+              class Test {
+                  List<Object> method(List<Object> input) {
+                      return input.stream().filter(n -> n instanceof org.test.CheckType).collect(Collectors.toList());
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              import java.util.stream.Collectors;
+
+              class Test {
+                  List<Object> method(List<Object> input) {
+                      return input.stream().filter(org.test.CheckType.class::isInstance).collect(Collectors.toList());
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.MemberReference visitMemberReference(J.MemberReference memberRef, Object o) {
+                    assertThat(TypeUtils.isOfClassType(((J.FieldAccess) memberRef.getContaining()).getTarget().getType(),
+                      "org.test.CheckType")).isTrue();
+                    return memberRef;
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void typeFromSourcePath() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.test;
+              public class CheckType {
+                  Integer foo() {
+                      return 0;
+                  }
+              }
+              """
+          ),
+          java(
+            //language=java
+            """
+              import java.util.List;
+              import java.util.stream.Stream;
+              import org.test.CheckType;
+
+              class Test {
+                  Stream<Integer> method(List<CheckType> input) {
+                      return input.stream().map(n -> n.foo());
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              import java.util.stream.Stream;
+              import org.test.CheckType;
+
+              class Test {
+                  Stream<Integer> method(List<CheckType> input) {
+                      return input.stream().map(CheckType::foo);
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.MemberReference visitMemberReference(J.MemberReference memberRef, Object o) {
+                    assertThat(TypeUtils.isOfClassType(((J.Identifier) memberRef.getContaining()).getType(),
                       "org.test.CheckType")).isTrue();
                     return memberRef;
                 }
@@ -261,28 +356,28 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
           java(
             """
               import java.util.Collections;
-              class Test {
-                  Runnable r = () -> run();
-                  public void run() {
-                      Collections.singletonList(1).forEach(n -> run());
-                  }
-              }
                             
               class Test2 {
+                  class Test {
+                      Runnable r = () -> run();
+                      public void run() {
+                          Collections.singletonList(1).forEach(n -> run());
+                      }
+                  }
                   Test t = new Test();
                   Runnable r = () -> t.run();
               }
               """,
             """
               import java.util.Collections;
-              class Test {
-                  Runnable r = this::run;
-                  public void run() {
-                      Collections.singletonList(1).forEach(n -> run());
-                  }
-              }
                             
               class Test2 {
+                  class Test {
+                      Runnable r = this::run;
+                      public void run() {
+                          Collections.singletonList(1).forEach(n -> run());
+                      }
+                  }
                   Test t = new Test();
                   Runnable r = t::run;
               }
@@ -389,8 +484,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
               }
               """
           ),
-          //language=java
           java(
+            //language=java
             """
               import java.util.List;
               import java.util.stream.Collectors;
@@ -417,6 +512,57 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                       return l.stream()
                           .filter(CheckType.class::isInstance)
                           .map(CheckType.class::cast)
+                          .collect(Collectors.toList());
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.MemberReference visitMemberReference(J.MemberReference memberRef, Object o) {
+                    assertThat(TypeUtils.isOfClassType(((J.FieldAccess) memberRef.getContaining()).getTarget().getType(),
+                      "org.test.CheckType")).isTrue();
+                    return memberRef;
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void qualifiedCastType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.test;
+              public class CheckType {
+              }
+              """
+          ),
+          java(
+            //language=java
+            """
+              import java.util.List;
+              import java.util.stream.Collectors;
+
+              class Test {
+                  List<Object> filter(List<Object> l) {
+                      return l.stream()
+                          .filter(org.test.CheckType.class::isInstance)
+                          .map(o -> (org.test.CheckType) o)
+                          .collect(Collectors.toList());
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              import java.util.stream.Collectors;
+
+              class Test {
+                  List<Object> filter(List<Object> l) {
+                      return l.stream()
+                          .filter(org.test.CheckType.class::isInstance)
+                          .map(org.test.CheckType.class::cast)
                           .collect(Collectors.toList());
                   }
               }
@@ -760,7 +906,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.function.Function;
               import java.util.function.Supplier;
-              
+                            
               class A {
                   void foo() {
                       Supplier<?> s;
@@ -781,7 +927,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.function.Function;
               import java.util.function.Supplier;
-              
+                            
               class A {
                   void foo() {
                       Supplier<?> s;
@@ -811,7 +957,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.function.Function;
               import java.util.function.Supplier;
-              
+                            
               class A {
                   void foo() {
                       Supplier<?> s;
@@ -998,7 +1144,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
     }
 
 
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings("OptionalOfNullableMisuse")
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3071")
     void missingImportForDeclaringType() {


### PR DESCRIPTION
Improves the type attribution for method references by "manually" instantiating the `J.MemberReference` rather than via `JavaTemplate`. This may seem strange, but the reason is that the recipe doesn't know where the type is coming from (JDK, 3rd party library, or even source path), so the template's compiler may not have the type on its classpath and cannot really produce a properly type-attributed result.
