### PR TITLE
`ReplaceLambdaWithMethodReference` should not replace lambda supplier of method reference with method reference

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -138,7 +138,8 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                     }
 
                     if (multipleMethodInvocations(method) ||
-                        !methodArgumentsMatchLambdaParameters(method, lambda)) {
+                        !methodArgumentsMatchLambdaParameters(method, lambda) ||
+                        method instanceof J.MemberReference) {
                         return l;
                     }
 

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -1184,5 +1184,27 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Test
+    void orElseGet() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Optional;
+              import java.util.function.Function;
 
+              class A {
+                public void testCase() {
+                  Function<String, Integer> function = str -> 1;
+                  Optional.of(function).orElseGet(() -> this::foo);
+                }
+
+                private Integer foo(String bar) {
+                  return 1;
+                }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -1185,6 +1185,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/132")
     void orElseGet() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -1186,7 +1186,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/132")
-    void orElseGet() {
+    void dontReplaceLambdaSupplierOfMethodReference() {
         rewriteRun(
           //language=java
           java(


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
While applying the `CommonStaticAnalysis` [recipe](https://docs.openrewrite.org/recipes/staticanalysis/commonstaticanalysis) on our internal codebase, we found a false positive that results in non-compilable code.

This PR introduces a minimal reproduction case to show the problem. Probably the test case can be simplified even further.
If anything is unclear, let me know.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
Depending on what the fix would be, I'm interested in contributing 😄. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
