### PR TITLE
Bug Fix for #121

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import fj.P;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -91,6 +92,16 @@ public class FinalizePrivateFields extends Recipe {
                     .stream()
                     .map(J.VariableDeclarations.NamedVariable::getVariableType)
                     .allMatch(v -> privateFieldsToBeFinalized.contains(v));
+
+                // makes sure the final flag is not also added to variables that have the volatile flag
+                for (J.VariableDeclarations.NamedVariable v : mv.getVariables()) {
+                    assert v.getVariableType() != null;
+                    for (Flag flag : v.getVariableType().getFlags()) {
+                        if (flag.equals(Flag.Volatile)) {
+                            return mv;
+                        }
+                    }
+                }
 
                 if (canAllVariablesBeFinalized) {
                     mv = autoFormat(mv.withVariables(ListUtils.map(mv.getVariables(), v -> {

--- a/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import fj.P;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
@@ -95,7 +94,7 @@ public class FinalizePrivateFields extends Recipe {
 
                 // makes sure the final flag is not also added to variables that have the volatile flag
                 for (J.VariableDeclarations.NamedVariable v : mv.getVariables()) {
-                    assert v.getVariableType() != null;
+                    if (v.getVariableType() == null) { break; }
                     for (Flag flag : v.getVariableType().getFlags()) {
                         if (flag.equals(Flag.Volatile)) {
                             return mv;

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
@@ -836,4 +836,24 @@ class FinalizePrivateFieldsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/121")
+    void mustNotChangeVolatileFields() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              public final class Reproducer {
+              
+                  private Reproducer() {
+                  }
+              
+                  private static volatile String foo = "this becomes final volatile, which is invalid";
+              
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
This PR fixes a bug having to do with the FinalizePrivateFields recipe adding the `final` flag to variables that also have the `volatile` flag which is invalid. 

## What's your motivation?
[#121](https://github.com/openrewrite/rewrite-static-analysis/issues/121)

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
