### PR TITLE
Do not use String `equals` for Groovy either

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
     implementation("org.openrewrite:rewrite-java")
+    implementation("org.openrewrite:rewrite-groovy:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
     implementation("org.openrewrite.meta:rewrite-analysis:${rewriteVersion}")
     implementation("org.apache.commons:commons-text:latest.release")

--- a/src/main/java/org/openrewrite/staticanalysis/groovy/GroovyFileChecker.java
+++ b/src/main/java/org/openrewrite/staticanalysis/groovy/GroovyFileChecker.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.groovy;
+
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Add a search marker if vising a Groovy file
+ */
+public class GroovyFileChecker<P> extends TreeVisitor<Tree, P> {
+    @Override
+    public @Nullable Tree visit(@Nullable Tree tree, P p) {
+        if (tree instanceof G.CompilationUnit) {
+            return SearchResult.found(tree);
+        }
+        return tree;
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/groovy/StringLiteralEqualityTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/groovy/StringLiteralEqualityTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.staticanalysis.StringLiteralEquality;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+
+class StringLiteralEqualityTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new StringLiteralEquality());
+    }
+
+    // Don't change for Groovy because in Groovy, `==` means structural equality and it's redundant to call equals().
+    @Test
+    void doNotChangeForGroovy() {
+        rewriteRun(
+          groovy(
+            """
+              def foo(String token) {
+                  if (token == "Foo" ) {
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a `GroovyFileChecker` as precondition to `StringLiteralEquality`.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/140