### PR TITLE
`ReplaceLambdaWithMethodReference` should not replace ambiguous references

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -159,11 +159,10 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                     Expression select =
                             method instanceof J.MethodInvocation ? ((J.MethodInvocation) method).getSelect() : null;
                     JavaType.Method methodType = method.getMethodType();
-                    if (methodType != null) {
+                    if (methodType != null && !isMethodReferenceAmbiguous(methodType)) {
                         if (methodType.hasFlags(Flag.Static) ||
                             methodSelectMatchesFirstLambdaParameter(method, lambda)) {
                             doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
-
                             return newStaticMethodReference(methodType, true, lambda.getType()).withPrefix(lambda.getPrefix());
                         } else if (method instanceof J.NewClass) {
                             return JavaTemplate.builder("#{}::new")
@@ -248,6 +247,10 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
             private boolean isNullCheck(J j1, J j2) {
                 return j1 instanceof J.Identifier && j2 instanceof J.Literal &&
                        "null".equals(((J.Literal) j2).getValueSource());
+            }
+
+            private boolean isMethodReferenceAmbiguous(JavaType.Method _method){
+                return _method.getDeclaringType().getMethods().stream().filter(meth -> meth.getName().equals(_method.getName())).count() > 1;
             }
         }
 

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -73,186 +73,190 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
 
     private static class ReplaceLambdaWithMethodReferenceJavaVisitor extends JavaVisitor<ExecutionContext> {
         @Override
-            public J visitLambda(J.Lambda lambda, ExecutionContext executionContext) {
-                J.Lambda l = (J.Lambda) super.visitLambda(lambda, executionContext);
-                updateCursor(l);
+        public J visitLambda(J.Lambda lambda, ExecutionContext executionContext) {
+            J.Lambda l = (J.Lambda) super.visitLambda(lambda, executionContext);
+            updateCursor(l);
 
-                String code = "";
-                J body = l.getBody();
-                if (body instanceof J.Block && ((J.Block) body).getStatements().size() == 1) {
-                    Statement statement = ((J.Block) body).getStatements().get(0);
-                    if (statement instanceof J.MethodInvocation) {
-                        body = statement;
-                    } else if (statement instanceof J.Return &&
-                               (((J.Return) statement).getExpression()) instanceof MethodCall) {
-                        body = ((J.Return) statement).getExpression();
+            String code = "";
+            J body = l.getBody();
+            if (body instanceof J.Block && ((J.Block) body).getStatements().size() == 1) {
+                Statement statement = ((J.Block) body).getStatements().get(0);
+                if (statement instanceof J.MethodInvocation) {
+                    body = statement;
+                } else if (statement instanceof J.Return &&
+                           (((J.Return) statement).getExpression()) instanceof MethodCall) {
+                    body = ((J.Return) statement).getExpression();
+                }
+            } else if (body instanceof J.InstanceOf) {
+                J.InstanceOf instanceOf = (J.InstanceOf) body;
+                J j = instanceOf.getClazz();
+                if ((j instanceof J.Identifier || j instanceof J.FieldAccess) &&
+                    instanceOf.getExpression() instanceof J.Identifier) {
+                    J.FieldAccess classLiteral = newClassLiteral(((TypeTree) j).getType(), j instanceof J.FieldAccess);
+                    if (classLiteral != null) {
+                        //noinspection DataFlowIssue
+                        JavaType.FullyQualified rawClassType = ((JavaType.Parameterized) classLiteral.getType()).getType();
+                        Optional<JavaType.Method> isInstanceMethod = rawClassType.getMethods().stream().filter(m -> m.getName().equals("isInstance")).findFirst();
+                        if (isInstanceMethod.isPresent()) {
+                            return newInstanceMethodReference(isInstanceMethod.get(), classLiteral, lambda.getType()).withPrefix(lambda.getPrefix());
+                        }
                     }
-                } else if (body instanceof J.InstanceOf) {
-                    J.InstanceOf instanceOf = (J.InstanceOf) body;
-                    J j = instanceOf.getClazz();
-                    if ((j instanceof J.Identifier || j instanceof J.FieldAccess) &&
-                        instanceOf.getExpression() instanceof J.Identifier) {
-                        J.FieldAccess classLiteral = newClassLiteral(((TypeTree) j).getType(), j instanceof J.FieldAccess);
+                }
+            } else if (body instanceof J.TypeCast) {
+                if (!(((J.TypeCast) body).getExpression() instanceof J.MethodInvocation)) {
+                    J.ControlParentheses<TypeTree> j = ((J.TypeCast) body).getClazz();
+                    J tree = j.getTree();
+                    if ((tree instanceof J.Identifier || tree instanceof J.FieldAccess) &&
+                        !(j.getType() instanceof JavaType.GenericTypeVariable)) {
+                        J.FieldAccess classLiteral = newClassLiteral(((Expression) tree).getType(), tree instanceof J.FieldAccess);
                         if (classLiteral != null) {
                             //noinspection DataFlowIssue
-                            JavaType.FullyQualified rawClassType = ((JavaType.Parameterized) classLiteral.getType()).getType();
-                            Optional<JavaType.Method> isInstanceMethod = rawClassType.getMethods().stream().filter(m -> m.getName().equals("isInstance")).findFirst();
-                            if (isInstanceMethod.isPresent()) {
-                                return newInstanceMethodReference(isInstanceMethod.get(), classLiteral, lambda.getType()).withPrefix(lambda.getPrefix());
+                            JavaType.FullyQualified classType = ((JavaType.Parameterized) classLiteral.getType()).getType();
+                            Optional<JavaType.Method> castMethod = classType.getMethods().stream().filter(m -> m.getName().equals("cast")).findFirst();
+                            if (castMethod.isPresent()) {
+                                return newInstanceMethodReference(castMethod.get(), classLiteral, lambda.getType()).withPrefix(lambda.getPrefix());
                             }
                         }
                     }
-                } else if (body instanceof J.TypeCast) {
-                    if (!(((J.TypeCast) body).getExpression() instanceof J.MethodInvocation)) {
-                        J.ControlParentheses<TypeTree> j = ((J.TypeCast) body).getClazz();
-                        J tree = j.getTree();
-                        if ((tree instanceof J.Identifier || tree instanceof J.FieldAccess) &&
-                            !(j.getType() instanceof JavaType.GenericTypeVariable)) {
-                            J.FieldAccess classLiteral = newClassLiteral(((Expression) tree).getType(), tree instanceof J.FieldAccess);
-                            if (classLiteral != null) {
-                                //noinspection DataFlowIssue
-                                JavaType.FullyQualified classType = ((JavaType.Parameterized) classLiteral.getType()).getType();
-                                Optional<JavaType.Method> castMethod = classType.getMethods().stream().filter(m -> m.getName().equals("cast")).findFirst();
-                                if (castMethod.isPresent()) {
-                                    return newInstanceMethodReference(castMethod.get(), classLiteral, lambda.getType()).withPrefix(lambda.getPrefix());
-                                }
+                }
+            }
+
+            if (body instanceof J.Binary) {
+                J.Binary binary = (J.Binary) body;
+                if (isNullCheck(binary.getLeft(), binary.getRight()) ||
+                    isNullCheck(binary.getRight(), binary.getLeft())) {
+                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                    code = J.Binary.Type.Equal.equals(binary.getOperator()) ? "java.util.Objects::isNull" :
+                            "java.util.Objects::nonNull";
+                    return JavaTemplate.builder(code)
+                            .contextSensitive()
+                            .build()
+                            .apply(getCursor(), l.getCoordinates().replace());
+                }
+            } else if (body instanceof MethodCall) {
+                MethodCall method = (MethodCall) body;
+                if (method instanceof J.NewClass) {
+                    J.NewClass nc = (J.NewClass) method;
+                    if (nc.getBody() != null) {
+                        return l;
+                    } else {
+                        if (isAMethodInvocationArgument(l, getCursor()) && nc.getType() instanceof JavaType.Class) {
+                            JavaType.Class clazz = (JavaType.Class) nc.getType();
+                            boolean hasMultipleConstructors = clazz.getMethods().stream().filter(JavaType.Method::isConstructor).count() > 1;
+                            if (hasMultipleConstructors) {
+                                return l;
                             }
                         }
                     }
                 }
 
-                if (body instanceof J.Binary) {
-                    J.Binary binary = (J.Binary) body;
-                    if (isNullCheck(binary.getLeft(), binary.getRight()) ||
-                        isNullCheck(binary.getRight(), binary.getLeft())) {
+                if (multipleMethodInvocations(method) ||
+                    !methodArgumentsMatchLambdaParameters(method, lambda) ||
+                    method instanceof J.MemberReference) {
+                    return l;
+                }
+
+                Expression select =
+                        method instanceof J.MethodInvocation ? ((J.MethodInvocation) method).getSelect() : null;
+                JavaType.Method methodType = method.getMethodType();
+                if (methodType != null && !isMethodReferenceAmbiguous(methodType)) {
+                    if (methodType.hasFlags(Flag.Static) ||
+                        methodSelectMatchesFirstLambdaParameter(method, lambda)) {
                         doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
-                        code = J.Binary.Type.Equal.equals(binary.getOperator()) ? "java.util.Objects::isNull" :
-                                "java.util.Objects::nonNull";
-                        return JavaTemplate.builder(code)
+                        return newStaticMethodReference(methodType, true, lambda.getType()).withPrefix(lambda.getPrefix());
+                    } else if (method instanceof J.NewClass) {
+                        return JavaTemplate.builder("#{}::new")
                                 .contextSensitive()
                                 .build()
-                                .apply(getCursor(), l.getCoordinates().replace());
-                    }
-                } else if (body instanceof MethodCall) {
-                    MethodCall method = (MethodCall) body;
-                    if (method instanceof J.NewClass) {
-                        J.NewClass nc = (J.NewClass) method;
-                        if (nc.getBody() != null) {
-                            return l;
-                        } else {
-                            if (isAMethodInvocationArgument(l, getCursor()) && nc.getType() instanceof JavaType.Class) {
-                                JavaType.Class clazz = (JavaType.Class) nc.getType();
-                                boolean hasMultipleConstructors = clazz.getMethods().stream().filter(JavaType.Method::isConstructor).count() > 1;
-                                if (hasMultipleConstructors) {
-                                    return l;
-                                }
-                            }
-                        }
-                    }
-
-                    if (multipleMethodInvocations(method) ||
-                        !methodArgumentsMatchLambdaParameters(method, lambda) ||
-                        method instanceof J.MemberReference) {
-                        return l;
-                    }
-
-                    Expression select =
-                            method instanceof J.MethodInvocation ? ((J.MethodInvocation) method).getSelect() : null;
-                    JavaType.Method methodType = method.getMethodType();
-                    if (methodType != null && !isMethodReferenceAmbiguous(methodType)) {
-                        if (methodType.hasFlags(Flag.Static) ||
-                            methodSelectMatchesFirstLambdaParameter(method, lambda)) {
-                            doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
-                            return newStaticMethodReference(methodType, true, lambda.getType()).withPrefix(lambda.getPrefix());
-                        } else if (method instanceof J.NewClass) {
-                            return JavaTemplate.builder("#{}::new")
-                                    .contextSensitive()
-                                    .build()
-                                    .apply(getCursor(), l.getCoordinates().replace(), className((J.NewClass) method));
-                        } else if (select != null) {
-                            return newInstanceMethodReference(methodType, select, lambda.getType()).withPrefix(lambda.getPrefix());
-                        } else {
-                            String templ = "#{}::#{}";
-                            return JavaTemplate.builder(templ)
-                                    .contextSensitive()
-                                    .build()
-                                    .apply(getCursor(), l.getCoordinates().replace(), "this",
-                                            method.getMethodType().getName());
-                        }
+                                .apply(getCursor(), l.getCoordinates().replace(), className((J.NewClass) method));
+                    } else if (select != null) {
+                        return newInstanceMethodReference(methodType, select, lambda.getType()).withPrefix(lambda.getPrefix());
+                    } else {
+                        String templ = "#{}::#{}";
+                        return JavaTemplate.builder(templ)
+                                .contextSensitive()
+                                .build()
+                                .apply(getCursor(), l.getCoordinates().replace(), "this",
+                                        method.getMethodType().getName());
                     }
                 }
-
-                return l;
             }
 
-            // returns the class name as given in the source code (qualified or unqualified)
-            private String className(J.NewClass method) {
-                TypeTree clazz = method.getClazz();
-                return clazz instanceof J.ParameterizedType ? ((J.ParameterizedType) clazz).getClazz().toString() :
-                        Objects.toString(clazz);
-            }
+            return l;
+        }
 
-            private boolean multipleMethodInvocations(MethodCall method) {
-                return method instanceof J.MethodInvocation &&
-                       ((J.MethodInvocation) method).getSelect() instanceof J.MethodInvocation;
-            }
+        // returns the class name as given in the source code (qualified or unqualified)
+        private String className(J.NewClass method) {
+            TypeTree clazz = method.getClazz();
+            return clazz instanceof J.ParameterizedType ? ((J.ParameterizedType) clazz).getClazz().toString() :
+                    Objects.toString(clazz);
+        }
 
-            private boolean methodArgumentsMatchLambdaParameters(MethodCall method, J.Lambda lambda) {
-                JavaType.Method methodType = method.getMethodType();
-                if (methodType == null) {
-                    return false;
-                }
-                boolean static_ = methodType.hasFlags(Flag.Static);
-                List<Expression> methodArgs = method.getArguments().stream().filter(a -> !(a instanceof J.Empty))
-                        .collect(Collectors.toList());
-                List<J.VariableDeclarations.NamedVariable> lambdaParameters = lambda.getParameters().getParameters()
-                        .stream().filter(J.VariableDeclarations.class::isInstance)
-                        .map(J.VariableDeclarations.class::cast).map(v -> v.getVariables().get(0))
-                        .collect(Collectors.toList());
-                if (methodArgs.isEmpty() && lambdaParameters.isEmpty()) {
-                    return true;
-                }
-                if (!static_ && methodSelectMatchesFirstLambdaParameter(method, lambda)) {
-                    methodArgs.add(0, ((J.MethodInvocation) method).getSelect());
-                }
-                if (methodArgs.size() != lambdaParameters.size()) {
-                    return false;
-                }
-                for (int i = 0; i < lambdaParameters.size(); i++) {
-                    JavaType lambdaParam = lambdaParameters.get(i).getVariableType();
-                    if (!(methodArgs.get(i) instanceof J.Identifier)) {
-                        return false;
-                    }
-                    JavaType methodArgument = ((J.Identifier) methodArgs.get(i)).getFieldType();
-                    if (lambdaParam != methodArgument) {
-                        return false;
-                    }
-                }
+        private boolean multipleMethodInvocations(MethodCall method) {
+            return method instanceof J.MethodInvocation &&
+                   ((J.MethodInvocation) method).getSelect() instanceof J.MethodInvocation;
+        }
+
+        private boolean methodArgumentsMatchLambdaParameters(MethodCall method, J.Lambda lambda) {
+            JavaType.Method methodType = method.getMethodType();
+            if (methodType == null) {
+                return false;
+            }
+            boolean static_ = methodType.hasFlags(Flag.Static);
+            List<Expression> methodArgs = method.getArguments().stream().filter(a -> !(a instanceof J.Empty))
+                    .collect(Collectors.toList());
+            List<J.VariableDeclarations.NamedVariable> lambdaParameters = lambda.getParameters().getParameters()
+                    .stream().filter(J.VariableDeclarations.class::isInstance)
+                    .map(J.VariableDeclarations.class::cast).map(v -> v.getVariables().get(0))
+                    .collect(Collectors.toList());
+            if (methodArgs.isEmpty() && lambdaParameters.isEmpty()) {
                 return true;
             }
-
-            private boolean methodSelectMatchesFirstLambdaParameter(MethodCall method, J.Lambda lambda) {
-                if (!(method instanceof J.MethodInvocation) ||
-                    !(((J.MethodInvocation) method).getSelect() instanceof J.Identifier) ||
-                    lambda.getParameters().getParameters().isEmpty() ||
-                    !(lambda.getParameters().getParameters().get(0) instanceof J.VariableDeclarations)) {
+            if (!static_ && methodSelectMatchesFirstLambdaParameter(method, lambda)) {
+                methodArgs.add(0, ((J.MethodInvocation) method).getSelect());
+            }
+            if (methodArgs.size() != lambdaParameters.size()) {
+                return false;
+            }
+            for (int i = 0; i < lambdaParameters.size(); i++) {
+                JavaType lambdaParam = lambdaParameters.get(i).getVariableType();
+                if (!(methodArgs.get(i) instanceof J.Identifier)) {
                     return false;
                 }
-                J.VariableDeclarations firstLambdaParameter = (J.VariableDeclarations) lambda.getParameters()
-                        .getParameters().get(0);
-                return ((J.Identifier) ((J.MethodInvocation) method).getSelect()).getFieldType() ==
-                       firstLambdaParameter.getVariables().get(0).getVariableType();
+                JavaType methodArgument = ((J.Identifier) methodArgs.get(i)).getFieldType();
+                if (lambdaParam != methodArgument) {
+                    return false;
+                }
             }
-
-            private boolean isNullCheck(J j1, J j2) {
-                return j1 instanceof J.Identifier && j2 instanceof J.Literal &&
-                       "null".equals(((J.Literal) j2).getValueSource());
-            }
-
-            private boolean isMethodReferenceAmbiguous(JavaType.Method _method){
-                return _method.getDeclaringType().getMethods().stream().filter(meth -> meth.getName().equals(_method.getName())).count() > 1;
-            }
+            return true;
         }
+
+        private boolean methodSelectMatchesFirstLambdaParameter(MethodCall method, J.Lambda lambda) {
+            if (!(method instanceof J.MethodInvocation) ||
+                !(((J.MethodInvocation) method).getSelect() instanceof J.Identifier) ||
+                lambda.getParameters().getParameters().isEmpty() ||
+                !(lambda.getParameters().getParameters().get(0) instanceof J.VariableDeclarations)) {
+                return false;
+            }
+            J.VariableDeclarations firstLambdaParameter = (J.VariableDeclarations) lambda.getParameters()
+                    .getParameters().get(0);
+            return ((J.Identifier) ((J.MethodInvocation) method).getSelect()).getFieldType() ==
+                   firstLambdaParameter.getVariables().get(0).getVariableType();
+        }
+
+        private boolean isNullCheck(J j1, J j2) {
+            return j1 instanceof J.Identifier && j2 instanceof J.Literal &&
+                   "null".equals(((J.Literal) j2).getValueSource());
+        }
+
+        private boolean isMethodReferenceAmbiguous(JavaType.Method _method) {
+            return _method.getDeclaringType().getMethods().stream()
+                           .filter(meth -> meth.getName().equals(_method.getName()))
+                           .filter(meth -> !meth.getName().equals("println"))
+                           .filter(meth -> !meth.isConstructor())
+                           .count() > 1;
+        }
+    }
 
     private static boolean isAMethodInvocationArgument(J.Lambda lambda, Cursor cursor) {
         Cursor parent = cursor.dropParentUntil(p -> p instanceof J.MethodInvocation || p instanceof J.CompilationUnit);

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -16,7 +16,6 @@
 
 package org.openrewrite.staticanalysis;
 
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -71,6 +70,26 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                       return l.stream()
                           .filter(s -> path.getFileName().toString().equals(s))
                           .collect(Collectors.toList());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/96")
+    @Test
+    void ignoreAmbiguousMethodReference() {
+        rewriteRun(
+          java(
+            """
+              import java.nio.file.Path;
+              import java.nio.file.Paths;
+              import java.util.List;import java.util.stream.Collectors;
+                            
+              class Test {
+                  List<String> method() {
+                      return Stream.of(1, 32, 12, 15, 23).map(x -> Integer.toString(x));
                   }
               }
               """
@@ -412,60 +431,6 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                   }
                   static class Test2 {
                       Runnable r = Test::run;
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void systemOutPrint() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import java.util.List;
-
-              class Test {
-                  void method(List<Integer> input) {
-                      input.forEach(x -> System.out.println(x));
-                  }
-              }
-              """,
-            """
-              import java.util.List;
-
-              class Test {
-                  void method(List<Integer> input) {
-                      input.forEach(System.out::println);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void systemOutPrintInBlock() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import java.util.List;
-
-              class Test {
-                  void method(List<Integer> input) {
-                      input.forEach(x -> { System.out.println(x); });
-                  }
-              }
-              """,
-            """
-              import java.util.List;
-
-              class Test {
-                  void method(List<Integer> input) {
-                      input.forEach(System.out::println);
                   }
               }
               """
@@ -912,14 +877,6 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                       Supplier<?> s;
                       s = () -> new Object();
                       s = () -> new java.lang.Object();
-                      s = () -> new java.util.ArrayList();
-                      s = () -> new java.util.ArrayList<>();
-                      s = () -> new java.util.ArrayList<Object>();
-                      s = () -> new ArrayList<Object>();
-                      s = () -> new java.util.HashSet<Object>();
-
-                      Function<Integer, ?> f;
-                      f = i -> new ArrayList(i);
                   }
               }
               """,
@@ -933,14 +890,6 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                       Supplier<?> s;
                       s = Object::new;
                       s = java.lang.Object::new;
-                      s = java.util.ArrayList::new;
-                      s = java.util.ArrayList::new;
-                      s = java.util.ArrayList::new;
-                      s = ArrayList::new;
-                      s = java.util.HashSet::new;
-
-                      Function<Integer, ?> f;
-                      f = ArrayList::new;
                   }
               }
               """


### PR DESCRIPTION
Closes #96 