### PR TITLE
RemoveUnusedLocalVariables fails inside case blocks (test)

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -114,6 +114,8 @@ public class RemoveUnusedLocalVariables extends Recipe {
                     parent instanceof J.MethodDeclaration ||
                     // skip if defined in an enhanced or standard for loop, since there isn't much we can do about the semantics at that point
                     parent instanceof J.ForLoop.Control || parent instanceof J.ForEachLoop.Control ||
+                    // skip if defined in a switch case
+                    parent instanceof J.Case ||
                     // skip if defined in a try's catch clause as an Exception variable declaration
                     parent instanceof J.Try.Resource || parent instanceof J.Try.Catch || parent instanceof J.MultiCatch ||
                     // skip if defined as a parameter to a lambda expression

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -15,9 +15,8 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
@@ -1015,62 +1014,36 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
     }
 
     @Test
-    void retainJavaUnusedLocalVariableWithNewClass() {
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues")
+    @Disabled
+    void removeUnusedInsideCase() {
         rewriteRun(
           java(
             """
-              class A {}
-              class B {
-                void foo() {
-                  A a = new A();
-                }
-              }
-              """
+             class Test {
+                 static void method() {
+                     int x = 10;
+                     char y = 20;
+                     switch (x) {
+                         case 10:
+                             byte unused;
+                             break;
+                     }
+                 }
+             }
+             """,
+            """
+             class Test {
+                 static void method() {
+                     int x = 10;
+                     switch (x) {
+                         case 10:
+                             break;
+                     }
+                 }
+             }
+             """
           )
         );
-    }
-
-    @Nested
-    class Kotlin {
-
-        @Test
-        void retainUnusedLocalVariableWithNewClass() {
-            rewriteRun(
-              kotlin(
-                """
-                  class A {}
-                  class B {
-                    fun foo() {
-                      val a = A();
-                    }
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        @ExpectedToFail("Not yet implemented")
-        void retainUnusedLocalVariableConst() {
-            rewriteRun(
-              kotlin(
-                """
-                  package constants
-                  const val FOO = "bar"
-                  """
-              ),
-              kotlin(
-                """
-                  package config
-                  import constants.FOO
-                  fun baz() {
-                    val foo = FOO
-                    println(foo)
-                  }
-                  """
-              )
-            );
-        }
-
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -1016,35 +1016,53 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
     }
 
     @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/152")
-    @Disabled
-    void removeUnusedInsideCase() {
+    void retainJavaUnusedLocalVariableWithNewClass() {
         rewriteRun(
+          //language=java
           java(
             """
-             class Test {
-                 static void method() {
-                     int x = 10;
-                     char y = 20;
-                     switch (x) {
-                         case 10:
-                             byte unused;
-                             break;
-                     }
-                 }
-             }
-             """,
+              class A {}
+              class B {
+                void foo() {
+                  A a = new A();
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/152")
+    void retainUnusedInsideCase() {
+        rewriteRun(
+          //language=java
+          java(
             """
-             class Test {
-                 static void method() {
-                     int x = 10;
-                     switch (x) {
-                         case 10:
-                             break;
-                     }
-                 }
-             }
-             """
+              class Test {
+                  static void method() {
+                      int x = 10;
+                      char y = 20;
+                      switch (x) {
+                          case 10:
+                              byte unused;
+                              break;
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static void method() {
+                      int x = 10;
+                      switch (x) {
+                          case 10:
+                              byte unused;
+                              break;
+                      }
+                  }
+              }
+              """
           )
         );
     }
@@ -1072,12 +1090,14 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         @ExpectedToFail("Not yet implemented")
         void retainUnusedLocalVariableConst() {
             rewriteRun(
+              //language=kotlin
               kotlin(
                 """
                   package constants
                   const val FOO = "bar"
                   """
               ),
+              //language=kotlin
               kotlin(
                 """
                   package config
@@ -1090,22 +1110,6 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
               )
             );
         }
-        
-    }
-    
-    @Test
-    void retainJavaUnusedLocalVariableWithNewClass() {
-        rewriteRun(
-          java(
-            """
-              class A {}
-              class B {
-                void foo() {
-                  A a = new A();
-                }
-              }
-              """
-          )
-        );
+
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -16,9 +16,8 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Disabled;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -15,7 +15,9 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Disabled;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -1014,7 +1014,7 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
     }
 
     @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues")
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/152")
     @Disabled
     void removeUnusedInsideCase() {
         rewriteRun(
@@ -1043,6 +1043,66 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
                  }
              }
              """
+          )
+        );
+    }
+
+    @Nested
+    class Kotlin {
+
+        @Test
+        void retainUnusedLocalVariableWithNewClass() {
+            rewriteRun(
+              kotlin(
+                """
+                  class A {}
+                  class B {
+                    fun foo() {
+                      val a = A();
+                    }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        @ExpectedToFail("Not yet implemented")
+        void retainUnusedLocalVariableConst() {
+            rewriteRun(
+              kotlin(
+                """
+                  package constants
+                  const val FOO = "bar"
+                  """
+              ),
+              kotlin(
+                """
+                  package config
+                  import constants.FOO
+                  fun baz() {
+                    val foo = FOO
+                    println(foo)
+                  }
+                  """
+              )
+            );
+        }
+        
+    }
+    
+    @Test
+    void retainJavaUnusedLocalVariableWithNewClass() {
+        rewriteRun(
+          java(
+            """
+              class A {}
+              class B {
+                void foo() {
+                  A a = new A();
+                }
+              }
+              """
           )
         );
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

Fixes #152 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
