### PR TITLE
Simplify null and empty string comparisons

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpression.java
@@ -184,11 +184,9 @@ public class SimplifyBooleanExpression extends Recipe {
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
                 J j = super.visitMethodInvocation(method, executionContext);
                 J.MethodInvocation asMethod = (J.MethodInvocation) j;
-                if (isEmpty.matches(asMethod)) {
-                    Expression receiver = asMethod.getSelect();
-                    if (J.Literal.isLiteralValue(receiver, "")) {
-                        return booleanLiteral(method, true);
-                    }
+                if (isEmpty.matches(asMethod) && J.Literal.isLiteralValue(asMethod.getSelect(), "")) {
+                    maybeUnwrapParentheses();
+                    return booleanLiteral(method, true);
                 }
                 return j;
             }

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
@@ -344,5 +346,46 @@ class SimplifyBooleanExpressionTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @ParameterizedTest
+    @Issue("https://github.com/openrewrite/rewrite-templating/issues/28")
+    @CsvSource(delimiterString = "//", textBlock = """
+      a == null || a.isEmpty()                                 // a == null || a.isEmpty() 
+      a == null || !a.isEmpty()                                // a == null || !a.isEmpty() 
+      a != null && a.isEmpty()                                 // a != null && a.isEmpty() 
+      a != null && !a.isEmpty()                                // a != null && !a.isEmpty() 
+      a == null || a.isEmpty() || "" == null || "".isEmpty()   // a == null || a.isEmpty() || "".isEmpty()
+      a == null || a.isEmpty() || "" == null || !"".isEmpty()  // a == null || a.isEmpty() || !"".isEmpty()
+      a == null || a.isEmpty() || "" != null && "".isEmpty()   // a == null || a.isEmpty() || "".isEmpty()
+      a == null || a.isEmpty() || "" != null && !"".isEmpty()  // a == null || a.isEmpty() || !"".isEmpty()
+      a == null || a.isEmpty() && "" == null || "".isEmpty()   // a == null || "".isEmpty()
+      a == null || a.isEmpty() && "" == null || !"".isEmpty()  // a == null || !"".isEmpty()
+      a == null || a.isEmpty() && "" != null && "".isEmpty()   // a == null || a.isEmpty() && "".isEmpty()
+      a == null || a.isEmpty() && "" != null && !"".isEmpty()  // a == null || a.isEmpty() && !"".isEmpty()
+      a == null || !a.isEmpty() || "" == null || "".isEmpty()  // a == null || !a.isEmpty() || "".isEmpty()
+      a == null || !a.isEmpty() || "" == null || !"".isEmpty() // a == null || !a.isEmpty() || !"".isEmpty()
+      a == null || !a.isEmpty() || "" != null && "".isEmpty()  // a == null || !a.isEmpty() || "".isEmpty()
+      a == null || !a.isEmpty() || "" != null && !"".isEmpty() // a == null || !a.isEmpty() || !"".isEmpty()
+      a == null || !a.isEmpty() && "" == null || "".isEmpty()  // a == null || "".isEmpty() 
+      a == null || !a.isEmpty() && "" == null || !"".isEmpty() // a == null || !"".isEmpty()
+      a == null || !a.isEmpty() && "" != null && "".isEmpty()  // a == null || !a.isEmpty() && "".isEmpty() 
+      a == null || !a.isEmpty() && "" != null && !"".isEmpty() // a == null || !a.isEmpty() && !"".isEmpty()
+      """)
+    void simplifyLiteralNull(String before, String after) {
+        //language=java
+        String template = """
+          class A {
+              void foo(String a) {
+                  boolean c = %s;
+              }
+          }
+          """;
+        String beforeJava = template.formatted(before);
+        if (before.equals(after)) {
+            rewriteRun(java(beforeJava));
+        } else {
+            rewriteRun(java(beforeJava, template.formatted(after)));
+        }
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
@@ -355,22 +355,40 @@ class SimplifyBooleanExpressionTest implements RewriteTest {
       a == null || !a.isEmpty()                                // a == null || !a.isEmpty() 
       a != null && a.isEmpty()                                 // a != null && a.isEmpty() 
       a != null && !a.isEmpty()                                // a != null && !a.isEmpty() 
-      a == null || a.isEmpty() || "" == null || "".isEmpty()   // a == null || a.isEmpty() || "".isEmpty()
-      a == null || a.isEmpty() || "" == null || !"".isEmpty()  // a == null || a.isEmpty() || !"".isEmpty()
-      a == null || a.isEmpty() || "" != null && "".isEmpty()   // a == null || a.isEmpty() || "".isEmpty()
-      a == null || a.isEmpty() || "" != null && !"".isEmpty()  // a == null || a.isEmpty() || !"".isEmpty()
-      a == null || a.isEmpty() && "" == null || "".isEmpty()   // a == null || "".isEmpty()
-      a == null || a.isEmpty() && "" == null || !"".isEmpty()  // a == null || !"".isEmpty()
-      a == null || a.isEmpty() && "" != null && "".isEmpty()   // a == null || a.isEmpty() && "".isEmpty()
-      a == null || a.isEmpty() && "" != null && !"".isEmpty()  // a == null || a.isEmpty() && !"".isEmpty()
-      a == null || !a.isEmpty() || "" == null || "".isEmpty()  // a == null || !a.isEmpty() || "".isEmpty()
-      a == null || !a.isEmpty() || "" == null || !"".isEmpty() // a == null || !a.isEmpty() || !"".isEmpty()
-      a == null || !a.isEmpty() || "" != null && "".isEmpty()  // a == null || !a.isEmpty() || "".isEmpty()
-      a == null || !a.isEmpty() || "" != null && !"".isEmpty() // a == null || !a.isEmpty() || !"".isEmpty()
-      a == null || !a.isEmpty() && "" == null || "".isEmpty()  // a == null || "".isEmpty() 
-      a == null || !a.isEmpty() && "" == null || !"".isEmpty() // a == null || !"".isEmpty()
-      a == null || !a.isEmpty() && "" != null && "".isEmpty()  // a == null || !a.isEmpty() && "".isEmpty() 
-      a == null || !a.isEmpty() && "" != null && !"".isEmpty() // a == null || !a.isEmpty() && !"".isEmpty()
+
+      a == null || a.isEmpty() || "" == null || "".isEmpty()   // true
+      a == null || a.isEmpty() || "" == null || !"".isEmpty()  // a == null || a.isEmpty()
+      a == null || a.isEmpty() || "" != null && "".isEmpty()   // true
+      a == null || a.isEmpty() || "" != null && !"".isEmpty()  // a == null || a.isEmpty()
+      a == null || a.isEmpty() && "" == null || "".isEmpty()   // true
+      a == null || a.isEmpty() && "" == null || !"".isEmpty()  // a == null
+      a == null || a.isEmpty() && "" != null && "".isEmpty()   // a == null || a.isEmpty()
+      a == null || a.isEmpty() && "" != null && !"".isEmpty()  // a == null
+      a == null || !a.isEmpty() || "" == null || "".isEmpty()  // true
+      a == null || !a.isEmpty() || "" == null || !"".isEmpty() // a == null || !a.isEmpty()
+      a == null || !a.isEmpty() || "" != null && "".isEmpty()  // true
+      a == null || !a.isEmpty() || "" != null && !"".isEmpty() // a == null || !a.isEmpty()
+      a == null || !a.isEmpty() && "" == null || "".isEmpty()  // true 
+      a == null || !a.isEmpty() && "" == null || !"".isEmpty() // a == null
+      a == null || !a.isEmpty() && "" != null && "".isEmpty()  // a == null || !a.isEmpty() 
+      a == null || !a.isEmpty() && "" != null && !"".isEmpty() // a == null
+
+      a == null || a.isEmpty() || "b" == null || "b".isEmpty()   // a == null || a.isEmpty() || "b".isEmpty()
+      a == null || a.isEmpty() || "b" == null || !"b".isEmpty()  // a == null || a.isEmpty() || !"b".isEmpty()
+      a == null || a.isEmpty() || "b" != null && "b".isEmpty()   // a == null || a.isEmpty() || "b".isEmpty()
+      a == null || a.isEmpty() || "b" != null && !"b".isEmpty()  // a == null || a.isEmpty() || !"b".isEmpty()
+      a == null || a.isEmpty() && "b" == null || "b".isEmpty()   // a == null || "b".isEmpty()
+      a == null || a.isEmpty() && "b" == null || !"b".isEmpty()  // a == null || !"b".isEmpty()
+      a == null || a.isEmpty() && "b" != null && "b".isEmpty()   // a == null || a.isEmpty() && "b".isEmpty()
+      a == null || a.isEmpty() && "b" != null && !"b".isEmpty()  // a == null || a.isEmpty() && !"b".isEmpty()
+      a == null || !a.isEmpty() || "b" == null || "b".isEmpty()  // a == null || !a.isEmpty() || "b".isEmpty()
+      a == null || !a.isEmpty() || "b" == null || !"b".isEmpty() // a == null || !a.isEmpty() || !"b".isEmpty()
+      a == null || !a.isEmpty() || "b" != null && "b".isEmpty()  // a == null || !a.isEmpty() || "b".isEmpty()
+      a == null || !a.isEmpty() || "b" != null && !"b".isEmpty() // a == null || !a.isEmpty() || !"b".isEmpty()
+      a == null || !a.isEmpty() && "b" == null || "b".isEmpty()  // a == null || "b".isEmpty() 
+      a == null || !a.isEmpty() && "b" == null || !"b".isEmpty() // a == null || !"b".isEmpty()
+      a == null || !a.isEmpty() && "b" != null && "b".isEmpty()  // a == null || !a.isEmpty() && "b".isEmpty() 
+      a == null || !a.isEmpty() && "b" != null && !"b".isEmpty() // a == null || !a.isEmpty() && !"b".isEmpty()
       """)
     void simplifyLiteralNull(String before, String after) {
         //language=java


### PR DESCRIPTION
## What's changed?
Also simplify comparisons such as `"" == null`, `"" != null` and `"".isEmpty()` such that we can clean up the replacements inserted in https://github.com/openrewrite/rewrite-migrate-java/pull/271 when parameters are using nullable literals.

## What's your motivation?
- https://github.com/openrewrite/rewrite-templating/issues/28
- https://github.com/openrewrite/rewrite-migrate-java/pull/271

## Anything in particular you'd like reviewers to focus on?
- [ ] Should we do anything more to prevent issues with Kotlin nullable?