### PR TITLE
do not remove try block if there are resources

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
@@ -82,7 +82,7 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
 
             J.Block nestedBlock = (J.Block) s;
             if (isEmptyBlock(nestedBlock) && ((Boolean.TRUE.equals(emptyBlockStyle.getStaticInit()) && nestedBlock.isStatic()) ||
-                    (Boolean.TRUE.equals(emptyBlockStyle.getInstanceInit()) && !nestedBlock.isStatic()))) {
+                                              (Boolean.TRUE.equals(emptyBlockStyle.getInstanceInit()) && !nestedBlock.isStatic()))) {
                 filtered.set(true);
                 return null;
             }
@@ -97,7 +97,9 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
     public J.Try visitTry(J.Try tryable, P p) {
         J.Try t = super.visitTry(tryable, p);
 
-        if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralTry()) && isEmptyBlock(t.getBody())) {
+        if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralTry()) &&
+            isEmptyBlock(t.getBody()) &&
+            (t.getResources() == null || t.getResources().isEmpty())) {
             doAfterVisit(new DeleteStatement<>(tryable));
         } else if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralFinally()) && t.getFinally() != null
                    && !t.getCatches().isEmpty() && isEmptyBlock(t.getFinally())) {
@@ -211,7 +213,7 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
 
     private boolean isEmptyBlock(Statement blockNode) {
         if (blockNode instanceof J.Block) {
-            J.Block block = (J.Block)blockNode;
+            J.Block block = (J.Block) blockNode;
             if (EmptyBlockStyle.BlockPolicy.STATEMENT.equals(emptyBlockStyle.getBlockPolicy())) {
                 return block.getStatements().isEmpty();
             } else if (EmptyBlockStyle.BlockPolicy.TEXT.equals(emptyBlockStyle.getBlockPolicy())) {

--- a/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
@@ -225,26 +225,7 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private boolean isEmptyResources(@Nullable List<J.Try.Resource> resources) {
-        if (resources == null || resources.isEmpty()) {
-            return true;
-        }
-        // Searching for access to instances from outside the scope to detect potential side effects.
-        // If that's the case, we cannot remove this resources block.
-        for (J.Try.Resource resource : resources) {
-            // Any reference to an identifier used here comes from outside the scope.
-            if (resource.getVariableDeclarations() instanceof J.Identifier) {
-                return false;
-            } else if (resource.getVariableDeclarations() instanceof J.VariableDeclarations) {
-                J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) resource.getVariableDeclarations();
-                for (J.VariableDeclarations.NamedVariable variable : variableDeclarations.getVariables()) {
-                    // If the variable is not initialized with a new instance, it means it can come from outside the scope.
-                    if (!(variable.getInitializer() instanceof J.NewClass)) {
-                        return false;
-                    }
-                }
-            }
-        }
-        return true;
+        return resources == null || resources.isEmpty();
     }
 
     private static class ExtractSideEffectsOfIfCondition<P> extends JavaVisitor<P> {

--- a/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
@@ -82,7 +82,7 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
 
             J.Block nestedBlock = (J.Block) s;
             if (isEmptyBlock(nestedBlock) && ((Boolean.TRUE.equals(emptyBlockStyle.getStaticInit()) && nestedBlock.isStatic()) ||
-                                              (Boolean.TRUE.equals(emptyBlockStyle.getInstanceInit()) && !nestedBlock.isStatic()))) {
+                    (Boolean.TRUE.equals(emptyBlockStyle.getInstanceInit()) && !nestedBlock.isStatic()))) {
                 filtered.set(true);
                 return null;
             }

--- a/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
@@ -25,7 +25,10 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.format.ShiftFormat;
 import org.openrewrite.java.style.EmptyBlockStyle;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;

--- a/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
@@ -416,7 +416,7 @@ class EmptyBlockTest implements RewriteTest {
     }
 
     @Test
-    void emptyTryWithResources() {
+    void emptyTryWithResourcesWithExternalResources() {
         rewriteRun(
           //language=java
           java(
@@ -437,4 +437,53 @@ class EmptyBlockTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyTryWithResourcesWithVariableInitializationOfExternalResource() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileInputStream;import java.io.IOException;import java.io.InputStream;import java.io.UncheckedIOException;public class A {
+                  private final InputStream stdin = new FileInputStream("test.in");
+                  
+                  public void destroy() {
+                      // close stream in a try-with-resources
+                      try (InputStream s = stdin) {
+                      } catch (IOException e) {
+                          throw new UncheckedIOException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyTryWithResourcesWithVariableInitializationMethodInvocation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileInputStream;import java.io.IOException;import java.io.InputStream;import java.io.UncheckedIOException;public class A {
+                  private final InputStream stdin = new FileInputStream("test.in");
+                  
+                  private InputStream getStdin() {
+                     return stdin;
+                  }
+                  
+                  public void destroy() {
+                      // close stream in a try-with-resources
+                      try (InputStream s = getStdin()) {
+                      } catch (IOException e) {
+                          throw new UncheckedIOException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
@@ -414,4 +414,27 @@ class EmptyBlockTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyTryWithResources() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileInputStream;import java.io.IOException;import java.io.UncheckedIOException;public class A {
+                  private final InputStream stdin = new FileInputStream("test.in");
+                  private final InputStream stdout = new FileInputStream("test.out");
+                  
+                  public void destroy() {
+                      // close all streams in a try-with-resources
+                      try (stdin; stdout) {
+                      } catch (IOException e) {
+                          throw new UncheckedIOException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
@@ -116,7 +116,7 @@ class EmptyBlockTest implements RewriteTest {
               public class A {
                   {
                       final String fileName = "fileName";
-                      try(FileInputStream fis = new FileInputStream(fileName)) {
+                      try {
                       } catch (IOException e) {
                       }
                   }
@@ -416,20 +416,18 @@ class EmptyBlockTest implements RewriteTest {
     }
 
     @Test
-    void emptyTryWithResourcesWithExternalResources() {
+    void emptyTryWithResources() {
         rewriteRun(
           //language=java
           java(
             """
-              import java.io.FileInputStream;import java.io.IOException;import java.io.UncheckedIOException;public class A {
-                  private final InputStream stdin = new FileInputStream("test.in");
-                  private final InputStream stdout = new FileInputStream("test.out");
-                  
-                  public void destroy() {
-                      // close all streams in a try-with-resources
-                      try (stdin; stdout) {
+              import java.io.*;
+
+              public class A {
+                  {
+                      final String fileName = "fileName";
+                      try (FileInputStream fis = new FileInputStream(fileName)) {
                       } catch (IOException e) {
-                          throw new UncheckedIOException(e);
                       }
                   }
               }
@@ -437,53 +435,4 @@ class EmptyBlockTest implements RewriteTest {
           )
         );
     }
-
-    @Test
-    void emptyTryWithResourcesWithVariableInitializationOfExternalResource() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import java.io.FileInputStream;import java.io.IOException;import java.io.InputStream;import java.io.UncheckedIOException;public class A {
-                  private final InputStream stdin = new FileInputStream("test.in");
-                  
-                  public void destroy() {
-                      // close stream in a try-with-resources
-                      try (InputStream s = stdin) {
-                      } catch (IOException e) {
-                          throw new UncheckedIOException(e);
-                      }
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void emptyTryWithResourcesWithVariableInitializationMethodInvocation() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import java.io.FileInputStream;import java.io.IOException;import java.io.InputStream;import java.io.UncheckedIOException;public class A {
-                  private final InputStream stdin = new FileInputStream("test.in");
-                  
-                  private InputStream getStdin() {
-                     return stdin;
-                  }
-                  
-                  public void destroy() {
-                      // close stream in a try-with-resources
-                      try (InputStream s = getStdin()) {
-                      } catch (IOException e) {
-                          throw new UncheckedIOException(e);
-                      }
-                  }
-              }
-              """
-          )
-        );
-    }
-
 }


### PR DESCRIPTION
## What's changed?
Try with resources can have side effects (closing the streams) even with empty try blocks. So we cannot delete it safely.

Modified the emptyTry test to not have resources (so it's removed because it's empty), and added a new emptyTryWithResources that is actually not removed because it has resources.

## Anyone you would like to review specifically?
@kmccarp 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
