### PR TITLE
Simplify lambda blocks to expressions replaces return that is used to infer which overloaded method to pick

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -15,22 +15,26 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
 class LambdaBlockToExpressionTest implements RewriteTest {
 
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new LambdaBlockToExpression());
+    }
+
     @DocumentExample
     @SuppressWarnings("CodeBlock2Expr")
     @Test
     void simplifyLambdaBlockToExpression() {
         rewriteRun(
-          spec -> spec.recipe(new LambdaBlockToExpression()),
           //language=java
           java(
             """
@@ -55,7 +59,6 @@ class LambdaBlockToExpressionTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1")
     void simplifyLambdaBlockToExpressionWithComments() {
         rewriteRun(
-          spec -> spec.recipe(new LambdaBlockToExpression()),
           //language=java
           java(
             """
@@ -78,4 +81,44 @@ class LambdaBlockToExpressionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/162")
+    void simplifyLambdaBlockWithAmbiguousMethod() {
+        //language=java
+        rewriteRun(
+          java("""
+            import java.util.function.Function;
+            import java.util.function.Consumer;
+            class A {
+                void aMethod(Consumer<Integer> consumer){
+                }
+                
+                void aMethod(Function<Integer,String> function){
+                }
+            }
+            """),
+          java(
+            """
+              class Test {
+                  void doTest() {
+                      A a = new A();
+                      a.aMethod(value -> {
+                        return value.toString();
+                      });
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void doTest() {
+                      A a = new A();
+                      a.aMethod(value -> value.toString());
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
adding a test for https://github.com/openrewrite/rewrite-static-analysis/issues/162