### PR TITLE
Add recipe to rewrite java 11 `Stream.collect(Collectors.toUnmodifiab…

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToList.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToList.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import java.time.Duration;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesJavaVersion;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.MethodInvocation;
+import org.openrewrite.java.tree.JRightPadded;
+
+@Value
+public class ReplaceCollectWithStreamToList extends Recipe {
+
+    private static final MethodMatcher STREAM_COLLECT_TO_LIST = new MethodMatcher("java.util.stream.Stream collect(java.util.stream.Collector)");
+    private static final MethodMatcher COLLECTORS_TO_LIST = new MethodMatcher("java.util.stream.Collectors toList()");
+    private static final MethodMatcher COLLECTORS_TO_UNMODIFIABLE_LIST = new MethodMatcher("java.util.stream.Collectors toUnmodifiableList()");
+
+    @Option(displayName = "Should the recipe also apply to mutable toList?",
+        description = "Also replace Java 11 `Stream.collect(Collectors.toList())` with Java 16 `Stream.toList()`.",
+        required = false)
+    @Nullable
+    Boolean includeMutable;
+
+    @Override
+    public String getDisplayName() {
+        return "Replace Stream.collect(Collectors.toUnmodifiableList()) with Stream.toList()";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace Java 11 `Stream.collect(Collectors.toUnmodifiableList())` with Java 16 `Stream.toList()`.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(Preconditions.and(new UsesJavaVersion<>(16),
+                new UsesMethod<>(STREAM_COLLECT_TO_LIST)), new JavaVisitor<ExecutionContext>() {
+
+            private final JavaTemplate template = JavaTemplate
+                    .builder("#{any(java.util.stream.Stream)}.toList()")
+                    .build();
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation result = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (STREAM_COLLECT_TO_LIST.matches(method)) {
+                    Expression command = method.getArguments().get(0);
+                    if (COLLECTORS_TO_UNMODIFIABLE_LIST.matches(command)){
+                        result = replaceCollector(result);
+                    } else if (COLLECTORS_TO_LIST.matches(command) && Boolean.TRUE.equals(includeMutable)) {
+                        result = replaceCollector(result);
+                    }
+                }
+                return result;
+            }
+
+            @NotNull
+            private J.MethodInvocation replaceCollector(MethodInvocation result) {
+                JRightPadded<Expression> select = result.getPadding().getSelect();
+                result = template.apply(updateCursor(result), result.getCoordinates().replace(), result.getSelect());
+                result = result.getPadding().withSelect(select);
+                maybeRemoveImport("java.util.stream.Collectors");
+                return result;
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToList.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToList.java
@@ -63,6 +63,11 @@ public class ReplaceCollectWithStreamToList extends Recipe {
     }
 
     @Override
+    public Set<String> getTags() {
+        return new HashSet<>(Arrays.asList("RSPEC-6204"));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(Preconditions.and(new UsesJavaVersion<>(16),
                 new UsesMethod<>(STREAM_COLLECT_TO_LIST)), new JavaVisitor<ExecutionContext>() {

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToListTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToListTest.java
@@ -30,31 +30,28 @@ class ReplaceCollectWithStreamToListTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     void replacesToUnmodifiableList() {
         rewriteRun(
           version(
             //language=java
             java(
               """
-              package com.example;
-
               import java.util.stream.Collectors;
               import java.util.stream.Stream;
 
               class Example {
-                  public void test() {
-                      Stream.of().collect(Collectors.toUnmodifiableList());
+                  public List<String> test(Stream<String> stream) {
+                      return stream.collect(Collectors.toUnmodifiableList());
                   }
               }
               """,
               """
-              package com.example;
-
               import java.util.stream.Stream;
 
               class Example {
-                  public void test() {
-                      Stream.of().toList();
+                  public List<String> test(Stream<String> stream) {
+                      return stream.toList();
                   }
               }
               """),

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToListTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToListTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+class ReplaceCollectWithStreamToListTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceCollectWithStreamToList(false));
+    }
+
+    @Test
+    void replacesToUnmodifiableList() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of().collect(Collectors.toUnmodifiableList());
+                  }
+              }
+              """,
+              """
+              package com.example;
+
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of().toList();
+                  }
+              }
+              """),
+            16));
+    }
+
+    @Test
+    void doesNotReplaceToList() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of().collect(Collectors.toList());
+                  }
+              }
+              """),
+            16));
+    }
+
+    @Test
+    void doesReplaceToList() {
+        rewriteRun(
+          recipeSpec -> recipeSpec.recipe(new ReplaceCollectWithStreamToList(true)),
+          version(
+            //language=java
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of().collect(Collectors.toList());
+                  }
+              }
+              """,
+              """
+              package com.example;
+
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of().toList();
+                  }
+              }
+              """),
+            16));
+    }
+
+    @Test
+    void formatting() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          .collect(Collectors.toUnmodifiableList());
+                  }
+              }
+              """,
+              """
+              package com.example;
+
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          .toList();
+                  }
+              }
+              """),
+            16));
+    }
+
+    @Test
+    void comment() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+              package com.example;
+
+              import java.util.stream.Collectors;
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          // Convert to list
+                          .collect(Collectors.toUnmodifiableList());
+                  }
+              }
+              """,
+              """
+              package com.example;
+
+              import java.util.stream.Stream;
+
+              class Example {
+                  public void test() {
+                      Stream.of()
+                          // Convert to list
+                          .toList();
+                  }
+              }
+              """),
+            16));
+    }
+
+}

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToListTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectWithStreamToListTest.java
@@ -19,6 +19,7 @@ import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -39,6 +40,7 @@ class ReplaceCollectWithStreamToListTest implements RewriteTest {
               """
               import java.util.stream.Collectors;
               import java.util.stream.Stream;
+              import java.util.List;
 
               class Example {
                   public List<String> test(Stream<String> stream) {
@@ -48,6 +50,7 @@ class ReplaceCollectWithStreamToListTest implements RewriteTest {
               """,
               """
               import java.util.stream.Stream;
+              import java.util.List;
 
               class Example {
                   public List<String> test(Stream<String> stream) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Adding a recipe that rewrites Java 11 `Stream.collect(Collectors.toUnmodifiableList())` to Java 16 `Stream.toList()` with an optional toggle to include `Stream.collect(Collectors.toList())` so no harm is done initially.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
I asked on slack if there was an opposing recipe to replacestreamtolistwithcollect, we came to the conclusion that it does not exist but does seem justifiable to have.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @joanvr 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
