### PR TITLE
Preserve arrays when inlining variables

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -21,7 +21,9 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 
 import java.time.Duration;
@@ -98,8 +100,10 @@ public class InlineVariable extends Recipe {
                 Statement lastStatement = stats.get(stats.size() - 1);
                 if (lastStatement instanceof J.Return) {
                     J.Return return_ = (J.Return) lastStatement;
-                    if (return_.getExpression() instanceof J.Identifier) {
-                        return ((J.Identifier) return_.getExpression()).getSimpleName();
+                    Expression expression = return_.getExpression();
+                    if (expression instanceof J.Identifier &&
+                        !(expression.getType() instanceof JavaType.Array)) {
+                        return ((J.Identifier) expression).getSimpleName();
                     }
                 } else if (lastStatement instanceof J.Throw) {
                     J.Throw thr = (J.Throw) lastStatement;

--- a/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
@@ -195,4 +195,21 @@ class InlineVariableTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void preserveArray() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  int[] test() {
+                      int[] arr = {1, 2, 3};
+                      return arr;
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Before this PR we get a compiler error.
After this PR we retain the array for now.

A future PR might move the type declaration.