### PR TITLE
fix: FinalizeMethodArguments considers unary and += expressions

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeMethodArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeMethodArguments.java
@@ -147,6 +147,7 @@ public class FinalizeMethodArguments extends Recipe {
             return assignment;
         }
 
+        // contributed as a fix for issue #176
         @Override
         public J.@NotNull Unary visitUnary(final J.@NotNull Unary unary, final AtomicBoolean hasAssignment) {
             if (hasAssignment.get()) {
@@ -163,6 +164,7 @@ public class FinalizeMethodArguments extends Recipe {
             return u;
         }
 
+        // contributed as a fix for issue  #176
         @Override
         public J.AssignmentOperation visitAssignmentOperation(final J.AssignmentOperation assignOp, final AtomicBoolean hasAssignment) {
             if (hasAssignment.get()) {

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
@@ -239,4 +239,73 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
           )
         );
     }
+    
+    @Test
+    void doNotReplaceIfAssignedThroughUnaryOrAccumulator(){
+        rewriteRun(java("""
+          package Test;
+                    
+          class Test {
+                    
+            protected int addFinalToThisVar(int unalteredVariable) {
+              return unalteredVariable;
+            }
+                    
+            protected int increment(int variableToIncrement) {
+              variableToIncrement++;
+              return variableToIncrement;
+            }
+                    
+            protected int preIncrement(int variableToPreIncrement) {
+              return ++variableToPreIncrement;
+            }
+                    
+            protected int decrement(int variableToDecrement) {
+              variableToDecrement--;
+              return variableToDecrement;
+            }
+                    
+            protected int preDecrement(int variableToPreDecrement) {
+              return --variableToPreDecrement;
+            }
+                    
+            protected int accumulate(int add, int accumulator) {
+              accumulator += add;
+              return accumulator;
+            }
+          }
+          """, """
+          package Test;
+                    
+          class Test {
+                    
+            protected int addFinalToThisVar(final int unalteredVariable) {
+              return unalteredVariable;
+            }
+                    
+            protected int increment(int variableToIncrement) {
+              variableToIncrement++;
+              return variableToIncrement;
+            }
+                    
+            protected int preIncrement(int variableToPreIncrement) {
+              return ++variableToPreIncrement;
+            }
+                    
+            protected int decrement(int variableToDecrement) {
+              variableToDecrement--;
+              return variableToDecrement;
+            }
+                    
+            protected int preDecrement(int variableToPreDecrement) {
+              return --variableToPreDecrement;
+            }
+                    
+            protected int accumulate(int add, int accumulator) {
+              accumulator += add;
+              return accumulator;
+            }
+          }
+          """));
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
@@ -242,6 +242,7 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
     
     @Test
     void doNotReplaceIfAssignedThroughUnaryOrAccumulator(){
+        //language=java
         rewriteRun(java("""
           package Test;
                     


### PR DESCRIPTION
## What's changed?
closes #176 

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
No other workaround was found.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
 - no new source files were added.
- [X] I've used the IntelliJ IDEA auto-formatter on affected files