### PR TITLE
fix: skip finalizing anonymous class fields in FinalizeLocalVariables

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
@@ -69,9 +69,9 @@ public class FinalizeLocalVariables extends Recipe {
                 }
 
                 // ignores anonymous class fields, contributed code for issue #181    
-                if (this.isAnonymousClassField(mv)) {
-                    return mv;
-                }
+                    if (this.getCursorToParentScope(this.getCursor()).getValue() instanceof J.NewClass) {
+                        return mv;
+                    }
 
                 if (mv.getVariables().stream()
                         .noneMatch(v -> {
@@ -87,18 +87,8 @@ public class FinalizeLocalVariables extends Recipe {
                 return mv;
             }
 
-            private boolean isAnonymousClassField(final J.VariableDeclarations multiVariable) {
-                return multiVariable.getVariables().stream().anyMatch(v -> {
-                    if (v.getVariableType() == null) {
-                        return false;
-                    }
-                    final JavaType ownClassFQN = v.getVariableType().getOwner();
-                    if (ownClassFQN == null) {
-                        return false;
-                    }
-                    final String[] typeFQNSplit = ownClassFQN.toString().split("\\.");
-                    return typeFQNSplit[typeFQNSplit.length - 1].contains("$");
-                });
+            private Cursor getCursorToParentScope(final Cursor cursor) {
+                return cursor.dropParentUntil(is -> is instanceof J.NewClass || is instanceof J.ClassDeclaration);
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
@@ -21,7 +21,6 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
@@ -45,8 +44,8 @@ public class FinalizeLocalVariables extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
 
-                @Override
-                public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext p) {
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext p) {
                 J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, p);
 
                 // if this already has "final", we don't need to bother going any further; we're done
@@ -69,9 +68,9 @@ public class FinalizeLocalVariables extends Recipe {
                 }
 
                 // ignores anonymous class fields, contributed code for issue #181    
-                    if (this.getCursorToParentScope(this.getCursor()).getValue() instanceof J.NewClass) {
-                        return mv;
-                    }
+                if (this.getCursorToParentScope(this.getCursor()).getValue() instanceof J.NewClass) {
+                    return mv;
+                }
 
                 if (mv.getVariables().stream()
                         .noneMatch(v -> {

--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
@@ -68,8 +68,7 @@ public class FinalizeLocalVariables extends Recipe {
                     return mv;
                 }
 
-                // ignores anonymous class fields
-                // @Issue(https://github.com/openrewrite/rewrite-static-analysis/issues/181)
+                // ignores anonymous class fields, contributed code for issue #181    
                 if (this.isAnonymousClassField(mv)) {
                     return mv;
                 }

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -440,6 +440,7 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/181")
     void shouldNotFinalizeVariablesWhichAreAssignedInAnonymousClasses() {
         this.rewriteRun(
           // language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -438,4 +438,33 @@ class FinalizeLocalVariablesTest implements RewriteTest {
                 )
         );
     }
+
+    @Test
+    void shouldNotFinalizeVariablesWhichAreAssignedInAnonymousClasses() {
+        this.rewriteRun(
+          // language=java
+          java("""
+            package Test;
+
+            import javafx.beans.property.IntegerProperty;
+            import javafx.beans.property.SimpleIntegerProperty;
+
+                class Test {
+
+                  private final IntegerProperty cellCount = new SimpleIntegerProperty(this, "cellCount", 0) {
+                    private int oldCount = 0;
+
+                    @Override
+                    protected void invalidated() {
+                      final int currentCellCount = this.get();
+
+                      final boolean countChanged = this.oldCount != currentCellCount;
+                      if (countChanged) {
+                        this.oldCount = currentCellCount;
+                      }
+                    }
+                  };
+                }
+                """));
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -424,7 +424,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     void shouldNotFinalizeVariableWhichIsReassignedInAnotherSwitchBranch() {
         rewriteRun(
           //language=java
-          java("""
+          java(
+            """
             class A {
                 static int variable = 0;
                 static {

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -446,28 +446,22 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     void shouldNotFinalizeVariablesWhichAreAssignedInAnonymousClasses() {
         this.rewriteRun(
           // language=java
-          java(
-            """
-              import javafx.beans.property.IntegerProperty;
-              import javafx.beans.property.SimpleIntegerProperty;
+          java("""
+            package Test;
 
-              class Test {
-                private final IntegerProperty cellCount = new SimpleIntegerProperty(this, "cellCount", 0) {
-                  private int oldCount = 0;
+                 class Test {
 
-                  @Override
-                  protected void invalidated() {
-                    final int currentCellCount = this.get();
+                   private final Object objectWithInnerField = new Object() {
+                     private int count = 0;
 
-                    final boolean countChanged = this.oldCount != currentCellCount;
-                    if (countChanged) {
-                      this.oldCount = currentCellCount;
-                    }
-                  }
-                };
-              }
-              """
-          )
-        );
+                     @Override
+                     public String toString() {
+                       this.count++;
+                       return super.toString() + this.count;
+                     }
+
+                   };
+                 }
+                """));
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -446,22 +446,20 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     void shouldNotFinalizeVariablesWhichAreAssignedInAnonymousClasses() {
         this.rewriteRun(
           // language=java
-          java("""
-            package Test;
-
-                 class Test {
-
-                   private final Object objectWithInnerField = new Object() {
-                     private int count = 0;
-
-                     @Override
-                     public String toString() {
-                       this.count++;
-                       return super.toString() + this.count;
-                     }
-
-                   };
-                 }
-                """));
+          java(
+            """
+              class Test {
+                private final Object objectWithInnerField = new Object() {
+                  private int count = 0;
+                  @Override
+                  public String toString() {
+                    this.count++;
+                    return super.toString() + this.count;
+                  }
+                };
+              }
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -225,14 +225,14 @@ class FinalizeLocalVariablesTest implements RewriteTest {
               }
               """,
             """
-            class Test {
-                static {
-                    final int n = 1;
-                    for(int i = 0; i < n; i++) {
-                    }
-                }
-            }
-            """
+              class Test {
+                  static {
+                      final int n = 1;
+                      for(int i = 0; i < n; i++) {
+                      }
+                  }
+              }
+              """
           )
         );
     }
@@ -282,7 +282,7 @@ class FinalizeLocalVariablesTest implements RewriteTest {
           java(
             """
               import java.util.concurrent.FutureTask;
-              
+                            
               class A {
                   void f() {
                       for(FutureTask<?> future; (future = new FutureTask<>(() -> "hello world")) != null;) { }
@@ -296,34 +296,36 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     @Test
     void shouldNotFinalizeForCounterWhichIsReassignedWithinForHeader() {
         rewriteRun(
-                //language=java
-                java("""
-                class A {             
-                    static {
-                        for (int i = 0; i < 10; i++) {
-                            // no-op
-                        }
-                    }
-                }
-                """
-                )
+          //language=java
+          java(
+            """
+              class A {             
+                  static {
+                      for (int i = 0; i < 10; i++) {
+                          // no-op
+                      }
+                  }
+              }
+              """
+          )
         );
     }
 
     @Test
     void shouldNotFinalizeForCounterWhichIsReassignedWithinForBody() {
         rewriteRun(
-                //language=java
-                java("""
-                class A {             
-                    static {
-                        for (int i = 0; i < 10;) {
-                            i = 11;
-                        }
-                    }
-                }
-                """
-                )
+          //language=java
+          java(
+            """
+              class A {             
+                  static {
+                      for (int i = 0; i < 10;) {
+                          i = 11;
+                      }
+                  }
+              }
+              """
+          )
         );
     }
 
@@ -394,48 +396,48 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     void recordShouldNotIntroduceExtraClosingParenthesis() {
         rewriteRun(
           version(
-          //language=java
-          java(
-            """
-            public class Main {
-                public static void test() {
-                    var myVar = "";
-                }
-                public record EmptyRecord() {
-                }
-            }
-              """,
-            """
-            public class Main {
-                public static void test() {
-                    final var myVar = "";
-                }
-                public record EmptyRecord() {
-                }
-            }
+            //language=java
+            java(
               """
-          ), 17)
+                public class Main {
+                    public static void test() {
+                        var myVar = "";
+                    }
+                    public record EmptyRecord() {
+                    }
+                }
+                  """,
+              """
+                public class Main {
+                    public static void test() {
+                        final var myVar = "";
+                    }
+                    public record EmptyRecord() {
+                    }
+                }
+                  """
+            ), 17)
         );
     }
 
     @Test
     void shouldNotFinalizeVariableWhichIsReassignedInAnotherSwitchBranch() {
         rewriteRun(
-                //language=java
-                java("""
-                class A {             
-                    static int variable = 0;
-                    static {
-                        switch (variable) {
-                          case 0:
-                              int notFinalized = 0;
-                          default:
-                              notFinalized = 1;
-                        }
+          //language=java
+          java("""
+            class A {
+                static int variable = 0;
+                static {
+                    switch (variable) {
+                      case 0:
+                          int notFinalized = 0;
+                      default:
+                          notFinalized = 1;
                     }
                 }
-                """
-                )
+            }
+            """
+          )
         );
     }
 
@@ -444,28 +446,28 @@ class FinalizeLocalVariablesTest implements RewriteTest {
     void shouldNotFinalizeVariablesWhichAreAssignedInAnonymousClasses() {
         this.rewriteRun(
           // language=java
-          java("""
-            package Test;
+          java(
+            """
+              import javafx.beans.property.IntegerProperty;
+              import javafx.beans.property.SimpleIntegerProperty;
 
-            import javafx.beans.property.IntegerProperty;
-            import javafx.beans.property.SimpleIntegerProperty;
+              class Test {
+                private final IntegerProperty cellCount = new SimpleIntegerProperty(this, "cellCount", 0) {
+                  private int oldCount = 0;
 
-                class Test {
+                  @Override
+                  protected void invalidated() {
+                    final int currentCellCount = this.get();
 
-                  private final IntegerProperty cellCount = new SimpleIntegerProperty(this, "cellCount", 0) {
-                    private int oldCount = 0;
-
-                    @Override
-                    protected void invalidated() {
-                      final int currentCellCount = this.get();
-
-                      final boolean countChanged = this.oldCount != currentCellCount;
-                      if (countChanged) {
-                        this.oldCount = currentCellCount;
-                      }
+                    final boolean countChanged = this.oldCount != currentCellCount;
+                    if (countChanged) {
+                      this.oldCount = currentCellCount;
                     }
-                  };
-                }
-                """));
+                  }
+                };
+              }
+              """
+          )
+        );
     }
 }


### PR DESCRIPTION
## What's changed?
Variables identified as fields of anonymous classes will be skipped in **FinalizeLocalVariables** recipe.

## What's your motivation?
Fixes #181 

## Anything in particular you'd like reviewers to focus on?
There is perhaps a better way of identifying anonymous classes.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
 - no new files were added
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
