### PR TITLE
Transform collection.size() < 1 to isEmpty()

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/IsEmptyCallOnCollectionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/IsEmptyCallOnCollectionsTest.java
@@ -75,7 +75,7 @@ class IsEmptyCallOnCollectionsTest implements RewriteTest {
     }
 
     @Test
-    void isEmptyCallOnCollections() {
+    void comparisonWithZero() {
         rewriteRun(
           //language=java
           java(
@@ -84,7 +84,7 @@ class IsEmptyCallOnCollectionsTest implements RewriteTest {
 
               class Test {
                   static void method(List<String> l) {
-                      if (l.isEmpty() || 0 == l.size()) {
+                      if (l.size() == 0 || 0 == l.size()) {
                           // empty body
                       } else if (l.size() != 0 || 0 != l.size()) {
                           // empty body
@@ -108,6 +108,49 @@ class IsEmptyCallOnCollectionsTest implements RewriteTest {
                       } else if (!l.isEmpty() || l.size() < 0) {
                           // empty body
                       } else if (!l.isEmpty() || 0 > l.size()) {
+                          // empty body
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void comparisonWithOne() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  static void method(List<String> l) {
+                      if (l.size() < 1 || 1 > l.size()) {
+                          // empty body
+                      } else if (l.size() > 1 || 1 < l.size()) {
+                          // empty body
+                      } else if (l.size() >= 1 || 1 <= l.size()) {
+                          // empty body
+                      } else if (l.size() <= 1 || 1 >= l.size()) {
+                          // empty body
+                      }
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  static void method(List<String> l) {
+                      if (l.isEmpty() || l.isEmpty()) {
+                          // empty body
+                      } else if (l.size() > 1 || 1 < l.size()) {
+                          // empty body
+                      } else if (!l.isEmpty() || !l.isEmpty()) {
+                          // empty body
+                      } else if (l.size() <= 1 || 1 >= l.size()) {
                           // empty body
                       }
                   }


### PR DESCRIPTION
Not only size comparisons with zero can be optimized to isEmpty() calls. Additionally we can do (plus order changes):
* size() < 1 to isEmpty()
* size() >= 1 to !isEmpty()

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's your motivation?
real life code

## Anything in particular you'd like reviewers to focus on?
I've changed one of the existing unit tests. It was obviously meant to test `size() == 0` and `0 == size()` (to create all 8 variants of positive and negative tests).

### Checklist
- [X] I've added unit tests to cover both positive and negative cases