### PR TITLE
Fix `default` modifier type position to comply with Java Language Specification

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ModifierOrder.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ModifierOrder.java
@@ -21,12 +21,14 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.Modifier.Type;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.ToIntFunction;
 
 import static java.util.stream.Collectors.toList;
 
@@ -84,10 +86,24 @@ public class ModifierOrder extends Recipe {
 
         List<J.Modifier.Type> sortedTypes = modifiers.stream()
                 .map(J.Modifier::getType)
-                .sorted(Comparator.comparingInt(J.Modifier.Type::ordinal))
+                .sorted(Comparator.comparingInt(createModifierTypeToPositionFunction()))
                 .collect(toList());
 
 
         return ListUtils.map(modifiers, (i, mod) -> mod.getType() == sortedTypes.get(i) ? mod : mod.withType(sortedTypes.get(i)));
+    }
+    
+    private static ToIntFunction<Type> createModifierTypeToPositionFunction() {
+        final int DEFAULT_MOD_POSITION = 4;
+        return type -> {
+            if (type == Type.Default) {
+                return DEFAULT_MOD_POSITION;
+            }
+            int ordinal = type.ordinal();
+            if (ordinal <= DEFAULT_MOD_POSITION) {
+                return ordinal - 1;
+            }
+            return ordinal;
+        };
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
@@ -85,11 +85,27 @@ class ModifierOrderTest implements RewriteTest {
                   public static default void bar() {
                       int i = 5;
                   }
+
+                  default private static void baz() {
+                      int i = 5;
+                  }
+
+                  static default protected void qux() {
+                      int i = 5;
+                  }
               }
               """
           , """
               interface Foo {
                   public default static void bar() {
+                      int i = 5;
+                  }
+
+                  private default static void baz() {
+                      int i = 5;
+                  }
+
+                  protected default static void qux() {
                       int i = 5;
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
@@ -73,6 +73,30 @@ class ModifierOrderTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/187")
+    void putDefaultModifierAtJLSRightPosition() {
+        // default modifier must be placed between abstract and static modifiers
+        rewriteRun(
+          //language=java
+          java(
+            """
+              interface Foo {
+                  public static default void bar() {
+                      int i = 5;
+                  }
+              }
+              """
+          , """
+              interface Foo {
+                  public default static void bar() {
+                      int i = 5;
+                  }
+              }
+              """)
+        );
+    }
+
     @Nested
     class KotlinTest {
         @Test


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added specific unit test for linked issue and implement custom comparator to avoid the issue

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Closes #187 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
This fix should be implemented through `J.Modifier.Type::ordinal` modifying `default` element position in enum to be placed at fifth position.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
