### PR TITLE
Simplify `if`s with literal conditions even if they jump

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -25,6 +25,11 @@ public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> 
     }
     int firstJumpIndex = maybeFirstJumpIndex.get();
 
+    if (firstJumpIndex == statements.size() - 1) {
+      // Jump is at the end of the block, so nothing to do
+      return block;
+    }
+
     List<Statement> newStatements =
         ListUtils.flatMap(
             block.getStatements(),

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> {
+class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> {
 
   @Override
   public J visitBlock(J.Block block, ExecutionContext executionContext) {

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import lombok.AllArgsConstructor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaVisitor;
@@ -26,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-@AllArgsConstructor
 public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> {
 
   @Override

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -1,0 +1,55 @@
+package org.openrewrite.staticanalysis;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.MethodDeclaration;
+import org.openrewrite.java.tree.J.Return;
+import org.openrewrite.java.tree.J.Throw;
+import org.openrewrite.java.tree.Statement;
+
+@AllArgsConstructor
+public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> {
+  @Override
+  public J visitMethodDeclaration(MethodDeclaration method, ExecutionContext executionContext) {
+    method = (MethodDeclaration) super.visitMethodDeclaration(method, executionContext);
+    if (method.getBody() == null) {
+      return method;
+    }
+
+    List<Statement> statements = method.getBody().getStatements();
+    Optional<Integer> maybeFirstJumpIndex = findFirstJump(statements);
+    if (!maybeFirstJumpIndex.isPresent()) {
+      return method;
+    }
+    int firstJumpIndex = maybeFirstJumpIndex.get();
+
+    List<Statement> newStatements =
+        ListUtils.flatMap(
+            method.getBody().getStatements(),
+            (index, statement) -> {
+              if (index <= firstJumpIndex) {
+                return statement;
+              }
+              return Collections.emptyList();
+            }
+        );
+
+    return method.withBody(method.getBody().withStatements(newStatements));
+  }
+
+  private Optional<Integer> findFirstJump(List<Statement> statements) {
+    for (int i = 0; i < statements.size(); i++) {
+      Statement statement = statements.get(i);
+      if (statement instanceof Return || statement instanceof Throw) {
+        return Optional.of(i);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -8,19 +8,14 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.J.Block;
-import org.openrewrite.java.tree.J.Break;
-import org.openrewrite.java.tree.J.Continue;
-import org.openrewrite.java.tree.J.Return;
-import org.openrewrite.java.tree.J.Throw;
 import org.openrewrite.java.tree.Statement;
 
 @AllArgsConstructor
 public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> {
 
   @Override
-  public J visitBlock(Block block, ExecutionContext executionContext) {
-    block = (Block) super.visitBlock(block, executionContext);
+  public J visitBlock(J.Block block, ExecutionContext executionContext) {
+    block = (J.Block) super.visitBlock(block, executionContext);
 
     List<Statement> statements = block.getStatements();
     Optional<Integer> maybeFirstJumpIndex = findFirstJump(statements);
@@ -47,10 +42,10 @@ public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> 
     for (int i = 0; i < statements.size(); i++) {
       Statement statement = statements.get(i);
       if (
-          statement instanceof Return ||
-          statement instanceof Throw ||
-          statement instanceof Break ||
-          statement instanceof Continue
+          statement instanceof J.Return ||
+          statement instanceof J.Throw ||
+          statement instanceof J.Break ||
+          statement instanceof J.Continue
       ) {
         return Optional.of(i);
       }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.staticanalysis;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -1,14 +1,15 @@
 package org.openrewrite.staticanalysis;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 @AllArgsConstructor
 public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> {

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -9,6 +9,8 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.J.Block;
+import org.openrewrite.java.tree.J.Break;
+import org.openrewrite.java.tree.J.Continue;
 import org.openrewrite.java.tree.J.Return;
 import org.openrewrite.java.tree.J.Throw;
 import org.openrewrite.java.tree.Statement;
@@ -44,7 +46,12 @@ public class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> 
   private Optional<Integer> findFirstJump(List<Statement> statements) {
     for (int i = 0; i < statements.size(); i++) {
       Statement statement = statements.get(i);
-      if (statement instanceof Return || statement instanceof Throw) {
+      if (
+          statement instanceof Return ||
+          statement instanceof Throw ||
+          statement instanceof Break ||
+          statement instanceof Continue
+      ) {
         return Optional.of(i);
       }
     }

--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecution.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecution.java
@@ -20,7 +20,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor;
 import org.openrewrite.java.cleanup.UnnecessaryParenthesesVisitor;
@@ -32,7 +31,6 @@ import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Statement;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SimplifyConstantIfBranchExecution extends Recipe {
 
@@ -111,9 +109,7 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
                 // True branch
                 // Only keep the `then` branch, and remove the `else` branch.
                 Statement s = if__.getThenPart().withPrefix(if__.getPrefix());
-                if (jumps(s)) {
-                    doAfterVisit(new RemoveUnreachableCodeVisitor());
-                }
+                doAfterVisit(new RemoveUnreachableCodeVisitor());
                 return maybeAutoFormat(
                         if__,
                         s,
@@ -125,9 +121,7 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
                 if (if__.getElsePart() != null) {
                     // The `else` part needs to be kept
                     Statement s = if__.getElsePart().getBody().withPrefix(if__.getPrefix());
-                    if (jumps(s)) {
-                        doAfterVisit(new RemoveUnreachableCodeVisitor());
-                    }
+                    doAfterVisit(new RemoveUnreachableCodeVisitor());
                     return maybeAutoFormat(
                             if__,
                             s,
@@ -151,37 +145,6 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
                  */
                 return J.Block.createEmptyBlock();
             }
-        }
-
-        private boolean jumps(Statement statement) {
-            AtomicBoolean visitedCFKeyword = new AtomicBoolean(false);
-            // if there is a return, break, continue, throws in _then, then set visitedKeyword to true
-            new JavaIsoVisitor<AtomicBoolean>() {
-                @Override
-                public J.Return visitReturn(J.Return _return, AtomicBoolean atomicBoolean) {
-                    atomicBoolean.set(true);
-                    return _return;
-                }
-
-                @Override
-                public J.Continue visitContinue(J.Continue continueStatement, AtomicBoolean atomicBoolean) {
-                    atomicBoolean.set(true);
-                    return continueStatement;
-                }
-
-                @Override
-                public J.Break visitBreak(J.Break breakStatement, AtomicBoolean atomicBoolean) {
-                    atomicBoolean.set(true);
-                    return breakStatement;
-                }
-
-                @Override
-                public J.Throw visitThrow(J.Throw thrown, AtomicBoolean atomicBoolean) {
-                    atomicBoolean.set(true);
-                    return thrown;
-                }
-            }.visit(statement, visitedCFKeyword);
-            return visitedCFKeyword.get();
         }
 
         private static boolean isLiteralTrue(@Nullable Expression expression) {

--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecution.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecution.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.SourceFile;
@@ -32,6 +30,9 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Statement;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SimplifyConstantIfBranchExecution extends Recipe {
 

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -1089,6 +1089,41 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
     }
 
     @Test
+    void removesNestedWithReturn() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before outer if");
+                      if (true) {
+                          System.out.println("outer then");
+                          if (true) {
+                              System.out.println("inner then");
+                              return;
+                          }
+                          System.out.println("after inner if");
+                      }
+                      System.out.println("after outer if");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before outer if");
+                      System.out.println("outer then");
+                      System.out.println("inner then");
+                      return;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void binaryOrIsAlwaysFalse() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -694,6 +694,35 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
     }
 
     @Test
+    void removesWhenReturnInElseBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void test() {
+                      if (false) {
+                          System.out.println("true");
+                      } else {
+                          System.out.println("false");
+                          return;
+                      }
+                      System.out.println("goodbye");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("false");
+                      return;
+                  }
+              }"""
+          )
+        );
+    }
+
+    @Test
     void removesWhenThrowsInIfBlock() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -15,13 +15,13 @@
  */
 package org.openrewrite.staticanalysis;
 
-import static org.openrewrite.java.Assertions.java;
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings({"ConstantConditions", "FunctionName", "PointlessBooleanExpression", "StatementWithEmptyBody", "LoopStatementThatDoesntLoop", "InfiniteLoopStatement", "DuplicateCondition"})
 class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
@@ -681,7 +681,7 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                   }
               }
               """,
-                """
+            """
               public class A {
                   public void test() {
                       System.out.println("hello");

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -696,6 +696,32 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
     }
 
     @Test
+    void removesWhenReturnInThenNoBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before");
+                      if (true) return;
+                      System.out.println("after");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before");
+                      return;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removesWhenReturnInThenBlockWithElse() {
         rewriteRun(
           //language=java
@@ -750,6 +776,34 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                   public void test() {
                       System.out.println("before");
                       System.out.println("else");
+                      return;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removesWhenReturnInElseNoBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before");
+                      if (false) {
+                          System.out.println("then");
+                      } else return;
+                      System.out.println("after");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before");
                       return;
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -746,7 +746,6 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                       while (true) {
                           System.out.println("hello");
                           break;
-                          System.out.println("goodbye");
                       }
                       System.out.println("goodbye");
                   }
@@ -781,7 +780,6 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                       while (true) {
                           System.out.println("hello");
                           continue;
-                          System.out.println("goodbye");
                       }
                       System.out.println("goodbye");
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -15,13 +15,13 @@
  */
 package org.openrewrite.staticanalysis;
 
+import static org.openrewrite.java.Assertions.java;
+
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-
-import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings({"ConstantConditions", "FunctionName", "PointlessBooleanExpression", "StatementWithEmptyBody", "LoopStatementThatDoesntLoop", "InfiniteLoopStatement", "DuplicateCondition"})
 class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
@@ -666,7 +666,7 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
     }
 
     @Test
-    void doesNotRemoveWhenReturnInIfBlock() {
+    void removesWhenReturnInIfBlock() {
         rewriteRun(
           //language=java
           java(
@@ -680,13 +680,21 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                       System.out.println("goodbye");
                   }
               }
+              """,
+                """
+              public class A {
+                  public void test() {
+                      System.out.println("hello");
+                      return;
+                  }
+              }
               """
           )
         );
     }
 
     @Test
-    void doesNotRemoveWhenThrowsInIfBlock() {
+    void removesWhenThrowsInIfBlock() {
         rewriteRun(
           //language=java
           java(
@@ -700,24 +708,44 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                       System.out.println("goodbye");
                   }
               }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("hello");
+                      throw new RuntimeException();
+                  }
+              }
               """
           )
         );
     }
 
     @Test
-    void doesNotRemoveWhenBreakInIfBlockWithinWhile() {
+    void removesWhenBreakInIfBlockWithinWhile() {
         rewriteRun(
           //language=java
           java(
             """
               public class A {
                   public void test() {
-                      while (true){
+                      while (true) {
                           if (true) {
                               System.out.println("hello");
                               break;
                           }
+                          System.out.println("goodbye");
+                      }
+                      System.out.println("goodbye");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      while (true) {
+                          System.out.println("hello");
+                          break;
                           System.out.println("goodbye");
                       }
                       System.out.println("goodbye");
@@ -729,7 +757,7 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
     }
 
     @Test
-    void doesNotRemoveWhenContinueInIfBlockWithinWhile() {
+    void removesWhenContinueInIfBlockWithinWhile() {
         rewriteRun(
           //language=java
           java(
@@ -741,6 +769,18 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                               System.out.println("hello");
                               continue;
                           }
+                          System.out.println("goodbye");
+                      }
+                      System.out.println("goodbye");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      while (true) {
+                          System.out.println("hello");
+                          continue;
                           System.out.println("goodbye");
                       }
                       System.out.println("goodbye");

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -1178,6 +1178,54 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
     }
 
     @Test
+    void simplifyNestedWithReturnAndThrowInTryCatch() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before outer if");
+                      if (true) {
+                          System.out.println("outer then");
+                          if (true) {
+                              try {
+                                  if(true) {
+                                      throw new RuntimeException("Explosion");
+                                  }
+                                  return;
+                              } catch (Exception ex) {
+                                  System.out.println("catch");
+                              }
+                          }
+                          System.out.println("after inner if");
+                      }
+                      System.out.println("after outer if");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void test() {
+                      System.out.println("before outer if");
+                      System.out.println("outer then");
+                      try {
+                          throw new RuntimeException("Explosion");
+                      } catch (Exception ex) {
+                          System.out.println("catch");
+                      }
+                      System.out.println("after inner if");
+                      System.out.println("after outer if");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+
+
+    @Test
     void binaryOrIsAlwaysFalse() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

This PR improves the `SimplifyConstantIfBranchExecution` recipe to simplify `if`s even if they have jumps (`return`, `throw`, `break`, or `continue`) in the branch we keep. The recipe will now also remove any unreachable code introduced by simplifying these `if`s.

I added numerous unit tests to demonstrate the new behavior.

## What's your motivation?

Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/192

## Have you considered any alternatives or workarounds?

I considered implementing the unreachable code elimination as another recipe. However, it feels like it's tightly coupled to the `if` simplification itself; unreachable code is a compile-time error, so if this recipe is going to simplify these `if`s, I think it should do so cleanly.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
