### PR TITLE
rename when same id but in different scopes

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCase.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCase.java
@@ -77,7 +77,8 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
                 if (toName.isEmpty() || !Character.isAlphabetic(toName.charAt(0))) {
                     return false;
                 }
-                return !hasNameKey.contains(toName);
+                Set<String> keys = computeAllKeys(toName, variable);
+                return keys.stream().noneMatch(hasNameKey::contains);
             }
 
             @Override
@@ -94,7 +95,7 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
                     if (!LOWER_CAMEL.matches(name) && name.length() > 1) {
                         renameVariable(v, LOWER_CAMEL.format(name));
                     } else {
-                        hasNameKey(name);
+                        hasNameKey(computeKey(name, v));
                     }
                 }
                 return mv;
@@ -140,7 +141,7 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
 
             @Override
             public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
-                hasNameKey(identifier.getSimpleName());
+                hasNameKey(computeKey(identifier.getSimpleName(), identifier));
                 return identifier;
             }
 

--- a/src/main/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCase.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCase.java
@@ -77,6 +77,7 @@ public class RenamePrivateFieldsToCamelCase extends Recipe {
                 }
                 return hasNameKey.stream().noneMatch(key ->
                         key.equals(toName) ||
+                        key.equals(variable.getSimpleName()) ||
                         key.endsWith(" " + toName) ||
                         key.endsWith(" " + variable.getSimpleName())
                 );

--- a/src/main/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCase.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCase.java
@@ -75,7 +75,11 @@ public class RenamePrivateFieldsToCamelCase extends Recipe {
                 if (toName.isEmpty() || !Character.isAlphabetic(toName.charAt(0))) {
                     return false;
                 }
-                return !hasNameKey.contains(toName) && !hasNameKey.contains(variable.getSimpleName());
+                return hasNameKey.stream().noneMatch(key ->
+                        key.equals(toName) ||
+                        key.endsWith(" " + toName) ||
+                        key.endsWith(" " + variable.getSimpleName())
+                );
             }
 
             @SuppressWarnings("all")
@@ -110,7 +114,7 @@ public class RenamePrivateFieldsToCamelCase extends Recipe {
                     String toName = LOWER_CAMEL.format(variable.getSimpleName());
                     renameVariable(variable, toName);
                 } else {
-                    hasNameKey(variable.getSimpleName());
+                    hasNameKey(computeKey(variable.getSimpleName(), variable));
                 }
 
                 return super.visitVariable(variable, ctx);

--- a/src/main/java/org/openrewrite/staticanalysis/RenameToCamelCase.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenameToCamelCase.java
@@ -75,24 +75,6 @@ public abstract class RenameToCamelCase extends JavaIsoVisitor<ExecutionContext>
         return identifier;
     }
 
-    protected Set<String> computeAllKeys(String identifier, J context) {
-        Set<String> keys = new HashSet<>();
-        keys.add(identifier);
-        JavaType.Variable fieldType = getFieldType(context);
-        if (fieldType != null && fieldType.getOwner() != null) {
-            keys.add(fieldType.getOwner() + " " + identifier);
-            if (fieldType.getOwner() instanceof JavaType.Method) {
-                // Add all enclosing classes
-                JavaType.FullyQualified declaringType = ((JavaType.Method) fieldType.getOwner()).getDeclaringType();
-                while (declaringType != null) {
-                    keys.add(declaringType + " " + identifier);
-                    declaringType = declaringType.getOwningClass();
-                }
-            }
-        }
-        return keys;
-    }
-
     @Nullable
     protected JavaType.Variable getFieldType(J tree) {
         if (tree instanceof J.Identifier) {

--- a/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
@@ -372,4 +372,68 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/171")
+    void renameMultipleOcurrencesDifferentScope() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      String ID;
+                  }
+                  void test2() {
+                      String ID;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      String id;
+                  }
+                  void test2() {
+                      String id;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameIfInParent() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  String id;
+                  void test() {
+                      String ID;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameIfInParentFromInnerClass() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  String id;
+                  class InnerClass {
+                      void test() {
+                          String ID;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Computing the key of the identifier to include the scope it's present. This way we can change multiple occurrences of the same identifier if in different scopes.

## What's your motivation?
Fixes #171 and potentially other related issues to this recipe like https://github.com/moderneinc/support-app/issues/9

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
