### PR TITLE
no diamond when argument to generic method

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
@@ -487,4 +487,34 @@ class UseDiamondOperatorTest implements RewriteTest {
         }
     }
 
+    @Test
+    void doNotChangeInferredGenericTypes() {
+        rewriteRun(
+          spec -> spec.allSources(s -> s.markers(javaVersion(9))),
+          //language=java
+          java("""
+            @FunctionalInterface
+            public interface IVisitor<T, R> {
+                void visit(T object, R ret);
+            }
+            """
+          ),
+          //language=java
+          java("""
+            class Test {
+                public <S, R> R method(IVisitor<S, R> visitor) {
+                    return null;
+                }
+                private void test(Tree t) {
+                    String s = method(new IVisitor<Integer, String>() {
+                        @Override
+                        public void visit(Integer object, String ret) { }
+                    });
+                }
+            }
+            """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
We are trying to detect when we are calling a generic method with type inference, so we do not apply the diamond operator in those scenarios, as we cannot guarantee that the type inference will still work after applying the diamond operator.

## What's your motivation?
Fixes https://github.com/moderneinc/support-app/issues/11
We've found some examples where we are producing invalid code due to applying the diamond operator when calling a generic method, thus breaking the type inference. 

## Anyone you would like to review specifically?
@timtebeek @knutwannheden @jkschneider @kunli2 

## Have you considered any alternatives or workarounds?
I was trying to detect the type inference by trying to find the method in the declaring class, since the methodType I have from the invocation has the types resolves to the inferred ones. But with the TypeUtils.findDeclaredMethod I could not find it, because it's trying to match the arguments, and because the declared method has generics, but the method invocation don't, it was not matching. I took advantage of this by returning without changes when I cannot find the method, but a better approach might be to find the method "ignoring" generics, and only return without changes if the affected parameter (the one where we want to apply the diamond operator) has generics, not any of them.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
