### PR TITLE
RemoveEmptyJavaDocParameters: added tests + fixed bugs

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParameters.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParameters.java
@@ -78,19 +78,16 @@ public class RemoveEmptyJavaDocParameters extends Recipe {
                     List<Javadoc> newBody = new ArrayList<>(javadoc.getBody().size());
                     boolean useNewBody = false;
 
-                    List<Javadoc> body = javadoc.getBody();
-                    // To fix elements on the first line without space
-                    if (!body.isEmpty() && !(body.get(0) instanceof Javadoc.LineBreak)) {
-                        body = new ArrayList<>(body);
-                        body.add(0, null); // we can use null since this element is never going to be used.
-                    }
+                    List<Javadoc> body = new ArrayList<>(javadoc.getBody());
+                    // We add a trailing element, to fix elements on the first line without space
+                    // We can use null since this element is never going to be read, and nulls get filtered later on.
+                    body.add(0, null);
 
                     for (int i = 0; i < body.size(); i++) {
                         // JavaDocs require a look ahead, because the current element may be an element that exists on the same line as a parameter.
                         // I.E. the space that precedes `* @param` will be a `Javadoc.Text` and needs to be removed along with the empty `@param`.
                         // A `Javadoc` will always precede a parameter even if there is empty space like `*@param`.
                         Javadoc currentDoc = body.get(i);
-                        boolean skipCurrentDoc = false;
                         if (i + 1 < body.size()) {
                             Javadoc nextDoc = body.get(i + 1);
                             if (nextDoc instanceof Javadoc.Parameter) {
@@ -112,7 +109,7 @@ public class RemoveEmptyJavaDocParameters extends Recipe {
                                     i += 1;
 
                                     useNewBody = true;
-                                    skipCurrentDoc = true;
+                                    currentDoc = null;
                                 }
                             } else if (nextDoc instanceof Javadoc.Return) {
                                 Javadoc.Return nextReturn = (Javadoc.Return) nextDoc;
@@ -133,7 +130,7 @@ public class RemoveEmptyJavaDocParameters extends Recipe {
                                     i += 1;
 
                                     useNewBody = true;
-                                    skipCurrentDoc = true;
+                                    currentDoc = null;
                                 }
                             } else if (nextDoc instanceof Javadoc.Erroneous) {
                                 Javadoc.Erroneous nextErroneous = (Javadoc.Erroneous) nextDoc;
@@ -146,12 +143,12 @@ public class RemoveEmptyJavaDocParameters extends Recipe {
                                     i += 1;
 
                                     useNewBody = true;
-                                    skipCurrentDoc = true;
+                                    currentDoc = null;
                                 }
                             }
                         }
 
-                        if (!skipCurrentDoc) {
+                        if (currentDoc != null) {
                             newBody.add(currentDoc);
                         }
                     }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
@@ -550,6 +550,59 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
         }
     }
 
+    @Nested
+    class EmptyJavaDoc {
+        @Test
+        void emptyJavaDoc() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**
+                       */
+                      void method(int arg0) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void emptyJavaDocSingleLine() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /** */
+                      void method(int arg0) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void emptyJavaDocSingleLineNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /***/
+                      void method(int arg0) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3078")
     void visitingQuarkMustNotFail() {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
@@ -16,6 +16,7 @@
 
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -35,49 +36,14 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void singleLineParam() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  /**@param arg0*/
-                  void method(int arg0) {
-                  }
-              }
-              """,
-            """
-              class Test {
-                  /***/
-                  void method(int arg0) {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite/issues/3078")
-    void visitingQuarkMustNotFail() {
-        rewriteRun(
-          other(
-            """
-              foo
-              """
-          )
-        );
-    }
-
-    @Test
-    void removeParamWithNoPrefix() {
+    void emptyParam() {
         rewriteRun(
           //language=java
           java(
             """
               class Test {
                   /**
-                   *@param arg0
+                   * @param arg0
                    */
                   void method(int arg0) {
                   }
@@ -88,6 +54,58 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
                   /**
                    */
                   void method(int arg0) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyReturn() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  /**
+                   * @return
+                   */
+                  int method() {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  /**
+                   */
+                  int method() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyThrows() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  /**
+                   * @throws
+                   */
+                  void method() throws IllegalStateException {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  /**
+                   */
+                  void method() throws IllegalStateException {
                   }
               }
               """
@@ -156,76 +174,389 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
         );
     }
 
-    @Test
-    void emptyReturn() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  /**
-                   * @return
-                   */
-                  int method() {
+    @Nested
+    class NoSpace {
+        @Test
+        void emptyParamNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**
+                       *@param arg0
+                       */
+                      void method(int arg0) {
+                      }
                   }
-              }
-              """,
-            """
-              class Test {
-                  /**
-                   */
-                  int method() {
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      void method(int arg0) {
+                      }
                   }
-              }
-              """
-          )
-        );
+                  """
+              )
+            );
+        }
+
+        @Test
+        void emptyReturnNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**
+                       *@return
+                       */
+                      int method() {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      int method() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void emptyThrowsNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**
+                       *@throws
+                       */
+                      void method() throws IllegalStateException {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      void method() throws IllegalStateException {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+    }
+
+    @Nested
+    class SingleLine {
+        @Test
+        void singleLineParam() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /** @param arg0*/
+                      void method(int arg0) {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /***/
+                      void method(int arg0) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void singleLineReturn() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /** @return*/
+                      int method() {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /***/
+                      int method() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void singleLineThrows() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /** @throws*/
+                      void method() throws IllegalStateException {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /***/
+                      void method() throws IllegalStateException {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void singleLineParamNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**@param arg0*/
+                      void method(int arg0) {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /***/
+                      void method(int arg0) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void singleLineReturnNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**@return*/
+                      int method() {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /***/
+                      int method() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void singleLineThrowsNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**@throws*/
+                      void method() throws IllegalStateException {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /***/
+                      void method() throws IllegalStateException {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
+    class FirstLine {
+        @Test
+        void firstLineParam() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /** @param arg0
+                       */
+                      void method(int arg0) {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      void method(int arg0) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void firstLineReturn() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /** @return
+                       */
+                      int method() {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      int method() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void firstLineThrows() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /** @throws
+                       */
+                      int method() throws IllegalStateException {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      int method() throws IllegalStateException {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void firstLineParamNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**@param arg0
+                       */
+                      void method(int arg0) {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      void method(int arg0) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void firstLineReturnNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**@return
+                       */
+                      int method() {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      int method() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void firstLineThrowsNoSpace() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  class Test {
+                      /**@throws
+                       */
+                      int method() throws IllegalStateException {
+                      }
+                  }
+                  """,
+                """
+                  class Test {
+                      /**
+                       */
+                      int method() throws IllegalStateException {
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 
     @Test
-    void emptyThrows() {
+    @Issue("https://github.com/openrewrite/rewrite/issues/3078")
+    void visitingQuarkMustNotFail() {
         rewriteRun(
-          //language=java
-          java(
+          other(
             """
-              class Test {
-                  /**
-                   * @throws
-                   */
-                  void method() throws IllegalStateException {
-                  }
-              }
-              """,
-            """
-              class Test {
-                  /**
-                   */
-                  void method() throws IllegalStateException {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void emptyThrowsOnFirstLine() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class Test {
-                  /** @throws*/
-                  void method() throws IllegalStateException {
-                  }
-              }
-              """,
-            """
-              class Test {
-                  /***/
-                  void method() throws IllegalStateException {
-                  }
-              }
+              foo
               """
           )
         );


### PR DESCRIPTION
## What's changed?
There was a lot of missing scenarios on the tests that were causing bugs (wrong format of last lines, first lines, even index out of bounds on some very rare scenarios).
Added all the missing combinations of [param, return, throws], [regular, singleLine, firstLine], [withSpace, noSpace].
Fixed the bugs not originally covered with the new tests.

## What's your motivation?
Fixes https://github.com/moderneinc/support-app/issues/14 and hopefully all other bugs in this recipe.

## Anyone you would like to review specifically?
@timtebeek @knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
