### PR TITLE
rename final variables too

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCase.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCase.java
@@ -109,11 +109,6 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
                     return false;
                 }
 
-                // Skip constant variable
-                if (mv.hasModifier(J.Modifier.Type.Final)) {
-                    return false;
-                }
-
                 // Ignore fields (aka "instance variable" or "class variable")
                 for (J.VariableDeclarations.NamedVariable v : mv.getVariables()) {
                     if (v.isField(getCursor())) {

--- a/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
@@ -436,4 +436,26 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
+    @Test
+    void renameFinalLocalVariables() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      final String FINAL_VARIABLE;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      final String finalVariable;
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?
Removed the exception on `final` modifier.

## What's your motivation?
According to https://rules.sonarsource.com/java/RSPEC-117/ there is no such exception on `final` modifier. Maybe this comes from the C variant https://rules.sonarsource.com/c/RSPEC-117/ where it mentions that `const` vars are excluded.
Fixes https://github.com/moderneinc/support-app/issues/9

## Anyone you would like to review specifically?
@pstreef @timtebeek @kunli2 @traceyyoshima 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
