### PR TITLE
RenameLocalVariablesToCamelCase: Do not rename method argument names.

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCase.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCase.java
@@ -55,7 +55,7 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
         return "Reformat local variable and method parameter names to camelCase to comply with Java naming convention. " +
                 "The recipe will not rename variables declared in for loop controls or catches with a single character. " +
                 "The first character is set to lower case and existing capital letters are preserved. " +
-                "Special characters that are allowed in java field names `$` and `_` are removed. " +
+                "Special characters that are allowed in java field names `$` and `_` are removed (unless the name starts with one). " +
                 "If a special character is removed the next valid alphanumeric will be capitalized. " +
                 "Currently, does not support renaming members of classes. " +
                 "The recipe will not rename a variable if the result already exists in the class, conflicts with a java reserved keyword, or the result is blank.";
@@ -105,7 +105,7 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
 
             private boolean isLocalVariable(J.VariableDeclarations mv) {
                 // The recipe will not rename variables declared in for loop controls or catches.
-                if (!isInMethodDeclarationBody() || isDeclaredInForLoopControl() || isDeclaredInCatch()) {
+                if (!isInMethodDeclarationBody() || isDeclaredInForLoopControl() || isDeclaredInCatch() || isMethodArgument()) {
                     return false;
                 }
 
@@ -117,6 +117,11 @@ public class RenameLocalVariablesToCamelCase extends Recipe {
                 }
 
                 return true;
+            }
+
+            private boolean isMethodArgument() {
+                return getCursor().getParentTreeCursor()
+                        .getValue() instanceof J.MethodDeclaration;
             }
 
             private boolean isInMethodDeclarationBody() {

--- a/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
@@ -462,20 +462,19 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/205")
     @Test
-    void doNotRenameMethodArguments(){
+    void doNotRenameMethodArguments() {
         //language=java
         rewriteRun(
           java(
             """
-             @Controller
-             class MyController {
-                 @GetMapping
-                 String getHello(@RequestParam String your_name) {
-                     return "hello " + your_name;
-                 }
-             }
-             """
+              class MyController {
+                  String getHello(String your_name) {
+                      return "hello " + your_name;
+                  }
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
@@ -15,7 +15,9 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.Recipe;
@@ -89,11 +91,11 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
               class Test {
                   int DoNoTChange;
 
-                  public int addTen(int rename_one) {
+                  public int addTen(int dont_rename_one) {
                       double RenameTwo = 2.0;
                       float __rename__three__ = 2.0;
                       long _Rename__Four = 2.0;
-                      return rename_one + RenameTwo + __rename__three__ + _Rename__Four + 10;
+                      return dont_rename_one + RenameTwo + __rename__three__ + _Rename__Four + 10;
                   }
               }
               """,
@@ -101,11 +103,11 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
               class Test {
                   int DoNoTChange;
 
-                  public int addTen(int renameOne) {
+                  public int addTen(int dont_rename_one) {
                       double renameTwo = 2.0;
                       float renameThree = 2.0;
                       long renameFour = 2.0;
-                      return renameOne + renameTwo + renameThree + renameFour + 10;
+                      return dont_rename_one + renameTwo + renameThree + renameFour + 10;
                   }
               }
               """
@@ -114,6 +116,7 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
     }
 
     @SuppressWarnings("JavadocDeclaration")
+    @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/2437")
     @Test
     void renameJavaDocParam() {
@@ -438,6 +441,7 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
 
     @Test
     void renameFinalLocalVariables() {
+        //language=java
         rewriteRun(
           java(
             """
@@ -454,6 +458,24 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void doNotRenameMethodArguments(){
+        //language=java
+        rewriteRun(
+          java(
+            """
+             @Controller
+             class MyController {
+                 @GetMapping
+                 String getHello(@RequestParam String your_name) {
+                     return "hello " + your_name;
+                 }
+             }
+             """
           )
         );
     }


### PR DESCRIPTION
Many frameworks depend on method argument names to use for request parameter names or json field names. By renaming these without knowing how the frameworks use these we can make breaking changes. It's better to do no change.

## What's changed?
Non camel case names are kept in method argument names.

## What's your motivation?
Do no harm

## Anything in particular you'd like reviewers to focus on?
`isMethodArgument()`

## Anyone you would like to review specifically?
@joanvr @timtebeek 

## Have you considered any alternatives or workarounds?
no

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files (No because it adds much extra indentation to the test file. I think that's not wanted?)
