### PR TITLE
Cast when needed on lambda expressions

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.openrewrite.staticanalysis.LambdaBlockToExpression.hasMethodOverloading;
-import static org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface.getSamCompatible;
 
 @Incubating(since = "7.23.0")
 public class RemoveRedundantTypeCast extends Recipe {
@@ -104,7 +103,7 @@ public class RemoveRedundantTypeCast extends Recipe {
 
                 if (targetType == null ||
                     targetType instanceof JavaType.Primitive && castType != expressionType ||
-                    getSamCompatible(targetType) == null) {
+                    typeCast.getExpression() instanceof J.Lambda && castType instanceof JavaType.Parameterized) {
                     // Not currently supported, this will be more accurate with dataflow analysis.
                     return visitedTypeCast;
                 } else if (!(targetType instanceof JavaType.Array) && TypeUtils.isOfClassType(targetType, "java.lang.Object") ||

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.openrewrite.staticanalysis.LambdaBlockToExpression.hasMethodOverloading;
+import static org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface.getSamCompatible;
 
 @Incubating(since = "7.23.0")
 public class RemoveRedundantTypeCast extends Recipe {
@@ -101,7 +102,9 @@ public class RemoveRedundantTypeCast extends Recipe {
                 JavaType expressionType = visitedTypeCast.getExpression().getType();
                 JavaType castType = visitedTypeCast.getType();
 
-                if (targetType == null || targetType instanceof JavaType.Primitive && castType != expressionType) {
+                if (targetType == null ||
+                    targetType instanceof JavaType.Primitive && castType != expressionType ||
+                    getSamCompatible(targetType) == null) {
                     // Not currently supported, this will be more accurate with dataflow analysis.
                     return visitedTypeCast;
                 } else if (!(targetType instanceof JavaType.Array) && TypeUtils.isOfClassType(targetType, "java.lang.Object") ||

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -161,6 +161,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         Expression argument = arguments.get(i);
                         if (argument == original && methodArgumentRequiresCast(lambda, method, i) &&
                             original.getClazz() != null) {
+                            doAfterVisit(new RemoveRedundantTypeCast().getVisitor());
                             return new J.TypeCast(
                                     Tree.randomId(),
                                     lambda.getPrefix(),

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -426,7 +426,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
 
     // TODO consider moving to TypeUtils
     @Nullable
-    static JavaType.Method getSamCompatible(JavaType type) {
+    private static JavaType.Method getSamCompatible(@Nullable JavaType type) {
         JavaType.Method sam = null;
         JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(type);
         if (fullyQualified == null) {

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -132,25 +132,6 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 return n;
             }
 
-            @Nullable
-            private JavaType.Method getSamCompatible(JavaType type) {
-                JavaType.Method sam = null;
-                JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(type);
-                if (fullyQualified == null) {
-                    return null;
-                }
-                for (JavaType.Method method : fullyQualified.getMethods()) {
-                    if (method.hasFlags(Flag.Default) || method.hasFlags(Flag.Static)) {
-                        continue;
-                    }
-                    if (sam != null) {
-                        return null;
-                    }
-                    sam = method;
-                }
-                return sam;
-            }
-
             private J maybeAddCast(J.Lambda lambda, J.NewClass original) {
                 J parent = getCursor().getParentTreeCursor().getValue();
 
@@ -441,5 +422,25 @@ public class UseLambdaForFunctionalInterface extends Recipe {
             }
         }.visit(lambda.getBody(), atomicBoolean);
         return atomicBoolean.get();
+    }
+
+    // TODO consider moving to TypeUtils
+    @Nullable
+    static JavaType.Method getSamCompatible(JavaType type) {
+        JavaType.Method sam = null;
+        JavaType.FullyQualified fullyQualified = TypeUtils.asFullyQualified(type);
+        if (fullyQualified == null) {
+            return null;
+        }
+        for (JavaType.Method method : fullyQualified.getMethods()) {
+            if (method.hasFlags(Flag.Default) || method.hasFlags(Flag.Static)) {
+                continue;
+            }
+            if (sam != null) {
+                return null;
+            }
+            sam = method;
+        }
+        return sam;
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -142,7 +142,6 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         Expression argument = arguments.get(i);
                         if (argument == original && methodArgumentRequiresCast(lambda, method, i) &&
                             original.getClazz() != null) {
-                            doAfterVisit(new RemoveRedundantTypeCast().getVisitor());
                             return new J.TypeCast(
                                     Tree.randomId(),
                                     lambda.getPrefix(),

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -392,8 +392,7 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
 
 
     @Test
-    @Issue("https://github.com/moderneinc/support-app/issues/17")
-    void test() {
+    void lambdaWithComplexTypeInference() {
         rewriteRun(
           java(
             """
@@ -408,29 +407,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
                               (Supplier<Map<String, Integer>>) () -> {
                                   Map<String, Integer> choices = Map.of("id1", 2);
                                   return choices.entrySet().stream()
-                                          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                              });
-                  }
-              }
-              
-              class MapDropdownChoice<K, V> {
-                  public MapDropdownChoice(Supplier<? extends Map<K, ? extends V>> choiceMap) {
-                  }
-              }
-              """,
-            """
-              import java.util.LinkedHashMap;
-              import java.util.Map;
-              import java.util.function.Supplier;
-              import java.util.stream.Collectors;
-              
-              class Test {
-                  void method() {
-                      Object o2 = new MapDropdownChoice<String, Integer>(
-                              () -> {
-                                  Map<String, Integer> choices = Map.of("id1", 2);
-                                  return choices.entrySet().stream()
-                                          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                                          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                                                  (e1, e2) -> e1, LinkedHashMap::new));
                               });
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -154,6 +154,24 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Test
+    void nonSamParameter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+              
+              class Test {
+                  public boolean foo() {
+                      return Objects.equals("x", (Comparable<String>) (s) -> 1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     @Test
     void redundantTypeCast() {

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -667,7 +667,7 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/moderneinc/support-app/issues/17")
-    void test() {
+    void lambdaWithComplexTypeInference() {
         rewriteRun(
           java(
             """
@@ -719,7 +719,7 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
                                           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
                               });
                       Object o2 = new MapDropdownChoice<String, Integer>(
-                              () -> {
+                              (Supplier<Map<String, Integer>>) () -> {
                                   Map<String, Integer> choices = Map.of("id1", 2);
                                   return choices.entrySet().stream()
                                           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -669,80 +669,66 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
     @Issue("https://github.com/moderneinc/support-app/issues/17")
     void test() {
         rewriteRun(
-          //language=java
           java(
             """
-              interface IModel<T> {
-                  T getObject();
-              }
-              """
-          ),
-          //language=java
-          java(
-            """
-              import java.util.Map;
-              
-              class MapDropdownChoice<K, V>{
-                  public MapDropdownChoice(String id, IModel<? extends Map<K, ? extends V>> choiceMap) {
-                  }
-              }
-                """
-          ),
-          //language=java
-          java(
-            """
-              class Choice {}
-              """
-          ),
-          //language=java
-          java(
-            """
-              import java.util.Map;
-              import java.util.stream.Collectors;
               import java.util.LinkedHashMap;
+              import java.util.Map;
+              import java.util.function.Supplier;
+              import java.util.stream.Collectors;
               
               class Test {
                   void method() {
-                      Object o = new MapDropdownChoice<String, Choice>("id",
-                            new IModel<Map<String, Choice>>() {
+                      Object o = new MapDropdownChoice<String, Integer>(
+                            new Supplier<Map<String, Integer>>() {
                                 @Override
-                                public Map<String, Choice> getObject() {
-                                    Map<String, Choice> choices = Map.of("id1", new Choice());
+                                public Map<String, Integer> getObject() {
+                                    Map<String, Integer> choices = Map.of("id1", 1);
                                     return choices.entrySet().stream()
                                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
                                 }
                             });
-                      Object o2 = new MapDropdownChoice<String, Choice>("id",
-                            new IModel<Map<String, Choice>>() {
+                      Object o2 = new MapDropdownChoice<String, Integer>(
+                            new Supplier<Map<String, Integer>>() {
                                 @Override
-                                public Map<String, Choice> getObject() {
-                                    Map<String, Choice> choices = Map.of("id1", new Choice());
+                                public Map<String, Integer> getObject() {
+                                    Map<String, Integer> choices = Map.of("id1", 2);
                                     return choices.entrySet().stream()
                                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                                 }
                             });
                   }
               }
+              
+              class MapDropdownChoice<K, V> {
+                  public MapDropdownChoice(Supplier<? extends Map<K, ? extends V>> choiceMap) {
+                  }
+              }
               """,
             """
-              import java.util.Map;
-              import java.util.stream.Collectors;
               import java.util.LinkedHashMap;
+              import java.util.Map;
+              import java.util.function.Supplier;
+              import java.util.stream.Collectors;
               
               class Test {
                   void method() {
-                      Object o = new MapDropdownChoice<String, Choice>("id",
-                              (IModel<Map<String, Choice>>) () -> {
-                                  Map<String, Choice> choices = Map.of("id1", new Choice());
+                      Object o = new MapDropdownChoice<String, Integer>(
+                              (Supplier<Map<String, Integer>>) () -> {
+                                  Map<String, Integer> choices = Map.of("id1", 1);
                                   return choices.entrySet().stream()
                                           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
                               });
-                      Object o2 = new MapDropdownChoice<String, Choice>("id",
+                      Object o2 = new MapDropdownChoice<String, Integer>(
                               () -> {
-                                  Map<String, Choice> choices = Map.of("id1", new Choice());
+                                  Map<String, Integer> choices = Map.of("id1", 2);
                                   return choices.entrySet().stream()
                                           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                               });
+                  }
+              }
+              
+              class MapDropdownChoice<K, V> {
+                  public MapDropdownChoice(Supplier<? extends Map<K, ? extends V>> choiceMap) {
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
We need to cast the lambda expression, when we have some unbounded generics on it's body. Right now I'm trying to identify those by searching for method invocations of methods with arguments with parametrized types with generics, but this just narrows it a bit, but those generics not necessarily are unbounded without the explicit cast. 

Also, changed the `methodArgumentRequiresCast` and previous check to accept MethodCall instead of `J.MethodInvocation`, so we can also reuse it for `J.NewClass` too

## What's your motivation?
Fixes https://github.com/moderneinc/support-app/issues/17

## Anything in particular you'd like reviewers to focus on?
How we can detect better when it's needed to add the cast and when it's redundant?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
