### PR TITLE
`FallThrough` must only add `break` on normal termination

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -270,6 +270,46 @@ class FallThroughTest implements RewriteTest {
     }
 
     @Test
+    void abortOnAbruptCompletion() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void noCase(int i) {
+                      for (;;) {
+                          switch (i) {
+                              case 0:
+                                  if (true)
+                                      return;
+                                  else
+                                      break;
+                              case 1:
+                                  if (true)
+                                      return;
+                                  else {
+                                      {
+                                          continue;
+                                      }
+                                  }
+                              case 1:
+                                  try {
+                                      return;
+                                  } catch (Exception e) {
+                                      break;
+                                  }
+                              default:
+                                  System.out.println("default");
+                          }
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void addBreaksFallthroughCasesComprehensive() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
A `break` must only be added if a case body terminates normally.
