### PR TITLE
Allow `RemoveRedundantTypeCast` to deal with generics

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -17,13 +17,11 @@ package org.openrewrite.staticanalysis;
 
 import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeTree;
-import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.java.tree.*;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 @Incubating(since = "7.23.0")
@@ -52,29 +50,60 @@ public class RemoveRedundantTypeCast extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
             @Override
-            public J visitTypeCast(J.TypeCast typeCast, ExecutionContext executionContext) {
+            public J visitTypeCast(J.TypeCast typeCast, ExecutionContext ctx) {
+                J visited = super.visitTypeCast(typeCast, ctx);
+                if (!(visited instanceof J.TypeCast)) {
+                    return visited;
+                }
+
                 Cursor parent = getCursor().dropParentUntil(is -> is instanceof J.VariableDeclarations ||
-                        is instanceof J.NewClass ||
-                        is instanceof J.Lambda ||
-                        is instanceof J.MethodInvocation ||
-                        is instanceof J.MethodDeclaration ||
-                        is instanceof J.ClassDeclaration);
+                                                                  is instanceof J.Lambda ||
+                                                                  is instanceof J.Return ||
+                                                                  is instanceof MethodCall ||
+                                                                  is instanceof J.MethodDeclaration ||
+                                                                  is instanceof J.ClassDeclaration ||
+                                                                  is instanceof JavaSourceFile);
 
-                // Not currently supported, this will be more accurate with dataflow analysis.
-                if (!(parent.getValue() instanceof J.VariableDeclarations)) {
-                    return typeCast;
+                J parentValue = parent.getValue();
+
+                JavaType targetType = null;
+                if (parentValue instanceof J.VariableDeclarations) {
+                    targetType = ((J.VariableDeclarations) parentValue).getVariables().get(0).getType();
+                } else if (parentValue instanceof MethodCall) {
+                    MethodCall methodCall = (MethodCall) parentValue;
+                    JavaType.Method methodType = methodCall.getMethodType();
+                    if (methodType != null && !methodType.getParameterTypes().isEmpty()) {
+                        List<Expression> arguments = methodCall.getArguments();
+                        for (int i = 0; i < arguments.size(); i++) {
+                            Expression arg = arguments.get(i);
+                            if (arg == typeCast) {
+                                targetType = methodType.getParameterTypes().get(i);
+                                break;
+                            }
+                        }
+                    }
+                } else if (parentValue instanceof J.Return && ((J.Return) parentValue).getExpression() == typeCast) {
+                    parent = parent.dropParentUntil(is -> is instanceof J.Lambda ||
+                                                          is instanceof J.MethodDeclaration ||
+                                                          is instanceof J.ClassDeclaration ||
+                                                          is instanceof JavaSourceFile);
+                    if (parent.getValue() instanceof J.MethodDeclaration && ((J.MethodDeclaration) parent.getValue()).getMethodType() != null) {
+                        targetType = ((J.MethodDeclaration) parent.getValue()).getMethodType().getReturnType();
+                    }
                 }
 
-                TypeTree typeTree = typeCast.getClazz().getTree();
-                JavaType expressionType = typeCast.getExpression().getType();
+                J.TypeCast visitedTypeCast = (J.TypeCast) visited;
+                JavaType expressionType = visitedTypeCast.getExpression().getType();
 
-                JavaType namedVariableType = ((J.VariableDeclarations) parent.getValue()).getVariables().get(0).getType();
-                if (!(namedVariableType instanceof JavaType.Array) && TypeUtils.isOfClassType(namedVariableType, "java.lang.Object") ||
-                        (!(typeTree instanceof J.ParameterizedType) && (TypeUtils.isOfType(namedVariableType, expressionType) || TypeUtils.isAssignableTo(namedVariableType, expressionType)))) {
-                    return typeCast.getExpression();
+                if (targetType == null) {
+                    // Not currently supported, this will be more accurate with dataflow analysis.
+                    return visitedTypeCast;
+                } else if (!(targetType instanceof JavaType.Array) && TypeUtils.isOfClassType(targetType, "java.lang.Object") ||
+                           TypeUtils.isOfType(targetType, expressionType) ||
+                           TypeUtils.isAssignableTo(targetType, expressionType)) {
+                    return visitedTypeCast.getExpression().withPrefix(visitedTypeCast.getPrefix());
                 }
-
-                return super.visitTypeCast(typeCast, executionContext);
+                return visitedTypeCast;
             }
         };
     }


### PR DESCRIPTION
The `RemoveRedundantTypeCast` recipe will now also remove casts when the types involve generics. Further, when the type cast is the expression of a `return` statement, then the target type will be derived from the corresponding method declaration if any (lambdas are not supported here yet).

Note: This implementation relies on openrewrite/rewrite#3655.
