### PR TITLE
Handle annotated types in UseCollectionInterfaces

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -131,21 +131,13 @@ public class UseCollectionInterfaces extends Recipe {
                                         newType,
                                         null
                                 );
+                            } else if (m.getReturnTypeExpression() instanceof J.AnnotatedType) {
+                                J.AnnotatedType annotatedType = (J.AnnotatedType) m.getReturnTypeExpression();
+                                J.ParameterizedType parameterizedType = (J.ParameterizedType) annotatedType.getTypeExpression();
+                                typeExpression = annotatedType.withTypeExpression(removeFromParameterizedType(newType, parameterizedType));
                             } else {
                                 J.ParameterizedType parameterizedType = (J.ParameterizedType) m.getReturnTypeExpression();
-                                J.Identifier returnType = new J.Identifier(
-                                        randomId(),
-                                        Space.EMPTY,
-                                        Markers.EMPTY,
-                                        emptyList(),
-                                        newType.getClassName(),
-                                        newType,
-                                        null);
-                                JavaType.Parameterized javaType = (JavaType.Parameterized) parameterizedType.getType();
-                                typeExpression = parameterizedType.withClazz(returnType)
-                                        .withType(javaType != null ? javaType.withType(newType) :
-                                                new JavaType.Parameterized(null, newType, null)
-                                        );
+                                typeExpression = removeFromParameterizedType(newType, parameterizedType);
                             }
                             m = m.withReturnTypeExpression(typeExpression);
                         }
@@ -183,22 +175,13 @@ public class UseCollectionInterfaces extends Recipe {
                                     newType,
                                     null
                             );
+                        } else if (mv.getTypeExpression() instanceof J.AnnotatedType) {
+                            J.AnnotatedType annotatedType = (J.AnnotatedType) mv.getTypeExpression();
+                            J.ParameterizedType parameterizedType = (J.ParameterizedType) annotatedType.getTypeExpression();
+                            typeExpression = annotatedType.withTypeExpression(removeFromParameterizedType(newType, parameterizedType));
                         } else {
                             J.ParameterizedType parameterizedType = (J.ParameterizedType) mv.getTypeExpression();
-                            J.Identifier returnType = new J.Identifier(
-                                    randomId(),
-                                    Space.EMPTY,
-                                    Markers.EMPTY,
-                                    emptyList(),
-                                    newType.getClassName(),
-                                    newType,
-                                    null
-                            );
-                            JavaType.Parameterized javaType = (JavaType.Parameterized) parameterizedType.getType();
-                            typeExpression = parameterizedType.withClazz(returnType)
-                                    .withType(javaType != null ? javaType.withType(newType) :
-                                            new JavaType.Parameterized(null, newType, null)
-                                    );
+                            typeExpression = removeFromParameterizedType(newType, parameterizedType);
                         }
 
                         mv = mv.withTypeExpression(typeExpression);
@@ -212,6 +195,26 @@ public class UseCollectionInterfaces extends Recipe {
                     }
                 }
                 return mv;
+            }
+
+            private TypeTree removeFromParameterizedType(JavaType.FullyQualified newType,
+                    J.ParameterizedType parameterizedType) {
+                TypeTree typeExpression;
+                J.Identifier returnType = new J.Identifier(
+                        randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        emptyList(),
+                        newType.getClassName(),
+                        newType,
+                        null
+                );
+                JavaType.Parameterized javaType = (JavaType.Parameterized) parameterizedType.getType();
+                typeExpression = parameterizedType.withClazz(returnType)
+                        .withType(javaType != null ? javaType.withType(newType) :
+                                new JavaType.Parameterized(null, newType, null)
+                        );
+                return typeExpression;
             }
         };
     }


### PR DESCRIPTION
Fixes #223.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
The previously existing handling of parameterized types has been extracted to a method and gets reused for the (nested parameterized) type of annotated types. However, I'm not sure if that is the only legal way of how all the different type classes can contain each other. It might therefore be necessary to convert that to a recursive approach, if more complex structures of annotated types, parameterized types and type identifiers are possible.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
