### PR TITLE
Set types based on the java compiler.

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypes.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypes.java
@@ -142,7 +142,7 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
                         Markers.EMPTY,
                         emptyList(),
                         fq.getClassName(),
-                        type,
+                        type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type,
                         null
                 );
 

--- a/src/main/java/org/openrewrite/staticanalysis/ReferentialEqualityToObjectEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReferentialEqualityToObjectEquals.java
@@ -71,7 +71,7 @@ public class ReferentialEqualityToObjectEquals extends Recipe {
                     Markers.EMPTY,
                     new JRightPadded<>(binary.getLeft().withPrefix(Space.EMPTY), Space.EMPTY, Markers.EMPTY),
                     null,
-                    new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "equals", JavaType.Primitive.Boolean, null),
+                    new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "equals", null, null),
                     JContainer.build(singletonList(new JRightPadded<>(binary.getRight().withPrefix(Space.EMPTY), Space.EMPTY, Markers.EMPTY))),
                     new JavaType.Method(
                             null,

--- a/src/main/java/org/openrewrite/staticanalysis/StringLiteralEquality.java
+++ b/src/main/java/org/openrewrite/staticanalysis/StringLiteralEquality.java
@@ -83,7 +83,7 @@ public class StringLiteralEquality extends Recipe {
                         Markers.EMPTY,
                         new JRightPadded<>(binary.getLeft().withPrefix(Space.EMPTY), Space.EMPTY, Markers.EMPTY),
                         null,
-                        new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "equals", JavaType.Primitive.Boolean, null),
+                        new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "equals", null, null),
                         JContainer.build(singletonList(new JRightPadded<>(binary.getRight().withPrefix(Space.EMPTY), Space.EMPTY, Markers.EMPTY))),
                         new JavaType.Method(
                                 null,

--- a/src/test/java/org/openrewrite/staticanalysis/ReferentialEqualityToObjectEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReferentialEqualityToObjectEqualsTest.java
@@ -188,4 +188,39 @@ class ReferentialEqualityToObjectEqualsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void notEquals() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  void doSomething() {
+                      A a1 = new A();
+                      A a2 = new A();
+                      if (a1 != a2) {}
+                  }
+                  class A {
+                      @Override
+                      public boolean equals(Object anObject) {return true;}
+                  }
+              }
+              """,
+            """
+              class T {
+                  void doSomething() {
+                      A a1 = new A();
+                      A a2 = new A();
+                      if (!a1.equals(a2)) {}
+                  }
+                  class A {
+                      @Override
+                      public boolean equals(Object anObject) {return true;}
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
These are various quick fixes identified by https://github.com/openrewrite/rewrite/pull/3743.
The changes set the JavaTypes to the same types the compiler creates for the same code.

Changes:

- The JavaType will be set correctly after changes in ExplicitLambdaArgumentTypes, ReferentialEqualityToObjectEquals, and StringLiteralEquality.
