### PR TITLE
ReplaceLambdaWithMethodReference skip parameterized method return types

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -170,6 +170,9 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                 if (methodType != null && !isMethodReferenceAmbiguous(methodType)) {
                     if (methodType.hasFlags(Flag.Static) ||
                         methodSelectMatchesFirstLambdaParameter(method, lambda)) {
+                        if (method.getType() instanceof JavaType.Parameterized) {
+                            return l;
+                        }
                         J.MemberReference updated = newStaticMethodReference(methodType, true, lambda.getType()).withPrefix(lambda.getPrefix());
                         doAfterVisit(service(ImportService.class).shortenFullyQualifiedTypeReferencesIn(updated));
                         return updated;

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -170,7 +170,9 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                 if (methodType != null && !isMethodReferenceAmbiguous(methodType)) {
                     if (methodType.hasFlags(Flag.Static) ||
                         methodSelectMatchesFirstLambdaParameter(method, lambda)) {
-                        if (method.getType() instanceof JavaType.Parameterized) {
+                        if (method.getType() instanceof JavaType.Parameterized &&
+                            ((JavaType.Parameterized) method.getType()).getTypeParameters().stream()
+                                    .anyMatch(JavaType.GenericTypeVariable.class::isInstance)) {
                             return l;
                         }
                         J.MemberReference updated = newStaticMethodReference(methodType, true, lambda.getType()).withPrefix(lambda.getPrefix());

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -1318,4 +1318,31 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/237")
+    void groupingByGetClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            import java.util.*;
+            import java.util.stream.*;
+            
+            class Animal {}
+            class Cat extends Animal {}
+            class Dog extends Animal {}
+
+            class Test {
+              public void groupOnGetClass() {
+                List<Animal> animals = List.of(new Cat(), new Dog());
+                Map<Class<? extends Animal>, List<Animal>> collect;
+                collect = animals.stream().collect(Collectors.groupingBy(a -> a.getClass()));
+              }
+            }
+            """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/237
