### PR TITLE
feature(LambdaBlockToExpression): convert lambda with method invocation as well

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
@@ -47,20 +47,20 @@ public class LambdaBlockToExpression extends Recipe {
                         if (lambda.getBody() instanceof J.Block) {
                             List<Statement> statements = ((J.Block) lambda.getBody()).getStatements();
                             if (statements.size() == 1) {
-                                Space prefix = statements.get(0).getPrefix();
-                                if(statements.get(0) instanceof J.Return) {
-                                    Expression expression = ((J.Return) statements.get(0)).getExpression();
+                                Statement statement = statements.get(0);
+                                Space prefix = statement.getPrefix();
+                                if (statement instanceof J.Return) {
+                                    Expression expression = ((J.Return) statement).getExpression();
                                     if (prefix.getComments().isEmpty()) {
                                         return l.withBody(expression);
                                     } else {
                                         return l.withBody(expression.withPrefix(prefix));
                                     }
-                                } else if (statements.get(0) instanceof J.MethodInvocation) {
-                                    J.MethodInvocation invocation = (J.MethodInvocation) statements.get(0);
+                                } else if (statement instanceof J.MethodInvocation) {
                                     if (prefix.getComments().isEmpty()) {
-                                        return l.withBody(invocation);
+                                        return l.withBody(statement);
                                     } else {
-                                        return l.withBody(invocation.withPrefix(prefix));
+                                        return l.withBody(statement.withPrefix(prefix));
                                     }
                                 }
                             }

--- a/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
@@ -58,7 +58,7 @@ public class LambdaBlockToExpression extends Recipe {
                                 } else if (statements.get(0) instanceof J.MethodInvocation) {
                                     J.MethodInvocation invocation = (J.MethodInvocation) statements.get(0);
                                     if (prefix.getComments().isEmpty()) {
-                                        return l.withBody(invocation.withPrefix(invocation.getPrefix().withWhitespace(" ")));
+                                        return l.withBody(invocation);
                                     } else {
                                         return l.withBody(invocation.withPrefix(prefix));
                                     }

--- a/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
@@ -46,12 +46,22 @@ public class LambdaBlockToExpression extends Recipe {
                         J.Lambda l = super.visitLambda(lambda, ctx);
                         if (lambda.getBody() instanceof J.Block) {
                             List<Statement> statements = ((J.Block) lambda.getBody()).getStatements();
-                            if (statements.size() == 1 && statements.get(0) instanceof J.Return) {
+                            if (statements.size() == 1) {
                                 Space prefix = statements.get(0).getPrefix();
-                                if (prefix.getComments().isEmpty()) {
-                                    return l.withBody(((J.Return) statements.get(0)).getExpression());
-                                } else {
-                                    return l.withBody(((J.Return) statements.get(0)).getExpression().withPrefix(prefix));
+                                if(statements.get(0) instanceof J.Return) {
+                                    Expression expression = ((J.Return) statements.get(0)).getExpression();
+                                    if (prefix.getComments().isEmpty()) {
+                                        return l.withBody(expression);
+                                    } else {
+                                        return l.withBody(expression.withPrefix(prefix));
+                                    }
+                                } else if (statements.get(0) instanceof J.MethodInvocation) {
+                                    J.MethodInvocation invocation = (J.MethodInvocation) statements.get(0);
+                                    if (prefix.getComments().isEmpty()) {
+                                        return l.withBody(invocation.withPrefix(invocation.getPrefix().withWhitespace(" ")));
+                                    } else {
+                                        return l.withBody(invocation.withPrefix(prefix));
+                                    }
                                 }
                             }
                         }

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -22,9 +22,6 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.math.BigDecimal;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openrewrite.java.Assertions.java;
 
 class LambdaBlockToExpressionTest implements RewriteTest {
@@ -138,7 +135,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
               public class Main {
               
                 public void run() {
-                  Runnable runHelloWorld = () -> System.out.println("Hello world!");
+                  Runnable runHelloWorld = () ->
+                      System.out.println("Hello world!");
                   runHelloWorld.run();
                 }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -117,69 +117,6 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
-    //no idea what the problem is, are external libraries not possible in tests?
-    //test output:
-    //java.lang.IllegalStateException: LST contains missing or invalid type information
-    //Identifier->Annotation->MethodDeclaration->Block->ClassDeclaration->CompilationUnit
-    ///*~~(Identifier type is missing or malformed)~~>*/Test
-    //
-    //MethodInvocation->Block->MethodDeclaration->Block->ClassDeclaration->CompilationUnit
-    ///*~~(MethodInvocation type is missing or malformed)~~>*/assertThrows(ArithmeticException.class, () -> {
-    //  BigDecimal.ONE.divide(BigDecimal.ZERO);
-    //})
-    //    at org.openrewrite.java.Assertions.assertValidTypes(Assertions.java:87)
-    //    at org.openrewrite.java.Assertions.validateTypes(Assertions.java:57)
-    //    at org.openrewrite.java.Assertions$$Lambda$438/0x00007fbb18152c28.accept(Unknown Source)
-    //    at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:304)
-    //    at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:132)
-    //    at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:127)
-    //    at org.openrewrite.staticanalysis.LambdaBlockToExpressionTest.simplifyLambdaBlockReturningVoidAsWell(LambdaBlockToExpressionTest.java:121)
-    //    at java.base/java.lang.reflect.Method.invoke(Method.java:568)
-    //    at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
-    //    at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
-
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/236")
-    @Test
-    void simplifyLambdaBlockReturningVoidAsWell() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-              
-              import java.math.BigDecimal;
-              import org.junit.jupiter.api.Test;
-              
-              public class SimpleTest {
-              
-                @Test
-                void shouldFailOnDivisionByZero() {
-                  assertThrows(ArithmeticException.class, () -> {
-                    BigDecimal.ONE.divide(BigDecimal.ZERO);
-                  });
-                }
-              
-              }
-              """,
-            """
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-              
-              import java.math.BigDecimal;
-              import org.junit.jupiter.api.Test;
-              
-              public class SimpleTest {
-              
-                @Test
-                void shouldFailOnDivisionByZero() {
-                  assertThrows(ArithmeticException.class, () -> BigDecimal.ONE.divide(BigDecimal.ZERO));
-                }
-              
-              }
-              """
-          )
-        );
-    }
-
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/236")
     @Test
     void simplifyLambdaBlockReturningVoidAsWell2() {

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -299,8 +299,9 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
                   void bar(Consumer<Integer> c) {
                   }
                   void foo() {
-                      bar(i -> bar(i2 -> {
-                      }));
+                      bar(i ->
+                              bar(i2 -> {
+                              }));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -299,10 +299,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
                   void bar(Consumer<Integer> c) {
                   }
                   void foo() {
-                      bar(i -> {
-                          bar(i2 -> {
-                          });
-                      });
+                      bar(i -> bar(i2 -> {
+                      }));
                   }
               }
               """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR will enable the transformation of lambdas with method invocation as body.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/236

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
1. The first test case I added doesn't work, see comment in code
2. I had to explicitly set the whitespace in the return statement (LambdaBlockToExpression.java L61) in order to have the code move up to the previous line. Is there a cleaner way to do that?

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
