### PR TITLE
Do not adopt Arrays.toString for varargs arguments

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
@@ -490,4 +490,29 @@ public class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void varargsButTwoArrays() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                String foo(Object[] array1, Object[] array2) {
+                    return String.format("%s %s", array1, array2);
+                }
+              }
+              """,
+            """
+              import java.util.Arrays;
+              
+              class SomeClass {
+                String foo(Object[] array1, Object[] array2) {
+                    return String.format("%s %s", Arrays.toString(array1), Arrays.toString(array2));
+                }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
@@ -27,8 +27,7 @@ import static org.openrewrite.java.Assertions.java;
 public class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec
-          .recipe(new RemoveToStringCallsFromArrayInstances());
+        spec.recipe(new RemoveToStringCallsFromArrayInstances());
     }
 
     @Test
@@ -227,16 +226,6 @@ public class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
                   System.out.println(String.format("s=%s", s));
                 }
               }
-              """,
-            """
-              import java.util.Arrays;
-              
-              class SomeClass {
-                public static void main(String[] args) {
-                  int[] s = new int[]{1, 2, 3};
-                  System.out.println(String.format("s=%s", Arrays.toString(s)));
-                }
-              }
               """
           )
         );
@@ -429,7 +418,7 @@ public class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
     }
 
     @Test
-    void worksWithPrintStreamFormat() {
+    void doesNotRunOnPrintStreamFormat() {
         //language=java
         rewriteRun(
           java(
@@ -442,20 +431,6 @@ public class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
                   String[] arr = new String[]{"test", "array"};
                   
                   ps.format("formatting array: %s", arr);
-                  ps.flush();
-                }
-              }
-              """,
-            """
-              import java.io.PrintStream;
-              import java.util.Arrays;
-              
-              class SomeClass {
-                public static void main(String[] args) {
-                  PrintStream ps = new PrintStream(System.out);
-                  String[] arr = new String[]{"test", "array"};
-                  
-                  ps.format("formatting array: %s", Arrays.toString(arr));
                   ps.flush();
                 }
               }
@@ -500,4 +475,19 @@ public class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void varargs() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class SomeClass {
+                String foo(Object[] strings) {
+                    return String.format("%s %s", strings);
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/230

## What's changed
In this proposal we look at the method parameter type, and if that is also an array we do not produce a change.

## Anything in particular you'd like reviewers to focus on?
Not sure I actually like this change yet; It seems before we were too eager to make changes, even where we changed to logic. The recipe was intended not to show the result of `arr.toString()`, that that wasn't what happened on some of the previous cases. Take for example

```java
jshell> String[] args = new String[] {"a","b","c"}
args ==> String[3] { "a", "b", "c" }

jshell> String.format("s=%s", args)
|  Warning:
|  non-varargs call of varargs method with inexact argument type for last parameter;
|    cast to java.lang.Object for a varargs call
|    cast to java.lang.Object[] for a non-varargs call and to suppress this warning
|  String.format("s=%s", args)
|                        ^--^
$6 ==> "s=a"
```
> [!NOTE]
> How we print `s=a`, not `s=[Ljava.lang.String;@73a8dfcc` as would be the case for `args.toString()`

That means that the recipe might inadvertently in the old situation changes the above to start producing
`s=[a, b, c]` for `String.format("s=%s", Arrays.toString(args))`
