### PR TITLE
`NeedBraces`: Deal with trailing comments

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NeedBraces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NeedBraces.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.Checkstyle;
@@ -26,6 +27,7 @@ import org.openrewrite.marker.Markers;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -64,14 +66,27 @@ public class NeedBraces extends Recipe {
          * We can use that to our advantage by saying if you aren't a block (e.g. a single {@link Statement}, etc.),
          * then we're going to make this into a block. That's how we'll get the code bodies surrounded in braces.
          */
-        private static <T extends Statement> J.Block buildBlock(T element) {
+        private <T extends Statement> J.Block buildBlock(Statement owner, T element) {
+            J j = getCursor().getParentTreeCursor().getValue();
+            Space end = Space.EMPTY;
+            if (j instanceof J.Block) {
+                J.Block block = (J.Block) j;
+                List<Statement> statements = block.getStatements();
+                int i = statements.indexOf(owner);
+                boolean last = i == statements.size() - 1;
+                Space trailingSpace = last ? block.getEnd() : statements.get(i + 1).getPrefix();
+                if (!trailingSpace.getComments().isEmpty() && trailingSpace.getWhitespace().indexOf('\n') == -1) {
+                    end = trailingSpace;
+                    getCursor().getParentTreeCursor().putMessage("replaced", i);
+                }
+            }
             return new J.Block(
                     Tree.randomId(),
                     Space.EMPTY,
                     Markers.EMPTY,
                     JRightPadded.build(false),
                     element instanceof J.Empty ? Collections.emptyList() : Collections.singletonList(JRightPadded.build(element)),
-                    Space.EMPTY
+                    end
             );
         }
 
@@ -85,6 +100,29 @@ public class NeedBraces extends Recipe {
         }
 
         @Override
+        public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
+            J.Block bl = super.visitBlock(block, ctx);
+            Integer index = getCursor().pollMessage("replaced");
+            if (index != null) {
+                if (index != -1) {
+                    boolean last = index == bl.getPadding().getStatements().size() - 1;
+                    if (!last) {
+                        bl = bl.withStatements(ListUtils.map(bl.getStatements(), (i, stmt) -> {
+                            if (i == index + 1) {
+                                return stmt.withPrefix(Space.EMPTY);
+                            }
+                            return stmt;
+                        }));
+                    } else {
+                        bl = bl.withEnd(bl.getEnd().withComments(Collections.emptyList()));
+                    }
+                    bl = maybeAutoFormat(block, bl, ctx);
+                }
+            }
+            return bl;
+        }
+
+        @Override
         public J.If visitIf(J.If iff, ExecutionContext ctx) {
             if (usedAsExpression()) {
                 // Kotlin has no dedicated ternary operator
@@ -93,7 +131,7 @@ public class NeedBraces extends Recipe {
             J.If elem = super.visitIf(iff, ctx);
             boolean hasAllowableBodyType = elem.getThenPart() instanceof J.Block;
             if (!needBracesStyle.getAllowSingleLineStatement() && !hasAllowableBodyType) {
-                J.Block b = buildBlock(elem.getThenPart());
+                J.Block b = buildBlock(elem, elem.getThenPart());
                 elem = maybeAutoFormat(elem, elem.withThenPart(b), ctx);
             }
             return elem;
@@ -108,7 +146,7 @@ public class NeedBraces extends Recipe {
             J.If.Else elem = super.visitElse(else_, ctx);
             boolean hasAllowableBodyType = elem.getBody() instanceof J.Block || elem.getBody() instanceof J.If;
             if (!needBracesStyle.getAllowSingleLineStatement() && !hasAllowableBodyType) {
-                J.Block b = buildBlock(elem.getBody());
+                J.Block b = buildBlock(getCursor().getParentTreeCursor().getValue(), elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             }
             return elem;
@@ -121,10 +159,10 @@ public class NeedBraces extends Recipe {
                     elem.getBody() instanceof J.Block || elem.getBody() instanceof J.Empty :
                     elem.getBody() instanceof J.Block;
             if (!needBracesStyle.getAllowEmptyLoopBody() && elem.getBody() instanceof J.Empty) {
-                J.Block b = buildBlock(elem.getBody());
+                J.Block b = buildBlock(elem, elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             } else if (!needBracesStyle.getAllowSingleLineStatement() && !hasAllowableBodyType) {
-                J.Block b = buildBlock(elem.getBody());
+                J.Block b = buildBlock(elem, elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             }
             return elem;
@@ -137,10 +175,10 @@ public class NeedBraces extends Recipe {
                     elem.getBody() instanceof J.Block || elem.getBody() instanceof J.Empty :
                     elem.getBody() instanceof J.Block;
             if (!needBracesStyle.getAllowEmptyLoopBody() && elem.getBody() instanceof J.Empty) {
-                J.Block b = buildBlock(elem.getBody());
+                J.Block b = buildBlock(elem, elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             } else if (!needBracesStyle.getAllowSingleLineStatement() && !hasAllowableBodyType) {
-                J.Block b = buildBlock(elem.getBody());
+                J.Block b = buildBlock(elem, elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             }
             return elem;
@@ -153,10 +191,10 @@ public class NeedBraces extends Recipe {
                     elem.getBody() instanceof J.Block || elem.getBody() instanceof J.Empty :
                     elem.getBody() instanceof J.Block;
             if (!needBracesStyle.getAllowEmptyLoopBody() && elem.getBody() instanceof J.Empty) {
-                J.Block b = buildBlock(elem.getBody());
+                J.Block b = buildBlock(elem, elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             } else if (!needBracesStyle.getAllowSingleLineStatement() && !hasAllowableBodyType) {
-                J.Block b = buildBlock(elem.getBody());
+                J.Block b = buildBlock(elem, elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             }
             return elem;

--- a/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
@@ -75,6 +75,7 @@ class NeedBracesTest implements RewriteTest {
 
                   static void addToIf(int n) {
                       if (n == 1) return;
+                      // foo
                   }
 
                   static void addToIfElse(int n) {
@@ -114,6 +115,7 @@ class NeedBracesTest implements RewriteTest {
                       if (n == 1) {
                           return;
                       }
+                      // foo
                   }
 
                   static void addToIfElse(int n) {
@@ -289,6 +291,33 @@ class NeedBracesTest implements RewriteTest {
                       if (true) {
                           return;
                       }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingComment() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  static void method() {
+                      if (true) return; // comment
+                      return;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static void method() {
+                      if (true) {
+                          return; // comment
+                      }
+                      return;
                   }
               }
               """


### PR DESCRIPTION
When there is a trailing comment on the line of the nested statement which gets wrapped with braces, then the braces should remain a trailing comment for that statement.

So the code:

```java
if (foo)
    return true; // early return
```

should be transformed into:

```java
if (foo) {
    return true; // early return
}
```
