### PR TITLE
Add BigDecimalDoubleConstructor Recipe

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/BigDecimalDoubleConstructor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/BigDecimalDoubleConstructor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+import java.math.BigDecimal;
+
+@RecipeDescriptor(
+        name = "`new BigDecimal(double)` should not be used",
+        description = "Use of `new BigDecimal(double)` constructor can lead to loss of precision. Use `BigDecimal.valueOf(double)` instead.\n" +
+                      "For example writing `new BigDecimal(0.1)` does not create a `BigDecimal` which is exactly equal to `0.1`, " +
+                      "but it is equal to `0.1000000000000000055511151231257827021181583404541015625`. " +
+                      "This is because `0.1` cannot be represented exactly as a double (or, for that matter, as a binary fraction of any finite length).",
+        tags = {"RSPEC-2111"}
+)
+public class BigDecimalDoubleConstructor {
+
+    @BeforeTemplate
+    BigDecimal bigDecimalDoubleConstructor(double d) {
+        return new BigDecimal(d);
+    }
+
+    @AfterTemplate
+    BigDecimal bigDecimalValueOf(double d) {
+        return BigDecimal.valueOf(d);
+    }
+}

--- a/src/main/resources/META-INF/rewrite/common-static-analysis.yml
+++ b/src/main/resources/META-INF/rewrite/common-static-analysis.yml
@@ -21,6 +21,7 @@ description: Resolve common static analysis issues discovered through 3rd party 
 recipeList:
 #  - org.openrewrite.staticanalysis.AddSerialVersionUidToSerializable
   - org.openrewrite.staticanalysis.AtomicPrimitiveEqualsUsesGet
+  - org.openrewrite.staticanalysis.BigDecimalDoubleConstructorRecipe
   - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
   - org.openrewrite.staticanalysis.BooleanChecksNotInverted
   - org.openrewrite.staticanalysis.CaseInsensitiveComparisonsDoNotChangeCase

--- a/src/test/java/org/openrewrite/staticanalysis/BigDecimalDoubleConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/BigDecimalDoubleConstructorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings("UnpredictableBigDecimalConstructorCall")
+public class BigDecimalDoubleConstructorTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new BigDecimalDoubleConstructorRecipe());
+    }
+
+    @Test
+    void bigDecimalDoubleConstructor() {
+        rewriteRun(
+          java(
+            """
+            import java.math.BigDecimal;
+            class Test {
+                void test(double d) {
+                    BigDecimal bd = new BigDecimal(1.0);
+                    BigDecimal bd2 = new BigDecimal(d);
+                }
+            }
+            """,
+            """
+            import java.math.BigDecimal;
+            class Test {
+                void test(double d) {
+                    BigDecimal bd = BigDecimal.valueOf(1.0);
+                    BigDecimal bd2 = BigDecimal.valueOf(d);
+                }
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
Simple recipe for fixing the double constructor.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

## What's changed?
<!-- A brief description of the changes in this pull request -->

Added a recipe to detect and fix using the improper `new BigDecimal(double)` constructor

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

More fun times with refaster annotations!

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

Is it fine I added this to `CommonStaticAnalysis`?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
