### PR TITLE
Do not ReplaceLambdaWithMethodReference for class fields

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -159,6 +159,7 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                 }
 
                 if (hasSelectWithPotentialSideEffects(method) ||
+                    hasSelectWhoseReferenceMightChange(method) ||
                     !methodArgumentsMatchLambdaParameters(method, lambda) ||
                     method instanceof J.MemberReference) {
                     return l;
@@ -210,6 +211,14 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
         private boolean hasSelectWithPotentialSideEffects(MethodCall method) {
             return method instanceof J.MethodInvocation &&
                    ((J.MethodInvocation) method).getSelect() instanceof MethodCall;
+        }
+
+        private boolean hasSelectWhoseReferenceMightChange(MethodCall method) {
+            if (method instanceof J.MethodInvocation && ((J.MethodInvocation) method).getSelect() instanceof J.Identifier) {
+                JavaType.Variable fieldType = ((J.Identifier) ((J.MethodInvocation) method).getSelect()).getFieldType();
+                return fieldType != null && fieldType.getOwner() instanceof JavaType.Class;
+            }
+            return false;
         }
 
         private boolean methodArgumentsMatchLambdaParameters(MethodCall method, J.Lambda lambda) {

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -63,7 +63,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
             """
               import java.nio.file.Path;
               import java.nio.file.Paths;
-              import java.util.List;import java.util.stream.Collectors;
+              import java.util.List;
+              import java.util.stream.Collectors;
                             
               class Test {
                   Path path = Paths.get("");
@@ -190,6 +191,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                   }
               }
               """,
+            //language=java
             """
               import java.util.List;
               import java.util.stream.Collectors;
@@ -237,6 +239,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                   }
               }
               """,
+            //language=java
             """
               import org.test.CheckType;
               
@@ -288,6 +291,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                   }
               }
               """,
+            //language=java
             """
               import java.util.List;
               import java.util.stream.Stream;
@@ -595,6 +599,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
                   }
               }
               """,
+            //language=java
             """
               import org.test.CheckType;
               
@@ -1293,8 +1298,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
 
     @Test
     void newClassSelector() {
+        //language=java
         rewriteRun(
-          //language=java
           java(
             """
               class A {
@@ -1345,4 +1350,22 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Test
+    void dontReplaceNullableFieldReferences() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.function.Supplier;
+              class A {
+                  Object field;
+                  void foo() {
+                      // Runtime exception when replaced with field::toString
+                      Supplier<String> supplier = () -> field.toString();
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's your motivation?
`ReplaceLambdaWithMethodReference` changes `() -> field.getValue()` to `field::getValue`, with runtime NPE if field is only initialized later.

## Anything in particular you'd like reviewers to focus on?
This is currently too broad and breaking three original test cases, but I'm not quite sure how to narrow it down further. From the perspective of do-no-harm we might disable those test cases though, as the addition here is safer.