### PR TITLE
`InstanceOfPatternMatch`: handle same type for multiple operands

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -791,5 +791,32 @@ class InstanceOfPatternMatchTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        void multipleCastsInDifferentOperands() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import java.util.Comparator;
+                  public class A {
+                     Comparator<Object> comparator() {
+                       return (a, b) ->
+                           (a instanceof String) && (b instanceof String) ? ((String) a).compareTo((String) b) : 0;
+                     }
+                  }
+                  """,
+                """
+                  import java.util.Comparator;
+                  public class A {
+                     Comparator<Object> comparator() {
+                       return (a, b) ->
+                            (a instanceof String s) && (b instanceof String s) ? s.compareTo(s) : 0;
+                     }
+                  }
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?

This introduces a failing unit test for the `InstanceOfPatternmatch` recipe. 
We are giving the same name to the variable while we have an expression with two operands that check the same type.

## What's your motivation?

The code in the "after" template is incorrect as it gives the following error: 
```
Variable 's' is already defined in the scope
```

## Any additional context

I'm curious how we can fix this. It doesn't seem trivial, so probably I don't have time right now to create a fix myself.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
