### PR TITLE
Add test case for `== false` rewrite

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/kotlin/SimplifyBooleanExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/kotlin/SimplifyBooleanExpressionTest.java
@@ -53,6 +53,27 @@ class SimplifyBooleanExpressionTest implements RewriteTest {
     }
 
     @Test
+    void simplifyEqualsFalse() {
+        rewriteRun(
+          kotlin(
+            """
+              fun getSymbol() : String? {
+                  return null
+              }
+              """
+          ),
+          kotlin(
+            """
+              val isPositive = getSymbol().equals("+") == false
+              """,
+            """
+              val isPositive = !getSymbol().equals("+")
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotChangeWithNullable() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
Context: https://rewriteoss.slack.com/archives/C01A843MWG5/p1709465857842709

Expected change:

```diff
- if (file.isOnlineLink() == false) {
+ if (!file.isOnlineLink()) {
```

According to https://rewriteoss.slack.com/archives/C01A843MWG5/p1709466186202159?thread_ts=1709465857.842709&cid=C01A843MWG5, it should go into SimplifyBooleanExpression. Therefore, I added a test

It also could be a refaster template, but IDK. Think, it is closer to the existing code in `SimplifyBooleanExpression` - or should be the complete class rewritten by refaster templates?

The visitor is there https://github.com/openrewrite/rewrite/blob/main/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java. (https://rewriteoss.slack.com/archives/C01A843MWG5/p1709476587357369?thread_ts=1709465857.842709&cid=C01A843MWG5)

Note that `SimplifyBooleanExpressionVisitor` resides in a different project.

---

I could not do `asBinary.getRight().negate()` as `negate()` is not a method - and I did not find the appropriate method to do so.