### PR TITLE
Skip RenamePrivateFieldsToCamelCase when using lombok

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCaseTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.Recipe;
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.marker.JavaVersion;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -580,6 +581,40 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
                         foo = "defaultValue";
                     }
                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
+    void doNotChangeLombokAnnotatedClasses() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),
+          //language=java
+          java(
+            """
+              @lombok.RequiredArgsConstructor
+              class Test {
+                  private String D_TYPE_CONNECT = "";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
+    void doNotChangeLombokAnnotatedFields() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),
+          //language=java
+          java(
+            """
+              class Test {
+                  @lombok.Setter
+                  private String D_TYPE_CONNECT = "";
               }
               """
           )


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/267

Mirrors what we do in `RemoveUnusedPrivateFields`
https://github.com/openrewrite/rewrite-static-analysis/blob/106421ad4d1db3fe062c8743d042627e07598a8c/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateFields.java#L42

## Anyone you would like to review specifically?
@blipper