### PR TITLE
Combine semantically equal catch blocks with same var declarations

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
@@ -1692,8 +1692,7 @@ public class CombineSemanticallyEqualCatchBlocks extends Recipe {
                             nullMissMatch(multiVariable.getTypeExpression(), compareTo.getTypeExpression()) ||
                             multiVariable.getVariables().size() != compareTo.getVariables().size() ||
                             multiVariable.getLeadingAnnotations().size() != compareTo.getLeadingAnnotations().size() ||
-                            doesNotContainSameComments(multiVariable.getPrefix(), compareTo.getPrefix()) ||
-                            doesNotContainSameComments(multiVariable.getVarargs(), compareTo.getVarargs())) {
+                            doesNotContainSameComments(multiVariable.getPrefix(), compareTo.getPrefix())) {
                         isEqual.set(false);
                         return multiVariable;
                     }

--- a/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
@@ -448,4 +448,40 @@ class CombineSemanticallyEqualCatchBlocksTest implements RewriteTest {
           )
         );
     }
+
+
+    @Test
+    void combineSameCatchBlocksWithVariableDeclaration() {
+        rewriteRun(
+          //language=java
+          java("class A extends RuntimeException {}"),
+          //language=java
+          java("class B extends RuntimeException {}"),
+          //language=java
+          java(
+            """
+              class Test {
+                  void method() {
+                      try {
+                      } catch (A ex) {
+                          String s = "foo";
+                      } catch (B ex) {
+                          String s = "foo";
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                      try {
+                      } catch (A | B ex) {
+                          String s = "foo";
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fix NPE in CombineSemanticallyEqualCatchBlocks occurring when semantically equal catch blocks contain a variable declaration.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes #278.

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
No.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
