### PR TITLE
Avoid parenthesis only cleanup in SimplifyConstantIfBranchExecution

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecution.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecution.java
@@ -87,6 +87,7 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
         @Override
         public J visitIf(J.If if_, ExecutionContext ctx) {
             J.If if__ = (J.If) super.visitIf(if_, ctx);
+            J.If ifBeforeCleanup = if__;
 
             J.ControlParentheses<Expression> cp = cleanupBooleanExpression(if__.getIfCondition(), ctx);
             if__ = if__.withIfCondition(cp);
@@ -104,7 +105,7 @@ public class SimplifyConstantIfBranchExecution extends Recipe {
 
             // The simplification process did not result in resolving to a single 'true' or 'false' value
             if (!compileTimeConstantBoolean.isPresent()) {
-                return if__; // Return the visited `if`
+                return ifBeforeCleanup; // Return the visited `if`
             } else if (compileTimeConstantBoolean.get()) {
                 // True branch
                 // Only keep the `then` branch, and remove the `else` branch.

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -49,6 +49,26 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/286")
+    void doNotChangeParenthesisOnly() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void test() {
+                      boolean b = true;
+                      if (!(b)) {
+                          System.out.println("hello");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void simplifyConstantIfTrue() {


### PR DESCRIPTION
## What's changed?
Recognize when the recipe cannot optimize to a constant condition and return the if-condition as before all attempted optimizations.

## What's your motivation?
Fixes #286.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
