### PR TITLE
Fix bug in InstanceOfPatternMatch getting the variable name from the name of a nested class

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -364,9 +364,7 @@ public class InstanceOfPatternMatch extends Recipe {
                 return name;
             } else if (type instanceof JavaType.FullyQualified) {
                 String className = ((JavaType.FullyQualified) type).getClassName();
-                if (className.indexOf('.') > 0) {
-                    className = className.substring(className.lastIndexOf('.'));
-                }
+                className = className.substring(className.lastIndexOf('.') + 1);
                 String baseName = null;
                 switch (style) {
                     case SHORT:

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -221,6 +221,41 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
+        @Test
+        void conflictingVariableOfNestedType() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import java.util.Map;
+                  
+                  public class A {
+                      void test(Object o) {
+                          Map.Entry entry = null;
+                          if (o instanceof Map.Entry) {
+                            entry = (Map.Entry) o;
+                          }
+                          System.out.println(entry);
+                      }
+                  }
+                  """,
+                """
+                  import java.util.Map;
+                  
+                  public class A {
+                      void test(Object o) {
+                          Map.Entry entry = null;
+                          if (o instanceof Map.Entry entry1) {
+                            entry = entry1;
+                          }
+                          System.out.println(entry);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
         @Issue("https://github.com/openrewrite/rewrite/issues/2787")
         @Disabled
         @Test


### PR DESCRIPTION
## What's changed?
Fix bug in InstanceOfPatternMatch getting the variable name from the name of a nested class.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/290

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
