### PR TITLE
`RemoveUnusedPrivateMethods` should ignore class annotated with `@SupressWarning("unused")`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethods.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import java.util.*;
-
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -28,6 +26,9 @@ import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.*;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 public class RemoveUnusedPrivateMethods extends Recipe {
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -129,13 +129,12 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
     }
 
     @Test
-    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
     void doNotRemoveMethodsOnClassNestedClass() {
         rewriteRun(
           //language=java
           java(
             """
-                            import java.util.stream.Stream;
+              import java.util.stream.Stream;
               
               class Test {
                   void test(String input) {
@@ -154,7 +153,6 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
               }
               """,
             """
-              import org.junit.jupiter.params.provider.MethodSource;
               import java.util.stream.Stream;
               
               class Test {
@@ -178,7 +176,6 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
           //language=java
           java(
             """
-              import org.junit.jupiter.params.provider.MethodSource;
               import java.util.stream.Stream;
               
               @SuppressWarnings("unused")
@@ -204,7 +201,6 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
           //language=java
           java(
             """
-              import org.junit.jupiter.params.provider.MethodSource;
               import java.util.stream.Stream;
               
               @SuppressWarnings("unused")
@@ -220,24 +216,6 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
                       }
                       private Stream<Object> unused() {
                           return null;
-                      }
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.params.provider.MethodSource;
-              import java.util.stream.Stream;
-              
-              @SuppressWarnings("unused")
-              class Test {
-                  void test(String input) {
-                  }
-                  private Stream<Object> unused() {
-                      return null;
-                  }
-              
-                  class InnerTest {
-                      void test(String input) {
                       }
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -130,13 +130,12 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4076")
-    void doNotRemoveMethodsOnClassInnerClass() {
+    void doNotRemoveMethodsOnClassNestedClass() {
         rewriteRun(
           //language=java
           java(
             """
-              import org.junit.jupiter.params.provider.MethodSource;
-              import java.util.stream.Stream;
+                            import java.util.stream.Stream;
               
               class Test {
                   void test(String input) {
@@ -144,7 +143,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
                   private Stream<Object> unused() {
                       return null;
                   }
-    
+              
                   class InnerTest {
                       void test(String input) {
                       }
@@ -161,7 +160,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
               class Test {
                   void test(String input) {
                   }
-    
+              
                   class InnerTest {
                       void test(String input) {
                       }
@@ -200,7 +199,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4076")
-    void doNotRemoveMethodsWithUnusedSuppressWarningsOnClassInnerClass() {
+    void doNotRemoveMethodsWithUnusedSuppressWarningsOnClassNestedClass() {
         rewriteRun(
           //language=java
           java(
@@ -215,7 +214,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
                   private Stream<Object> unused() {
                       return null;
                   }
-    
+              
                   class InnerTest {
                       void test(String input) {
                       }
@@ -236,7 +235,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
                   private Stream<Object> unused() {
                       return null;
                   }
-    
+              
                   class InnerTest {
                       void test(String input) {
                       }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -130,6 +130,50 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4076")
+    void doNotRemoveMethodsOnClassInnerClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.provider.MethodSource;
+              import java.util.stream.Stream;
+              
+              class Test {
+                  void test(String input) {
+                  }
+                  private Stream<Object> unused() {
+                      return null;
+                  }
+    
+                  class InnerTest {
+                      void test(String input) {
+                      }
+                      private Stream<Object> unused() {
+                          return null;
+                      }
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.provider.MethodSource;
+              import java.util.stream.Stream;
+              
+              class Test {
+                  void test(String input) {
+                  }
+    
+                  class InnerTest {
+                      void test(String input) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
     void doNotRemoveMethodsWithUnusedSuppressWarningsOnClass() {
         rewriteRun(
           //language=java
@@ -145,9 +189,62 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
                   private Stream<Object> unused() {
                       return null;
                   }
+                  private Stream<Object> anotherUnused() {
+                      return null;
+                  }
               }
               """
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
+    void doNotRemoveMethodsWithUnusedSuppressWarningsOnClassInnerClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.provider.MethodSource;
+              import java.util.stream.Stream;
+              
+              @SuppressWarnings("unused")
+              class Test {
+                  void test(String input) {
+                  }
+                  private Stream<Object> unused() {
+                      return null;
+                  }
+    
+                  class InnerTest {
+                      void test(String input) {
+                      }
+                      private Stream<Object> unused() {
+                          return null;
+                      }
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.provider.MethodSource;
+              import java.util.stream.Stream;
+              
+              @SuppressWarnings("unused")
+              class Test {
+                  void test(String input) {
+                  }
+                  private Stream<Object> unused() {
+                      return null;
+                  }
+    
+                  class InnerTest {
+                      void test(String input) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -42,22 +42,22 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
               class Test {
                   private void unused() {
                   }
-                            
+              
                   public void dontRemove() {
                       dontRemove2();
                   }
-                  
+              
                   private void dontRemove2() {
                   }
               }
               """,
             """
               class Test {
-                            
+              
                   public void dontRemove() {
                       dontRemove2();
                   }
-                  
+              
                   private void dontRemove2() {
                   }
               }
@@ -129,7 +129,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
     }
 
     @Test
-    void doNotRemoveMethodsOnClassNestedClass() {
+    void removeMethodsOnNestedClass() {
         rewriteRun(
           //language=java
           java(
@@ -223,5 +223,4 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
           )
         );
     }
-
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -127,4 +127,27 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
+    void doNotRemoveMethodsWithUnusedSuppressWarningsOnClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.provider.MethodSource;
+              import java.util.stream.Stream;
+              
+              @SuppressWarnings("unused")
+              class Test {
+                  void test(String input) {
+                  }
+                  private Stream<Object> unused() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Fix #294
- #294