### PR TITLE
Do not rewrite String.replaceAll with special chars in replacement string

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseStringReplace.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseStringReplace.java
@@ -83,6 +83,21 @@ public class UseStringReplace extends Recipe {
 
             //Checks if method invocation matches with String#replaceAll
             if (REPLACE_ALL.matches(invocation)) {
+                Expression secondArgument = invocation.getArguments().get(1);
+
+                //Checks if the second argument is a string literal with $ or \ in it as this has special meaning and
+                // should not be rewritten:
+                //https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/regex/Matcher.html#replaceAll(java.lang.String)
+                if (isStringLiteral(secondArgument)) {
+                    J.Literal literal = (J.Literal) secondArgument;
+                    String value = (String) literal.getValue();
+
+                    if (Objects.nonNull(value) && (value.contains("$") || value.contains("\\"))) {
+                        // do not rewrite
+                        return invocation;
+                    }
+                }
+
                 Expression firstArgument = invocation.getArguments().get(0);
 
                 //Checks if the first argument is a String literal

--- a/src/main/java/org/openrewrite/staticanalysis/UseStringReplace.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseStringReplace.java
@@ -52,7 +52,7 @@ public class UseStringReplace extends Recipe {
     @Override
     public String getDescription() {
         return "When `String::replaceAll` is used, the first argument should be a real regular expression. " +
-                "If it’s not the case, `String::replace` does exactly the same thing as `String::replaceAll` without the performance drawback of the regex.";
+               "If it’s not the case, `String::replace` does exactly the same thing as `String::replaceAll` without the performance drawback of the regex.";
     }
 
     @Override
@@ -81,34 +81,27 @@ public class UseStringReplace extends Recipe {
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation invocation = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
-            //Checks if method invocation matches with String#replaceAll
+            // Checks if method invocation matches with String#replaceAll
             if (REPLACE_ALL.matches(invocation)) {
+                // Checks if the second argument is a string literal with $ or \ in it as this has special meaning
+                // https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/regex/Matcher.html#replaceAll(java.lang.String)
                 Expression secondArgument = invocation.getArguments().get(1);
-
-                //Checks if the second argument is a string literal with $ or \ in it as this has special meaning and
-                // should not be rewritten:
-                //https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/regex/Matcher.html#replaceAll(java.lang.String)
-                if (isStringLiteral(secondArgument)) {
-                    J.Literal literal = (J.Literal) secondArgument;
-                    String value = (String) literal.getValue();
-
-                    if (Objects.nonNull(value) && (value.contains("$") || value.contains("\\"))) {
-                        // do not rewrite
-                        return invocation;
-                    }
+                if (!isStringLiteral(secondArgument)) {
+                    return invocation; // Might contain special characters; unsafe to replace
+                }
+                String secondValue = (String) ((J.Literal) secondArgument).getValue();
+                if (Objects.nonNull(secondValue) && (secondValue.contains("$") || secondValue.contains("\\"))) {
+                    return invocation; // Does contain special characters; unsafe to replace
                 }
 
+                // Checks if the first argument is a String literal
                 Expression firstArgument = invocation.getArguments().get(0);
-
-                //Checks if the first argument is a String literal
                 if (isStringLiteral(firstArgument)) {
-                    J.Literal literal = (J.Literal) firstArgument;
-                    String value = (String) literal.getValue();
-
-                    //Checks if the String literal may not be a regular expression,
-                    //if so, then change the method invocation name
-                    if (Objects.nonNull(value) && !mayBeRegExp(value)) {
-                        String unEscapedLiteral = unEscapeCharacters(value);
+                    // Checks if the String literal may not be a regular expression,
+                    // if so, then change the method invocation name
+                    String firstValue = (String) ((J.Literal) firstArgument).getValue();
+                    if (Objects.nonNull(firstValue) && !mayBeRegExp(firstValue)) {
+                        String unEscapedLiteral = unEscapeCharacters(firstValue);
                         invocation = invocation
                                 .withName(invocation.getName().withSimpleName("replace"))
                                 .withArguments(ListUtils.mapFirst(invocation.getArguments(), arg -> ((J.Literal) arg)

--- a/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
@@ -174,8 +174,13 @@ class UseStringReplaceTest implements RewriteTest {
           java(
             """
               class Test {
-                public String method() {
+                public String method1() {
                   return "abc".replaceAll("b", "$0");
+                }
+
+                public String method2() {
+                  String s = "$0";
+                  return "abc".replaceAll("b", s);
                 }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
@@ -146,4 +146,40 @@ class UseStringReplaceTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
+    @DisplayName("String#replaceAll is not replaced by String#replace, because second argument has a backslash in it")
+    void replaceAllUnchangedIfBackslashInReplacementString() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                public String method() {
+                  return "abc".replaceAll("b", "\\\\\\\\\\\\\\\\");
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
+    @DisplayName("String#replaceAll is not replaced by String#replace, because second argument has a dollar sign in it")
+    void replaceAllUnchangedIfDollarInReplacementString() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                public String method() {
+                  return "abc".replaceAll("b", "$0");
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
If the replacement string of String.replaceAll contains $ or \, we should not rewrite it as these indicate special replacements: https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/regex/Matcher.html#replaceAll(java.lang.String)

- Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/301
