### PR TITLE
Don't use lambdas for methods with type parameters.

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -96,6 +96,11 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         StringBuilder templateBuilder = new StringBuilder();
                         J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) n.getBody().getStatements().get(0);
 
+                        // If the functional interface method has type parameters, we can't replace it with a lambda.
+                        if (methodDeclaration.getTypeParameters() != null && !methodDeclaration.getTypeParameters().isEmpty()) {
+                            return n;
+                        }
+
                         if (methodDeclaration.getParameters().get(0) instanceof J.Empty) {
                             templateBuilder.append("() -> {");
                         } else {

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -736,7 +736,6 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/309")
     void dontUseLambdaForMethodWithTypeParameter() {


### PR DESCRIPTION
For a method that has a type parameter, we can't replace anonymous class declarations with a lambda. For example:
```java
public interface I {
  <T> List<T> call();
}

// Can't be replaced by lambda
final I i = new I() {
  @Override
  public <T> List<T> call() { ... }
};
```

The proposed fix is to check the method in question for type parameters, and if there are any, return early from `UseLambdaForFunctionalInterface` without making any changes.

Fixes #309
