### PR TITLE
Convert additional lambdas to expressions based on number of args

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
@@ -89,6 +89,7 @@ public class LambdaBlockToExpression extends Recipe {
     // TODO this is actually more complex in the presence of generics and inheritance
     static boolean hasMethodOverloading(JavaType.Method methodType) {
         String methodName = methodType.getName();
+        int numberOfParameters = methodType.getParameterNames().size();
         return Optional.of(methodType)
                 .map(JavaType.Method::getDeclaringType)
                 .filter(JavaType.Class.class::isInstance)
@@ -97,7 +98,8 @@ public class LambdaBlockToExpression extends Recipe {
                 .map(methods -> {
                     int overloadingCount = 0;
                     for (JavaType.Method dm : methods) {
-                        if (dm.getName().equals(methodName)) {
+                        if (methodName.equals(dm.getName()) &&
+                            numberOfParameters == dm.getParameterNames().size()) {
                             if (++overloadingCount > 1) {
                                 return true;
                             }

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -75,7 +75,7 @@ class LambdaBlockToExpressionTest implements RewriteTest {
             """
               import java.util.function.Function;
               class Test {
-                  Function<Integer, Integer> f = n -> 
+                  Function<Integer, Integer> f = n ->
                       // The buttonType will always be "cancel", even if we pressed one of the entry type buttons
                       n + 1;
               }
@@ -145,4 +145,41 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/582")
+    void simplifyAssertThrows() {
+        rewriteRun(
+          spec-> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
+          //language=java
+          java(
+            """
+            import static org.junit.jupiter.api.Assertions.assertThrows;
+            
+            class Test {
+                void test() {
+                    assertThrows(IllegalArgumentException.class, () -> {
+                        foo();
+                    });
+                }
+                void foo() {
+                    throw new IllegalArgumentException("boom");
+                }
+            }
+            """,
+            """
+            import static org.junit.jupiter.api.Assertions.assertThrows;
+            
+            class Test {
+                void test() {
+                    assertThrows(IllegalArgumentException.class, () ->
+                        foo());
+                }
+                void foo() {
+                    throw new IllegalArgumentException("boom");
+                }
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Also look at number of arguments when looking for methods that might conflict in LambdaBlockToExpression.
The compiler should not get confused in there are a differing number of arguments in same name methods.

## What's your motivation?
Allow adoption into
- https://github.com/openrewrite/rewrite-testing-frameworks/pull/582