### PR TITLE
Support fluent chains in RemoveMethodCallVisitor

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitor.java
@@ -45,7 +45,7 @@ public class RemoveMethodCallVisitor<P> extends JavaIsoVisitor<P> {
     @SuppressWarnings("NullableProblems")
     @Override
     public J.@Nullable NewClass visitNewClass(J.NewClass newClass, P p) {
-        if (matchesMethod(newClass) && predicateMatchesAllArguments(newClass) && isStatementInParentBlock(newClass)) {
+        if (methodMatcher.matches(newClass) && predicateMatchesAllArguments(newClass) && isStatementInParentBlock(newClass)) {
             if (newClass.getMethodType() != null) {
                 maybeRemoveImport(newClass.getMethodType().getDeclaringType());
             }
@@ -58,7 +58,7 @@ public class RemoveMethodCallVisitor<P> extends JavaIsoVisitor<P> {
     @Override
     public J.@Nullable MethodInvocation visitMethodInvocation(J.MethodInvocation method, P p) {
         // Find method invocations that match the specified method and arguments
-        if (matchesMethod(method) && predicateMatchesAllArguments(method)) {
+        if (methodMatcher.matches(method) && predicateMatchesAllArguments(method)) {
             // If the method invocation is a standalone statement, remove it altogether
             if (isStatementInParentBlock(method)) {
                 if (method.getMethodType() != null) {
@@ -74,10 +74,6 @@ public class RemoveMethodCallVisitor<P> extends JavaIsoVisitor<P> {
             }
         }
         return super.visitMethodInvocation(method, p);
-    }
-
-    private boolean matchesMethod(MethodCall method) {
-        return methodMatcher.matches(method);
     }
 
     private boolean predicateMatchesAllArguments(MethodCall method) {

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitor.java
@@ -22,7 +22,6 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.*;
 
 import java.util.function.BiPredicate;
-import java.util.function.Supplier;
 
 /**
  * Removes all {@link MethodCall} matching both the
@@ -69,8 +68,8 @@ public class RemoveMethodCallVisitor<P> extends JavaIsoVisitor<P> {
             }
 
             // If the method invocation is in a fluent chain, remove just the current invocation
-            if (isInFluentChain(method)) {
-                //noinspection ConstantConditions
+            if (method.getSelect() instanceof J.MethodInvocation &&
+                TypeUtils.isOfType(method.getType(), method.getSelect().getType())) {
                 return super.visitMethodInvocation((J.MethodInvocation) method.getSelect(), p);
             }
         }
@@ -93,20 +92,5 @@ public class RemoveMethodCallVisitor<P> extends JavaIsoVisitor<P> {
     private boolean isStatementInParentBlock(Statement method) {
         J.Block parentBlock = getCursor().firstEnclosing(J.Block.class);
         return parentBlock == null || parentBlock.getStatements().contains(method);
-    }
-
-    private boolean isInFluentChain(J.MethodInvocation method) {
-        Expression select = method.getSelect();
-        if (select instanceof J.MethodInvocation) {
-            return sameReturnType(method, (J.MethodInvocation) select);
-        }
-        return false;
-    }
-
-    private boolean sameReturnType(J.MethodInvocation m1, J.MethodInvocation m2) {
-        if (m1.getMethodType() == null || m2.getMethodType() == null) {
-            return false;
-        }
-        return m1.getMethodType().getReturnType() == m2.getMethodType().getReturnType();
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitorTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
@@ -44,7 +43,7 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
             """
               abstract class Test {
                   abstract void assertTrue(boolean condition);
-
+              
                   void test() {
                       System.out.println("Hello");
                       assertTrue(true);
@@ -54,7 +53,7 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
               """, """
               abstract class Test {
                   abstract void assertTrue(boolean condition);
-
+              
                   void test() {
                       System.out.println("Hello");
                       System.out.println("World");
@@ -73,7 +72,7 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
             """
               abstract class Test {
                   abstract void assertTrue(boolean condition);
-
+              
                   void test() {
                       System.out.println("Hello");
                       assertTrue(false);
@@ -96,7 +95,7 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
             """
               abstract class Test {
                   abstract void assertTrue(String message, boolean condition);
-
+              
                   void test() {
                       System.out.println("Hello");
                       assertTrue("message", true);
@@ -107,7 +106,7 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
             """
               abstract class Test {
                   abstract void assertTrue(String message, boolean condition);
-
+              
                   void test() {
                       System.out.println("Hello");
                       System.out.println("World");
@@ -126,7 +125,7 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
             """
               abstract class Test {
                   abstract int assertTrue(boolean condition);
-
+              
                   void test() {
                       System.out.println("Hello");
                       int value = assertTrue(true);
@@ -140,31 +139,31 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
 
     @Test
     void removeMethodCallFromFluentChain() {
-        final MethodMatcher methodMatcher = new MethodMatcher("java.lang.StringBuilder append(..)");
-        final RemoveMethodCallVisitor<ExecutionContext> visitor =
-          new RemoveMethodCallVisitor<>(methodMatcher, (i, e) -> true);
         rewriteRun(
-          spec -> spec.recipe(RewriteTest.toRecipe(() -> visitor)),
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new RemoveMethodCallVisitor<>(
+            new MethodMatcher("java.lang.StringBuilder append(..)"), (i, e) -> true))),
           // language=java
           java(
             """
-            class Main {
-                void hello() {
-                    final String s = new StringBuilder("hello")
-                            .delete(1, 2)
-                            .append("world")
-                            .toString();
-                }
-            }
-            """,
+              class Main {
+                  void hello() {
+                      final String s = new StringBuilder("hello")
+                              .delete(1, 2)
+                              .append("world")
+                              .toString();
+                  }
+              }
+              """,
             """
-            class Main {
-                void hello() {
-                    final String s = new StringBuilder("hello")
-                            .delete(1, 2)
-                            .toString();
-                }
-            }
-            """));
+              class Main {
+                  void hello() {
+                      final String s = new StringBuilder("hello")
+                              .delete(1, 2)
+                              .toString();
+                  }
+              }
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveMethodCallVisitorTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
@@ -135,5 +136,35 @@ class RemoveMethodCallVisitorTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void removeMethodCallFromFluentChain() {
+        final MethodMatcher methodMatcher = new MethodMatcher("java.lang.StringBuilder append(..)");
+        final RemoveMethodCallVisitor<ExecutionContext> visitor =
+          new RemoveMethodCallVisitor<>(methodMatcher, (i, e) -> true);
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> visitor)),
+          // language=java
+          java(
+            """
+            class Main {
+                void hello() {
+                    final String s = new StringBuilder("hello")
+                            .delete(1, 2)
+                            .append("world")
+                            .toString();
+                }
+            }
+            """,
+            """
+            class Main {
+                void hello() {
+                    final String s = new StringBuilder("hello")
+                            .delete(1, 2)
+                            .toString();
+                }
+            }
+            """));
     }
 }


### PR DESCRIPTION
## What's changed?
`RemoveMethodCallVisitor` can now remove method invocations in a fluent chain, assuming that the select is also a method invocation and of the same return type. In particular, this works for the builder pattern.

## What's your motivation?
- Fixes #339

## Anything in particular you'd like reviewers to focus on?
Is partial support for this use-case worth the added complexity?

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
