### PR TITLE
Update InstanceOfPatternMatchTest.java

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-
+import static org.junit.jupiter.api.Assertions.*;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
 
@@ -37,6 +37,44 @@ class InstanceOfPatternMatchTest implements RewriteTest {
     @SuppressWarnings({"ImplicitArrayToString", "PatternVariableCanBeUsed", "UnnecessaryLocalVariable"})
     @Nested
     class If {
+        //Run the Java 17 upgrade recipe on this code to migrate from Java 8 to Java 17.
+        //After applying the upgrade, the code will be modified, which leads to compilation errors when building with JDK 17
+        //Solution: Revert back to original code
+        @Test
+        void CompilationFailuresOnUpgradeToJAVA17() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Java17UpgradeCompilationTest {
+                        void testWithoutUpgrade() {
+                            Object obj1 = "abc";
+                            Object obj2 = "def";
+                            if (obj1.getClass().equals(obj2.getClass()) &&
+                                    obj1 instanceof Comparable) {
+                                int diff = ((Comparable)obj1).compareTo(obj2);
+                                assertEquals(-3, diff); 
+                            }
+                        }
+                    }
+                  """,
+                """
+                  public class Java17UpgradeCompilationTest {
+                        void testWithoutUpgrade() {
+                            Object obj1 = "abc";
+                            Object obj2 = "def";
+                            if (obj1.getClass().equals(obj2.getClass()) &&
+                                    obj1 instanceof Comparable<?> comparable) {
+                                int diff = comparable.compareTo(obj2);
+                                assertEquals(-3, diff); 
+                            }
+                        }
+                    }
+                  """
+              )
+            );
+        }
+
         @Test
         void ifConditionWithoutPattern() {
             rewriteRun(


### PR DESCRIPTION
Sometimes when I use java17 upgrade recipe, it makes these types of changes to my code:
from this:
```
if (obj1.getClass().equals(obj2.getClass()) &&
                obj1 instanceof Comparable) {
            int diff = ((Comparable)obj1).compareTo(obj2);
            if (diff != 0) return diff;
        }
    }
```
to this:
```
if (obj1.getClass().equals(obj2.getClass()) &&
                            obj1 instanceof Comparable<?> comparable) {
                        int diff = comparable.compareTo(obj2);
                        if (diff != 0) return diff;
                    }
                }
```
from this:
```
if (answer instanceof MultipleOptionsAnswer) {
    MultipleOptionsAnswer optionsAnswer = (MultipleOptionsAnswer) answer;
    List<Option> options = optionsAnswer.getOptions();
```
to this:
```
if (answer instanceof MultipleOptionsAnswer<?,?> optionsAnswer) {
    List<Option> options = optionsAnswer.getOptions();
```
which throws error like this while building on jdk 17, `incompatible types: java.util.List<capture#1 of ?> cannot be converted to java.util.List`
and I need to revert back the changes to build it successfully
**Solution: Revert back to original code**