### PR TITLE
Fix: `CatchClauseOnlyRethrows` does not handle multi catch correctly

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -77,7 +77,10 @@ public class CatchClauseOnlyRethrows extends Recipe {
                         // keep this one
                         for (int j = i + 1; j < tryable.getCatches().size(); j++) {
                             J.Try.Catch next = tryable.getCatches().get(j);
-                            if (!onlyRethrows(next) && hasWiderExceptionType(aCatch, next)) {
+                            if (hasWiderExceptionType(aCatch, next)) {
+                                if (onlyRethrows(next)) {
+                                    return null;
+                                }
                                 return aCatch;
                             }
                         }

--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -90,7 +90,12 @@ public class CatchClauseOnlyRethrows extends Recipe {
             private boolean hasWiderExceptionType(J.Try.Catch aCatch, J.Try.Catch next) {
                 if (next.getParameter().getType() instanceof JavaType.MultiCatch) {
                     JavaType.MultiCatch multiCatch = (JavaType.MultiCatch) next.getParameter().getType();
-                    return multiCatch.getThrowableTypes().stream().anyMatch(alt -> TypeUtils.isAssignableTo(alt, aCatch.getParameter().getType()));
+                    for (JavaType throwableType : multiCatch.getThrowableTypes()) {
+                        if (TypeUtils.isAssignableTo(throwableType, aCatch.getParameter().getType())) {
+                            return true;
+                        }
+                    }
+                    return false;
                 }
                 return TypeUtils.isAssignableTo(next.getParameter().getType(), aCatch.getParameter().getType());
             }

--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -77,8 +77,7 @@ public class CatchClauseOnlyRethrows extends Recipe {
                         // keep this one
                         for (int j = i + 1; j < tryable.getCatches().size(); j++) {
                             J.Try.Catch next = tryable.getCatches().get(j);
-                            if (!onlyRethrows(next) && TypeUtils.isAssignableTo(next.getParameter().getType(),
-                                    aCatch.getParameter().getType())) {
+                            if (!onlyRethrows(next) && hasWiderExceptionType(aCatch, next)) {
                                 return aCatch;
                             }
                         }
@@ -86,6 +85,14 @@ public class CatchClauseOnlyRethrows extends Recipe {
                     }
                     return aCatch;
                 }));
+            }
+
+            private boolean hasWiderExceptionType(J.Try.Catch aCatch, J.Try.Catch next) {
+                if (next.getParameter().getType() instanceof JavaType.MultiCatch) {
+                    JavaType.MultiCatch multiCatch = (JavaType.MultiCatch) next.getParameter().getType();
+                    return multiCatch.getThrowableTypes().stream().anyMatch(alt -> TypeUtils.isAssignableTo(alt, aCatch.getParameter().getType()));
+                }
+                return TypeUtils.isAssignableTo(next.getParameter().getType(), aCatch.getParameter().getType());
             }
 
             private boolean onlyRethrows(J.Try.Catch aCatch) {

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -82,6 +82,31 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMultiCast() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileReader;
+              import java.io.IOException;
+              
+              class A {
+                  void foo() throws IOException {
+                      try {
+                          new FileReader("").read();
+                      } catch (IOException e) {
+                          throw e;
+                      } catch(Exception | Throwable t) {
+                          t.printStackTrace();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void tryCanBeRemoved() {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The CatchClauseOnlyRethrows will now correctly handle multicatch blocks that use the short hand syntax `catch(Foo | Bar exception) {...}`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

In issue https://github.com/openrewrite/rewrite/issues/4235, a bug was demonstrated that caused a `catch` statement to be incorrectly removed as a wider exception is specified later on. I found that the reason for this behavior is the incorrect handling of `catch(Foo | Bar exception)` when checking for a wider exception type. The current code only performs a direct comparison between the parameter type of the current `catch` statement and that of the next one. This works fine if the statement is of the form `catch(Foo exception)`. However, in the case where the shorthand `catch(Foo | Bar exception)` is used, direct comparison of their parameter type no longer works. I added addition logic that will also correctly handle the check for`JavaType.MultiCatch` types.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
