### PR TITLE
Fix `CatchCauseOnlyRethrows` onlyRethrows check for multi catch statements

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -20,7 +20,10 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
 import java.util.Set;
@@ -37,7 +40,7 @@ public class CatchClauseOnlyRethrows extends Recipe {
     @Override
     public String getDescription() {
         return "A `catch` clause that only rethrows the caught exception is unnecessary. " +
-                "Letting the exception bubble up as normal achieves the same result with less code.";
+               "Letting the exception bubble up as normal achieves the same result with less code.";
     }
 
     @Override
@@ -105,11 +108,18 @@ public class CatchClauseOnlyRethrows extends Recipe {
 
             private boolean onlyRethrows(J.Try.Catch aCatch) {
                 if (aCatch.getBody().getStatements().size() != 1 ||
-                        !(aCatch.getBody().getStatements().get(0) instanceof J.Throw)) {
+                    !(aCatch.getBody().getStatements().get(0) instanceof J.Throw)) {
                     return false;
                 }
 
                 Expression exception = ((J.Throw) aCatch.getBody().getStatements().get(0)).getException();
+                JavaType catchParameterType = aCatch.getParameter().getType();
+                if (!(catchParameterType instanceof JavaType.MultiCatch)) {
+                    JavaType.FullyQualified catchType = TypeUtils.asFullyQualified(catchParameterType);
+                    if (catchType == null || !catchType.equals(exception.getType())) {
+                        return false;
+                    }
+                }
                 if (exception instanceof J.Identifier) {
                     return ((J.Identifier) exception).getSimpleName().equals(aCatch.getParameter().getTree().getVariables().get(0).getSimpleName());
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -110,11 +110,6 @@ public class CatchClauseOnlyRethrows extends Recipe {
                 }
 
                 Expression exception = ((J.Throw) aCatch.getBody().getStatements().get(0)).getException();
-                JavaType.FullyQualified catchType = TypeUtils.asFullyQualified(aCatch.getParameter().getType());
-                if (catchType == null || !catchType.equals(exception.getType())) {
-                    return false;
-                }
-
                 if (exception instanceof J.Identifier) {
                     return ((J.Identifier) exception).getSimpleName().equals(aCatch.getParameter().getTree().getVariables().get(0).getSimpleName());
                 }

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -165,14 +165,40 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                   }
               }
               """,
-              """
+            """
+            import java.io.FileReader;
+            import java.io.IOException;
+            import java.io.FileNotFoundException;
+              
+            class A {
+                void foo() throws IOException {
+                    new FileReader("").read();
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void multiCatchPreservedOnDifferentThrow() {
+        rewriteRun(
+          //language=java
+          java(
+            """
               import java.io.FileReader;
               import java.io.IOException;
               import java.io.FileNotFoundException;
-                
+              
               class A {
                   void foo() throws IOException {
-                      new FileReader("").read();
+                      try {
+                          new FileReader("").read();
+                      } catch (FileNotFoundException e) {
+                          throw e;
+                      } catch(IOException | ArrayIndexOutOfBoundsException e) {
+                          throw new IOException("another message", e);
+                      }
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -142,6 +142,45 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
+    void tryCanBeRemovedWithMultiCatch() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileReader;
+              import java.io.IOException;
+              import java.io.FileNotFoundException;
+              
+              class A {
+                  void foo() throws IOException {
+                      try {
+                          new FileReader("").read();
+                      } catch (FileNotFoundException e) {
+                          throw e;
+                      } catch(IOException | ArrayIndexOutOfBoundsException e) {
+                          throw e;
+                      } catch(Exception e) {
+                          throw e;
+                      }
+                  }
+              }
+              """,
+              """
+              import java.io.FileReader;
+              import java.io.IOException;
+              import java.io.FileNotFoundException;
+                
+              class A {
+                  void foo() throws IOException {
+                      new FileReader("").read();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void tryShouldBePreservedBecauseFinally() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

This pull request includes changes to the `CatchClauseOnlyRethrows` class and its corresponding test class to improve the handling of multi-catch blocks and simplify the code.

#### Improvements to `CatchClauseOnlyRethrows` class:

* [`src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java`](diffhunk://#diff-ec75c4b7b267bbb601fc5ec16f9ac13b68208977fb41bb14c51e0ae5d6ad719bL113-L117): Removed type checks for the caught exception and its type, simplifying the `onlyRethrows` method, and allowing multi catch statement to be correctly handeled.

#### Enhancements to test coverage:

* [`src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java`](diffhunk://#diff-09165a4b9dca9fbdf3d3e09ce293a6a3ceb8f699c25dd57dece3b667bec81789R144-R182): Added a new test case `tryCanBeRemovedWithMultiCatch` to ensure that try-catch blocks with multi catch exceptions are correctly handled and can be removed when appropriate.

## What's your motivation?
Consider the following input:
```java
class A {
  void foo() throws IOException {
      try {
          new FileReader("").read();
      } catch (FileNotFoundException e) {
          throw e;
      } catch(IOException | ArrayIndexOutOfBoundsException e) {
          throw e;
      }
  }
}
```
Currently, no suggestions are provided to remove the redundant catch (FileNotFoundException e) block. The issue stems from the `onlyRethrows` method not functioning correctly with multi-catch statements. For a `J.Try.Catch` the `onlyRethrows` method will perform the following check:

1. The catch body contains a single statement of type J.Throw.
2. The J.Throw exception type matches the catch parameter type.
3. The J.Throw statement contains an identifier that matches the catch parameter.


The problem lies with the second check. For catch (IOException e), the check passes since e is assigned to IOException. However, for catch (IOException | ArrayIndexOutOfBoundsException e), the type of e becomes Exception, causing the check to fail.

Fortunately, I believe the second check is unnecessary. If the throw contains only a single statement of type J.Throw (check 1), and this throws only contains a J.Identifier pointing to the catch parameter, there’s no chance of modifying e. Hence checking for type changes is not required. This change resolves the issue with multi-catch statements and improves method efficiency.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
