### PR TITLE
Revise inline variable

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -34,6 +34,7 @@ import static java.time.Duration.ofMinutes;
 import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.openrewrite.internal.ListUtils.concatAll;
 import static org.openrewrite.internal.ListUtils.map;
 
@@ -80,13 +81,14 @@ public class InlineVariable extends Recipe {
                         (VariableDeclarations) statements.get(statements.size() - 2)) : null;
     }
 
-    private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements, Block bl,
-                                                                final VariableDeclarations varDec) {
+    private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements,
+                                                                Block bl,
+                                                                VariableDeclarations varDec) {
         NamedVariable identDefinition = varDec.getVariables().get(0);
-        if (varDec.getLeadingAnnotations().isEmpty() && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))) {
-            return replaceStatements(bl, statements, identDefinition, varDec);
-        }
-        return null;
+        return isEmpty(varDec.getLeadingAnnotations())
+                && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))
+                ? replaceStatements(bl, statements, identDefinition, varDec)
+                : null;
     }
 
     private static Block replaceStatements(Block bl, List<Statement> statements,

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -88,12 +88,12 @@ public class InlineVariable extends Recipe {
         return null;
     }
 
-    private static Block replaceStatements(Block bl, List<Statement> statements,
-                i == statements.size() - 1 ? statement instanceof Return ?
-                        updateReturnStatement((Return) statement, identDefinition, varDec) :
-                        statement instanceof Throw ?
-                        updateThrowStatement((Throw) statement, identDefinition, varDec) :
-                        statement : statement));
+    private static @NotNull Block replaceStatements(Block bl, List<Statement> statements,
+                                                    NamedVariable identDefinition, VariableDeclarations varDec) {
+        return bl.withStatements(map(statements, (i, statement) -> i == statements.size() - 2 ? null :
+                i == statements.size() - 1 ? statement instanceof Return
+                        ? updateReturnStatement((Return) statement, identDefinition, varDec)
+                        : statement instanceof Throw
                         ? updateThrowStatement((Throw) statement, identDefinition, varDec)
                         : statement : statement));
     }

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -102,18 +102,26 @@ public class InlineVariable extends Recipe {
 
             private @Nullable String identReturned(List<Statement> stats) {
                 Statement lastStatement = stats.get(stats.size() - 1);
-                if (lastStatement instanceof J.Return) {
-                    J.Return return_ = (J.Return) lastStatement;
-                    Expression expression = return_.getExpression();
-                    if (expression instanceof J.Identifier &&
-                        !(expression.getType() instanceof JavaType.Array)) {
-                        return ((J.Identifier) expression).getSimpleName();
-                    }
+                if (lastStatement instanceof J.Return ) {
+                    return Return((J.Return) lastStatement);
                 } else if (lastStatement instanceof J.Throw) {
-                    J.Throw thr = (J.Throw) lastStatement;
-                    if (thr.getException() instanceof J.Identifier) {
-                        return ((J.Identifier) thr.getException()).getSimpleName();
-                    }
+                    return Throw((J.Throw) lastStatement);
+                }
+                return null;
+            }
+
+            private @org.jetbrains.annotations.Nullable String Throw(final J.Throw lastStatement) {
+                if (lastStatement.getException() instanceof J.Identifier) {
+                    return ((J.Identifier) lastStatement.getException()).getSimpleName();
+                }
+                return null;
+            }
+
+            private @org.jetbrains.annotations.Nullable String Return(final J.Return lastStatement) {
+                Expression expression = lastStatement.getExpression();
+                if (expression instanceof J.Identifier &&
+                    !(expression.getType() instanceof JavaType.Array)) {
+                    return ((J.Identifier) expression).getSimpleName();
                 }
                 return null;
             }

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.collect.Iterables.isEmpty;
 import static java.time.Duration.ofMinutes;
 import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
@@ -75,17 +76,18 @@ public class InlineVariable extends Recipe {
     }
 
     private static @Nullable Block getBlock(List<Statement> statements, Block bl) {
-        return statements.get(statements.size() - 2) instanceof VariableDeclarations ?
-                getVariableDeclarationsBlock(statements, bl) : null;
+        return statements.get(statements.size() - 2) instanceof VariableDeclarations
+                ? getVariableDeclarationsBlock(statements, bl)
+                : null;
     }
 
     private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements, Block bl) {
         VariableDeclarations varDec = (VariableDeclarations) statements.get(statements.size() - 2);
         NamedVariable identDefinition = varDec.getVariables().get(0);
-        if (varDec.getLeadingAnnotations().isEmpty() && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))) {
-            return replaceStatements(bl, statements, identDefinition, varDec);
-        }
-        return null;
+        return isEmpty(varDec.getLeadingAnnotations())
+                && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))
+                ? replaceStatements(bl, statements, identDefinition, varDec)
+                : null;
     }
 
     private static Block replaceStatements(Block bl, List<Statement> statements,

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -88,8 +88,8 @@ public class InlineVariable extends Recipe {
         return null;
     }
 
-    private static @NotNull Block replaceStatements(Block bl, List<Statement> statements,
-                                                    NamedVariable identDefinition, VariableDeclarations varDec) {
+    private static Block replaceStatements(Block bl, List<Statement> statements,
+                                           NamedVariable identDefinition, VariableDeclarations varDec) {
         return bl.withStatements(map(statements, (i, statement) -> i == statements.size() - 2 ? null :
                 i == statements.size() - 1 ? statement instanceof Return
                         ? updateReturnStatement((Return) statement, identDefinition, varDec)

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -88,17 +88,12 @@ public class InlineVariable extends Recipe {
 
     private static @NotNull Block replaceStatements(Block bl, List<Statement> statements,
                                                     NamedVariable identDefinition, VariableDeclarations varDec) {
-        return bl.withStatements(map(statements, (i, statement) -> {
-            if (i == statements.size() - 2) return null; // Remove the variable declaration
-            if (i == statements.size() - 1) { // Last statement (return or throw)
-                return statement instanceof Return
-                        ? updateReturnStatement((Return) statement, identDefinition, varDec)
-                        : statement instanceof Throw
-                        ? updateThrowStatement((Throw) statement, identDefinition, varDec)
-                        : statement;
-            }
-            return statement;
-        }));
+        return bl.withStatements(map(statements, (i, statement) -> i == statements.size() - 2 ? null :
+                i == statements.size() - 1 ? statement instanceof Return
+                ? updateReturnStatement((Return) statement, identDefinition, varDec)
+                : statement instanceof Throw
+                ? updateThrowStatement((Throw) statement, identDefinition, varDec)
+                : statement : statement));
     }
 
     private static Return updateReturnStatement(Return returnStmt, NamedVariable identDefinition,

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -88,12 +88,12 @@ public class InlineVariable extends Recipe {
         return null;
     }
 
-    private static @NotNull Block replaceStatements(Block bl, List<Statement> statements,
-                                                    NamedVariable identDefinition, VariableDeclarations varDec) {
-        return bl.withStatements(map(statements, (i, statement) -> i == statements.size() - 2 ? null :
-                i == statements.size() - 1 ? statement instanceof Return
-                        ? updateReturnStatement((Return) statement, identDefinition, varDec)
-                        : statement instanceof Throw
+    private static Block replaceStatements(Block bl, List<Statement> statements,
+                i == statements.size() - 1 ? statement instanceof Return ?
+                        updateReturnStatement((Return) statement, identDefinition, varDec) :
+                        statement instanceof Throw ?
+                        updateThrowStatement((Throw) statement, identDefinition, varDec) :
+                        statement : statement));
                         ? updateThrowStatement((Throw) statement, identDefinition, varDec)
                         : statement : statement));
     }

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -76,14 +76,16 @@ public class InlineVariable extends Recipe {
     }
 
     private static @Nullable Block getBlock(List<Statement> statements, Block bl) {
-        if (statements.get(statements.size() - 2) instanceof VariableDeclarations) {
-            VariableDeclarations varDec = (VariableDeclarations) statements.get(statements.size() - 2);
-            NamedVariable identDefinition = varDec.getVariables().get(0);
-            if (varDec.getLeadingAnnotations().isEmpty() && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))) {
-                return replaceStatements(bl, statements, identDefinition, varDec);
-            }
+        return statements.get(statements.size() - 2) instanceof VariableDeclarations ? getJ(statements, bl) : null;
+    }
+
+    private static @Nullable Block getJ(final List<Statement> statements, final Block bl) {
+        VariableDeclarations varDec = (VariableDeclarations) statements.get(statements.size() - 2);
+        NamedVariable identDefinition = varDec.getVariables().get(0);
+        if (varDec.getLeadingAnnotations().isEmpty() && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))) {
+            return replaceStatements(bl, statements, identDefinition, varDec);
         }
-        return null; // no found
+        return null;
     }
 
     private static @NotNull Block replaceStatements(Block bl, List<Statement> statements,

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -88,7 +88,7 @@ public class InlineVariable extends Recipe {
                 return replaceStatements(bl, statements, identDefinition, varDec);
             }
         }
-        return null;
+        return null; // no block found
     }
 
     private static J.@NotNull Block replaceStatements(J.Block bl, List<Statement> statements,
@@ -122,7 +122,7 @@ public class InlineVariable extends Recipe {
                         throwStmt.getComments())));
     }
 
-    private static String identReturned(Statement lastStatement) {
+    private static @Nullable String identReturned(Statement lastStatement) {
         return (lastStatement instanceof Return)
                 ? extractIdentifierFromReturn((Return) lastStatement)
                 : (lastStatement instanceof Throw)
@@ -130,13 +130,13 @@ public class InlineVariable extends Recipe {
                 : null;
     }
 
-    private static String extractIdentifierFromThrow(final Throw lastStatement) {
+    private static @Nullable String extractIdentifierFromThrow(final Throw lastStatement) {
         return (lastStatement.getException() instanceof Identifier)
                 ? ((Identifier) lastStatement.getException()).getSimpleName()
                 : null;
     }
 
-    private static String extractIdentifierFromReturn(final Return lastStatement) {
+    private static @Nullable String extractIdentifierFromReturn(final Return lastStatement) {
         Expression expression = lastStatement.getExpression();
         return (expression instanceof Identifier && !(expression.getType() instanceof JavaType.Array))
                 ? ((Identifier) expression).getSimpleName()

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -101,8 +101,7 @@ public class InlineVariable extends Recipe {
 
     private static Return updateReturnStatement(Return returnStmt, NamedVariable identDefinition,
                                                 VariableDeclarations varDec) {
-        return returnStmt
-                .withExpression(requireNonNull(identDefinition.getInitializer())
+        return returnStmt.withExpression(requireNonNull(identDefinition.getInitializer())
                         .withPrefix(requireNonNull(returnStmt.getExpression()).getPrefix()))
                 .withPrefix(varDec.getPrefix().withComments(concatAll(varDec.getComments(), returnStmt.getComments())));
     }

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -1,18 +1,19 @@
 /*
  * Copyright 2022 the original author or authors.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.openrewrite.staticanalysis;
 
 import org.openrewrite.ExecutionContext;
@@ -38,16 +39,25 @@ import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.openrewrite.internal.ListUtils.concatAll;
 import static org.openrewrite.internal.ListUtils.map;
 
+/**
+ * Inlines variables that are immediately used in return or throw statements.
+ *
+ * <p>This transformation simplifies code by removing unnecessary variable
+ * declarations, improving readability and potentially reducing memory usage.</p>
+ *
+ * <p>For more information, see the rule details at:
+ * <a href="https://sonarsource.github.io/rspec/#/rspec/S1488/java">SonarSource RSPEC-S1488</a>.</p>
+ */
 public class InlineVariable extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Inline variable";
+        return "Inline Variable";
     }
 
     @Override
     public String getDescription() {
-        return "Inline variables when they are immediately used to return or throw.";
+        return "Inlines variables when they are immediately used in return or throw statements.";
     }
 
     @Override
@@ -67,6 +77,7 @@ public class InlineVariable extends Recipe {
             public Block visitBlock(Block block, ExecutionContext ctx) {
                 Block superBlock = super.visitBlock(block, ctx);
                 List<Statement> statements = superBlock.getStatements();
+                // Only consider blocks with more than one statement for inlining.
                 if (statements.size() > 1) {
                     return requireNonNull(defaultIfNull(getBlock(statements, superBlock), superBlock));
                 }
@@ -75,18 +86,44 @@ public class InlineVariable extends Recipe {
         };
     }
 
+    /**
+     * Checks the last two statements in the block to see if they consist of variable declarations
+     * followed by a return or throw statement. If so, it returns the modified block with inlined
+     * variables.
+     *
+     * @param statements The list of statements in the block.
+     * @param bl         The original block.
+     * @return The modified block with inlined variables, or null if conditions aren't met.
+     */
     private static @Nullable Block getBlock(List<Statement> statements, Block bl) {
         return statements.get(statements.size() - 2) instanceof VariableDeclarations ?
                 getVariableDeclarationsBlock(statements, bl,
                         (VariableDeclarations) statements.get(statements.size() - 2)) : null;
     }
 
+    /**
+     * Examines variable declarations to determine if they can be inlined.
+     *
+     * @param statements The list of statements in the block.
+     * @param bl         The original block.
+     * @param varDec     The variable declarations to be examined.
+     * @return The modified block with inlined variables, or null if conditions aren't met.
+     */
     private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements,
                                                                 Block bl,
                                                                 VariableDeclarations varDec) {
         return getVariableDeclarationsBlock(statements, bl, varDec, varDec.getVariables().get(0));
     }
 
+    /**
+     * Determines if the variable declaration is eligible for inlining based on its usage.
+     *
+     * @param statements      The list of statements in the block.
+     * @param bl              The original block.
+     * @param varDec          The variable declarations to be examined.
+     * @param identDefinition The identifier of the variable.
+     * @return The modified block with inlined variables, or null if conditions aren't met.
+     */
     private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements, Block bl,
                                                                 VariableDeclarations varDec,
                                                                 NamedVariable identDefinition) {
@@ -96,6 +133,15 @@ public class InlineVariable extends Recipe {
                 : null;
     }
 
+    /**
+     * Replaces the variable declaration and its usage with the actual value.
+     *
+     * @param bl              The original block.
+     * @param statements      The list of statements in the block.
+     * @param identDefinition The identifier of the variable.
+     * @param varDec          The variable declarations being replaced.
+     * @return The modified block with the inlined variables.
+     */
     private static Block replaceStatements(Block bl, List<Statement> statements,
                                            NamedVariable identDefinition, VariableDeclarations varDec) {
         return bl.withStatements(map(statements, (i, statement) -> i == statements.size() - 2 ? null :
@@ -106,6 +152,14 @@ public class InlineVariable extends Recipe {
                         : statement : statement));
     }
 
+    /**
+     * Updates a return statement to use the actual expression instead of the variable.
+     *
+     * @param returnStmt      The original return statement.
+     * @param identDefinition The identifier of the variable.
+     * @param varDec          The variable declarations being replaced.
+     * @return The updated return statement.
+     */
     private static Return updateReturnStatement(Return returnStmt, NamedVariable identDefinition,
                                                 VariableDeclarations varDec) {
         return returnStmt.withExpression(requireNonNull(identDefinition.getInitializer())
@@ -113,6 +167,14 @@ public class InlineVariable extends Recipe {
                 .withPrefix(varDec.getPrefix().withComments(concatAll(varDec.getComments(), returnStmt.getComments())));
     }
 
+    /**
+     * Updates a throw statement to use the actual exception instead of the variable.
+     *
+     * @param throwStmt       The original throw statement.
+     * @param identDefinition The identifier of the variable.
+     * @param varDec          The variable declarations being replaced.
+     * @return The updated throw statement.
+     */
     private static Throw updateThrowStatement(Throw throwStmt, NamedVariable identDefinition,
                                               VariableDeclarations varDec) {
         return throwStmt.withException(requireNonNull(identDefinition.getInitializer())
@@ -120,6 +182,12 @@ public class InlineVariable extends Recipe {
                 .withPrefix(varDec.getPrefix().withComments(concatAll(varDec.getComments(), throwStmt.getComments())));
     }
 
+    /**
+     * Extracts the identifier returned in the last statement if applicable.
+     *
+     * @param lastStatement The last statement in the block.
+     * @return The identifier as a string, or null if not applicable.
+     */
     private static @Nullable String identReturned(Statement lastStatement) {
         return (lastStatement instanceof Return)
                 ? extractIdentifierFromReturn(((Return) lastStatement).getExpression())
@@ -128,12 +196,24 @@ public class InlineVariable extends Recipe {
                 : null;
     }
 
+    /**
+     * Extracts the identifier from a throw statement.
+     *
+     * @param lastStatement The throw statement to extract from.
+     * @return The identifier as a string, or null if not applicable.
+     */
     private static @Nullable String extractIdentifierFromThrow(Throw lastStatement) {
         return (lastStatement.getException() instanceof Identifier)
                 ? ((Identifier) lastStatement.getException()).getSimpleName()
                 : null;
     }
 
+    /**
+     * Extracts the identifier from a return expression.
+     *
+     * @param expression The expression to extract from.
+     * @return The identifier as a string, or null if not applicable.
+     */
     private static @Nullable String extractIdentifierFromReturn(@Nullable Expression expression) {
         return (expression instanceof Identifier && !(expression.getType() instanceof JavaType.Array))
                 ? ((Identifier) expression).getSimpleName()

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -76,11 +76,12 @@ public class InlineVariable extends Recipe {
 
     private static @Nullable Block getBlock(List<Statement> statements, Block bl) {
         return statements.get(statements.size() - 2) instanceof VariableDeclarations ?
-                getVariableDeclarationsBlock(statements, bl) : null;
+                getVariableDeclarationsBlock(statements, bl,
+                        (VariableDeclarations) statements.get(statements.size() - 2)) : null;
     }
 
-    private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements, Block bl) {
-        VariableDeclarations varDec = (VariableDeclarations) statements.get(statements.size() - 2);
+    private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements, Block bl,
+                                                                final VariableDeclarations varDec) {
         NamedVariable identDefinition = varDec.getVariables().get(0);
         if (varDec.getLeadingAnnotations().isEmpty() && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))) {
             return replaceStatements(bl, statements, identDefinition, varDec);

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
-import static com.google.common.collect.Iterables.isEmpty;
 import static java.time.Duration.ofMinutes;
 import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
@@ -76,18 +75,17 @@ public class InlineVariable extends Recipe {
     }
 
     private static @Nullable Block getBlock(List<Statement> statements, Block bl) {
-        return statements.get(statements.size() - 2) instanceof VariableDeclarations
-                ? getVariableDeclarationsBlock(statements, bl)
-                : null;
+        return statements.get(statements.size() - 2) instanceof VariableDeclarations ?
+                getVariableDeclarationsBlock(statements, bl) : null;
     }
 
     private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements, Block bl) {
         VariableDeclarations varDec = (VariableDeclarations) statements.get(statements.size() - 2);
         NamedVariable identDefinition = varDec.getVariables().get(0);
-        return isEmpty(varDec.getLeadingAnnotations())
-                && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))
-                ? replaceStatements(bl, statements, identDefinition, varDec)
-                : null;
+        if (varDec.getLeadingAnnotations().isEmpty() && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))) {
+            return replaceStatements(bl, statements, identDefinition, varDec);
+        }
+        return null;
     }
 
     private static Block replaceStatements(Block bl, List<Statement> statements,

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -52,7 +52,7 @@ public class InlineVariable extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Inline Variable";
+        return "Inline variable";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -72,7 +72,7 @@ public class InlineVariable extends Recipe {
                 J.Block bl = super.visitBlock(block, ctx);
                 List<Statement> statements = bl.getStatements();
                 if (statements.size() > 1) {
-                    String identReturned = identReturned(statements);
+                    String identReturned = identReturned(statements.get(statements.size() - 1));
                     if (nonNull(identReturned) && statements.get(statements.size() - 2) instanceof VariableDeclarations) {
                         VariableDeclarations varDec = (VariableDeclarations) statements.get(statements.size() - 2);
                         NamedVariable identDefinition = varDec.getVariables().get(0);
@@ -110,29 +110,26 @@ public class InlineVariable extends Recipe {
         }));
     }
 
-    private @Nullable String identReturned(List<Statement> stats) {
-        Statement lastStatement = stats.get(stats.size() - 1);
-        if (lastStatement instanceof Return) {
-            return Return((Return) lastStatement);
-        } else if (lastStatement instanceof Throw) {
-            return Throw((Throw) lastStatement);
-        }
-        return null;
+    private @Nullable String identReturned(Statement lastStatement) {
+        return (lastStatement instanceof Return)
+                ? Return((Return) lastStatement)
+                : (lastStatement instanceof Throw)
+                ? Throw((Throw) lastStatement)
+                : null;
     }
 
+
     private @org.jetbrains.annotations.Nullable String Throw(final Throw lastStatement) {
-        if (lastStatement.getException() instanceof Identifier) {
-            return ((Identifier) lastStatement.getException()).getSimpleName();
-        }
-        return null;
+        return (lastStatement.getException() instanceof Identifier)
+                ? ((Identifier) lastStatement.getException()).getSimpleName()
+                : null;
     }
 
     private @org.jetbrains.annotations.Nullable String Return(final Return lastStatement) {
         Expression expression = lastStatement.getExpression();
-        if (expression instanceof Identifier &&
-                !(expression.getType() instanceof JavaType.Array)) {
-            return ((Identifier) expression).getSimpleName();
-        }
-        return null;
+        return (expression instanceof Identifier && !(expression.getType() instanceof JavaType.Array))
+                ? ((Identifier) expression).getSimpleName()
+                : null;
     }
+
 }

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -77,8 +77,7 @@ public class InlineVariable extends Recipe {
             public Block visitBlock(Block block, ExecutionContext ctx) {
                 Block superBlock = super.visitBlock(block, ctx);
                 List<Statement> statements = superBlock.getStatements();
-                // Only consider blocks with more than one statement for inlining.
-                if (statements.size() > 1) {
+                if (statements.size() > 1) { // Only consider blocks with more than one statement
                     return requireNonNull(defaultIfNull(getBlock(statements, superBlock), superBlock));
                 }
                 return superBlock;

--- a/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InlineVariable.java
@@ -76,10 +76,11 @@ public class InlineVariable extends Recipe {
     }
 
     private static @Nullable Block getBlock(List<Statement> statements, Block bl) {
-        return statements.get(statements.size() - 2) instanceof VariableDeclarations ? getJ(statements, bl) : null;
+        return statements.get(statements.size() - 2) instanceof VariableDeclarations ?
+                getVariableDeclarationsBlock(statements, bl) : null;
     }
 
-    private static @Nullable Block getJ(final List<Statement> statements, final Block bl) {
+    private static @Nullable Block getVariableDeclarationsBlock(List<Statement> statements, Block bl) {
         VariableDeclarations varDec = (VariableDeclarations) statements.get(statements.size() - 2);
         NamedVariable identDefinition = varDec.getVariables().get(0);
         if (varDec.getLeadingAnnotations().isEmpty() && identDefinition.getSimpleName().equals(identReturned(statements.get(statements.size() - 1)))) {


### PR DESCRIPTION
# Inline Code for SRP and Clean Code Principles

This document outlines the **Single Responsibility Principle (SRP)** and clean code principles, emphasizing a compact writing style.

### Extended Guideline

In addition to existing guidelines, we propose another rule: **Inline single-use variables**. When a variable is declared but only used once, it adds unnecessary clutter. Therefore, we recommend inlining such variables to promote cleaner and more readable code. The goal is to streamline the implementation to be direct and simple.

### Code Examples

Here are some examples demonstrating these principles:

```javascript
const calculateArea = () => {
    const length = 1; 
    const width = 2; 
    const area = length + width; 
    return area; 
};

const calculateAreaWithParams = () => {
    const length = 1; 
    const width = 2; 
    return length + width; 
};

const calculateAreaInline = () => {
    return 1 + 2; 
};

// Improved version with inlined single-use variables
const calculateAreaImproved = () => {
    return 1 + 2; // Length and width inlined
};
