### PR TITLE
Add `AnnotateNullableMethods` recipe

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -33,11 +33,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AnnotateNullableMethods extends Recipe {
-    private static final String NULLABLE_ANN_PACKAGE = "org.jspecify.annotations";
-    private static final String NULLABLE_ANN_CLASS = NULLABLE_ANN_PACKAGE + ".Nullable";
+    private static final String NULLABLE_ANN_CLASS = "org.jspecify.annotations.Nullable";
     private static final AnnotationMatcher NULLABLE_ANNOTATION_MATCHER =
             new AnnotationMatcher("@" + NULLABLE_ANN_CLASS);
-    private static final String NULLABLE_ANN_ARTIFACT = "jspecify";
 
     @Override
     public String getDisplayName() {
@@ -62,7 +60,7 @@ public class AnnotateNullableMethods extends Recipe {
     private static class AnnotateNullableMethodsVisitor extends JavaIsoVisitor<ExecutionContext> {
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
-            if (md.hasModifier(J.Modifier.Type.Private)) {
+            if (!md.hasModifier(J.Modifier.Type.Public)) {
                 return md;
             }
 
@@ -81,7 +79,7 @@ public class AnnotateNullableMethods extends Recipe {
                 maybeAddImport(NULLABLE_ANN_CLASS);
                 return JavaTemplate.builder("@Nullable")
                         .imports(NULLABLE_ANN_CLASS)
-                        .javaParser(JavaParser.fromJavaVersion().classpath(NULLABLE_ANN_ARTIFACT))
+                        .javaParser(JavaParser.fromJavaVersion().classpath("jspecify"))
                         .build()
                         .apply(getCursor(), md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
             }

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -45,11 +45,11 @@ public class AnnotateNullableMethods extends Recipe {
     @Override
     public String getDescription() {
         return "Automatically adds the @org.jspecify.annotation.Nullable to non-private methods" +
-                "that may return null. This recipe scans for methods that do not already have a @Nullable" +
-                "annotation and checks their return statements for potential null values. It also" +
-                "identifies known methods from standard libraries that may return null, such as methods" +
-                "from Map, Queue, Deque, NavigableSet, and Spliterator. The return of streams, or lambdas" +
-                " are not taken into account.";
+               "that may return null. This recipe scans for methods that do not already have a @Nullable" +
+               "annotation and checks their return statements for potential null values. It also" +
+               "identifies known methods from standard libraries that may return null, such as methods" +
+               "from Map, Queue, Deque, NavigableSet, and Spliterator. The return of streams, or lambdas" +
+               " are not taken into account.";
     }
 
     @Override
@@ -58,6 +58,7 @@ public class AnnotateNullableMethods extends Recipe {
     }
 
     private static class AnnotateNullableMethodsVisitor extends JavaIsoVisitor<ExecutionContext> {
+
         AtomicBoolean annotatedNullable = new AtomicBoolean(false);
 
         @Override
@@ -94,6 +95,7 @@ public class AnnotateNullableMethods extends Recipe {
 
     @AllArgsConstructor
     private static class FindNullableReturnStatements extends JavaIsoVisitor<AtomicBoolean> {
+
         private static final List<MethodMatcher> KNOWN_NULLABLE_METHODS = getMatchersKnownNullableMethods();
 
         static AtomicBoolean find(J subtree) {

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -42,12 +42,11 @@ public class AnnotateNullableMethods extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Automatically adds the `@org.jspecify.annotation.Nullable` to non-private methods " +
-               "that may return `null`. This recipe scans for methods that do not already have a `@Nullable` " +
-               "annotation and checks their return statements for potential null values. It also " +
-               "identifies known methods from standard libraries that may return null, such as methods " +
-               "from `Map`, `Queue`, `Deque`, `NavigableSet`, and `Spliterator`. The return of streams, or lambdas " +
-               "are not taken into account.";
+        return "Add the `@org.jspecify.annotation.Nullable` to non-private methods that may return `null`. " +
+               "This recipe scans for methods that do not already have a `@Nullable` annotation and checks their return " +
+               "statements for potential null values. It also identifies known methods from standard libraries that may " +
+               "return null, such as methods from `Map`, `Queue`, `Deque`, `NavigableSet`, and `Spliterator`. " +
+               "The return of streams, or lambdas are not taken into account.";
     }
 
     @Override
@@ -63,7 +62,7 @@ public class AnnotateNullableMethods extends Recipe {
                 }
 
                 J.MethodDeclaration md = super.visitMethodDeclaration(methodDeclaration, ctx);
-                if (FindNullableReturnStatements.find(md)) {
+                if (FindNullableReturnStatements.find(md.getBody())) {
                     maybeAddImport(NULLABLE_ANN_CLASS);
                     J.MethodDeclaration annotatedMethod = JavaTemplate.builder("@Nullable")
                             .imports(NULLABLE_ANN_CLASS)
@@ -118,7 +117,7 @@ public class AnnotateNullableMethods extends Recipe {
                 new MethodMatcher("java.util.Spliterator trySplit(..)")
         );
 
-        static boolean find(J subtree) {
+        static boolean find(@Nullable J subtree) {
             return new FindNullableReturnStatements().reduce(subtree, new AtomicBoolean()).get();
         }
 

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.*;
+import org.openrewrite.java.service.AnnotationService;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AnnotateNullableMethods extends Recipe {
+    private static final String NULLABLE_ANN_PACKAGE = "org.jspecify.annotations";
+    private static final String NULLABLE_ANN_CLASS = NULLABLE_ANN_PACKAGE + ".Nullable";
+    private static final AnnotationMatcher NULLABLE_ANNOTATION_MATCHER =
+            new AnnotationMatcher("@" + NULLABLE_ANN_CLASS);
+    private static final String NULLABLE_ANN_ARTIFACT = "jspecify";
+
+    @Override
+    public String getDisplayName() {
+        return "Annotate methods which may return null with @Nullable";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Automatically adds the @org.jspecify.annotation.Nullable to non-private methods" +
+                "that may return null. This recipe scans for methods that do not already have a @Nullable" +
+                "annotation and checks their return statements for potential null values. It also" +
+                "identifies known methods from standard libraries that may return null, such as methods" +
+                "from Map, Queue, Deque, NavigableSet, and Spliterator. The return of streams, or lambdas" +
+                " are not taken into account.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AnnotateNullableMethodsVisitor();
+    }
+
+    private static class AnnotateNullableMethodsVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
+            if (md.hasModifier(J.Modifier.Type.Private)) {
+                return md;
+            }
+
+            if (md.getMethodType() != null && md.getMethodType().getReturnType() instanceof JavaType.Primitive) {
+                return md;
+            }
+
+            if (service(AnnotationService.class).matches(getCursor(), NULLABLE_ANNOTATION_MATCHER)) {
+                return md;
+            }
+
+            md = super.visitMethodDeclaration(md, ctx);
+            updateCursor(md);
+
+            if (FindNullableReturnStatements.find(md).get()) {
+                maybeAddImport(NULLABLE_ANN_CLASS);
+                return JavaTemplate.builder("@Nullable")
+                        .imports(NULLABLE_ANN_CLASS)
+                        .javaParser(JavaParser.fromJavaVersion().classpath(NULLABLE_ANN_ARTIFACT))
+                        .build()
+                        .apply(getCursor(), md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+            }
+            return md;
+        }
+    }
+
+    @AllArgsConstructor
+    private static class FindNullableReturnStatements extends JavaIsoVisitor<AtomicBoolean> {
+        private static final List<MethodMatcher> KNOWN_NULLABLE_METHODS = getMatchersKnownNullableMethods();
+
+        static AtomicBoolean find(J subtree) {
+            return new FindNullableReturnStatements().reduce(subtree, new AtomicBoolean());
+        }
+
+        private static List<MethodMatcher> getMatchersKnownNullableMethods() {
+            List<MethodMatcher> matchers = new ArrayList<>();
+
+            matchers.add(new MethodMatcher("java.util.Map compute(..)"));
+            matchers.add(new MethodMatcher("java.util.Map computeIfAbsent(..)"));
+            matchers.add(new MethodMatcher("java.util.Map computeIfPresent(..)"));
+            matchers.add(new MethodMatcher("java.util.Map get(..)"));
+            matchers.add(new MethodMatcher("java.util.Map merge(..)"));
+            matchers.add(new MethodMatcher("java.util.Map put(..)"));
+            matchers.add(new MethodMatcher("java.util.Map putIfAbsent(..)"));
+
+            matchers.add(new MethodMatcher("java.util.Queue poll(..)"));
+            matchers.add(new MethodMatcher("java.util.Queue peek(..)"));
+
+            matchers.add(new MethodMatcher("java.util.Deque peekFirst(..)"));
+            matchers.add(new MethodMatcher("java.util.Deque pollFirst(..)"));
+            matchers.add(new MethodMatcher("java.util.Deque peekLast(..)"));
+
+            matchers.add(new MethodMatcher("java.util.NavigableSet lower(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableSet floor(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableSet ceiling(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableSet higher(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableSet pollFirst(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableSet pollLast(..)"));
+
+            matchers.add(new MethodMatcher("java.util.NavigableMap lowerEntry(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap floorEntry(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap ceilingEntry(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap higherEntry(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap lowerKey(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap floorKey(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap ceilingKey(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap higherKey(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap firstEntry(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap lastEntry(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap pollFirstEntry(..)"));
+            matchers.add(new MethodMatcher("java.util.NavigableMap pollLastEntry(..)"));
+
+            matchers.add(new MethodMatcher("java.util.Spliterator trySplit(..)"));
+
+            return Collections.unmodifiableList(matchers);
+        }
+
+        @Override
+        public J.Return visitReturn(J.Return retrn, AtomicBoolean containsNullableReturn) {
+            if (containsNullableReturn.get()) {
+                return retrn;
+            }
+
+            J.Return r = super.visitReturn(retrn, containsNullableReturn);
+            updateCursor(r);
+
+            // If the returns is contained within a lambda statement, we don't consider it.
+            Cursor ex = getCursor().dropParentUntil(e -> e instanceof J.MethodDeclaration || e instanceof J.Lambda);
+            if (!(ex.getValue() instanceof J.MethodDeclaration)) {
+                return r;
+            }
+
+            if (r.getExpression() != null && maybeIsNull(r.getExpression())) {
+                containsNullableReturn.set(true);
+            }
+
+            return r;
+        }
+
+        private boolean maybeIsNull(Expression returnExpression) {
+            if (returnExpression instanceof J.Literal && ((J.Literal) returnExpression).getValue() == null) {
+                return true;
+            } else if (returnExpression instanceof J.MethodInvocation) {
+                return isKnowNullableMethod((J.MethodInvocation) returnExpression);
+            }
+            return false;
+        }
+
+        private boolean isKnowNullableMethod(J.MethodInvocation methodInvocation) {
+            for (MethodMatcher m : KNOWN_NULLABLE_METHODS) {
+                if (m.matches(methodInvocation)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -62,7 +63,8 @@ public class AnnotateNullableMethods extends Recipe {
                 }
 
                 J.MethodDeclaration md = super.visitMethodDeclaration(methodDeclaration, ctx);
-                if (FindNullableReturnStatements.find(md.getBody())) {
+                updateCursor(md);
+                if (FindNullableReturnStatements.find(md.getBody(), getCursor().getParentTreeCursor())) {
                     maybeAddImport(NULLABLE_ANN_CLASS);
                     J.MethodDeclaration annotatedMethod = JavaTemplate.builder("@Nullable")
                             .imports(NULLABLE_ANN_CLASS)
@@ -117,8 +119,8 @@ public class AnnotateNullableMethods extends Recipe {
                 new MethodMatcher("java.util.Spliterator trySplit(..)")
         );
 
-        static boolean find(@Nullable J subtree) {
-            return new FindNullableReturnStatements().reduce(subtree, new AtomicBoolean()).get();
+        static boolean find(@Nullable J subtree, Cursor parentTreeCursor) {
+            return new FindNullableReturnStatements().reduce(subtree, new AtomicBoolean(), parentTreeCursor).get();
         }
 
         @Override

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -66,13 +66,12 @@ public class AnnotateNullableMethods extends Recipe {
                 J.MethodDeclaration md = super.visitMethodDeclaration(methodDeclaration, ctx);
                 updateCursor(md);
                 if (FindNullableReturnStatements.find(md.getBody(), getCursor().getParentTreeCursor())) {
-                    maybeAddImport(NULLABLE_ANN_CLASS);
-                    J.MethodDeclaration annotatedMethod = JavaTemplate.builder("@Nullable")
-                            .imports(NULLABLE_ANN_CLASS)
+                    J.MethodDeclaration annotatedMethod = JavaTemplate.builder("@" + NULLABLE_ANN_CLASS)
                             .javaParser(JavaParser.fromJavaVersion().dependsOn(
                                     "package org.jspecify.annotations;public @interface Nullable {}"))
                             .build()
                             .apply(getCursor(), md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
                     return (J.MethodDeclaration) new NullableOnMethodReturnType().getVisitor().visitNonNull(annotatedMethod, ctx, getCursor().getParentTreeCursor());
                 }
                 return md;

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -16,7 +16,9 @@
 package org.openrewrite.staticanalysis;
 
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.*;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.Expression;

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -59,7 +59,8 @@ public class AnnotateNullableMethods extends Recipe {
                     methodDeclaration.getMethodType() == null ||
                     methodDeclaration.getMethodType().getReturnType() instanceof JavaType.Primitive ||
                     service(AnnotationService.class).matches(getCursor(), NULLABLE_ANNOTATION_MATCHER) ||
-                    service(AnnotationService.class).matches(new Cursor(null, methodDeclaration.getReturnTypeExpression()), NULLABLE_ANNOTATION_MATCHER)) {
+                    (methodDeclaration.getReturnTypeExpression() != null &&
+                    service(AnnotationService.class).matches(new Cursor(null, methodDeclaration.getReturnTypeExpression()), NULLABLE_ANNOTATION_MATCHER))) {
                     return methodDeclaration;
                 }
 

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -61,8 +61,6 @@ public class AnnotateNullableMethods extends Recipe {
                 }
 
                 J.MethodDeclaration md = super.visitMethodDeclaration(methodDeclaration, ctx);
-                updateCursor(md);
-
                 if (FindNullableReturnStatements.find(md)) {
                     maybeAddImport(NULLABLE_ANN_CLASS);
                     J.MethodDeclaration annotatedMethod = JavaTemplate.builder("@Nullable")

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -71,7 +71,7 @@ public class AnnotateNullableMethods extends Recipe {
                                     "package org.jspecify.annotations;public @interface Nullable {}"))
                             .build()
                             .apply(getCursor(), md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
-                    doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                    doAfterVisit(ShortenFullyQualifiedTypeReferences.modifyOnly(annotatedMethod));
                     return (J.MethodDeclaration) new NullableOnMethodReturnType().getVisitor().visitNonNull(annotatedMethod, ctx, getCursor().getParentTreeCursor());
                 }
                 return md;

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -58,7 +58,8 @@ public class AnnotateNullableMethods extends Recipe {
                 if (!methodDeclaration.hasModifier(J.Modifier.Type.Public) ||
                     methodDeclaration.getMethodType() == null ||
                     methodDeclaration.getMethodType().getReturnType() instanceof JavaType.Primitive ||
-                    service(AnnotationService.class).matches(getCursor(), NULLABLE_ANNOTATION_MATCHER)) {
+                    service(AnnotationService.class).matches(getCursor(), NULLABLE_ANNOTATION_MATCHER) ||
+                    service(AnnotationService.class).matches(new Cursor(null, methodDeclaration.getReturnTypeExpression()), NULLABLE_ANNOTATION_MATCHER)) {
                     return methodDeclaration;
                 }
 

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -232,4 +232,21 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void returnStaticNestInnerClassAnnotation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.jspecify.annotations.Nullable;
+              
+              public class Outer {     
+                  public static Outer.@Nullable Inner test() { return null; }
+                  static class Inner {}
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 class AnnotateNullableMethodsTest implements RewriteTest {
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new AnnotateNullableMethods()).parser(JavaParser.fromJavaVersion().classpath("jspecify"));
@@ -38,7 +39,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           java(
             """
               public class Test {
-    
+              
                   public String getString() {
                       return null;
                   }
@@ -54,8 +55,8 @@ class AnnotateNullableMethodsTest implements RewriteTest {
             """
               import org.jspecify.annotations.Nullable;
               
-              public class Test {      
-    
+              public class Test {
+              
                   public @Nullable String getString() {
                       return null;
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -27,14 +27,15 @@ class AnnotateNullableMethodsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AnnotateNullableMethods()).parser(JavaParser.fromJavaVersion().classpath("jspecify"));
+        spec
+          .recipe(new AnnotateNullableMethods())
+          .parser(JavaParser.fromJavaVersion().classpath("jspecify"));
     }
 
     @DocumentExample
     @Test
     void methodReturnsNullLiteral() {
         rewriteRun(
-          spec -> spec.recipe(new AnnotateNullableMethods()),
           //language=java
           java(
             """
@@ -76,7 +77,6 @@ class AnnotateNullableMethodsTest implements RewriteTest {
     @Test
     void methodReturnNullButIsAlreadyAnnotated() {
         rewriteRun(
-          spec -> spec.recipe(new AnnotateNullableMethods()),
           //language=java
           java(
             """
@@ -102,7 +102,6 @@ class AnnotateNullableMethodsTest implements RewriteTest {
     @Test
     void methodDoesNotReturnNull() {
         rewriteRun(
-          spec -> spec.recipe(new AnnotateNullableMethods()),
           //language=java
           java(
             """
@@ -121,17 +120,14 @@ class AnnotateNullableMethodsTest implements RewriteTest {
     @Test
     void methodReturnsDelegateKnowNullableMethod() {
         rewriteRun(
-          spec -> spec.recipe(new AnnotateNullableMethods()),
           //language=java
           java(
             """
-              import java.util.HashMap;
               import java.util.Map;
               
               public class Test {
               
-                  public String getString() {
-                      Map<String, String> map = new HashMap<>();
+                  public String getString(Map<String, String> map) {
                       return map.get("key");
                   }
               }
@@ -139,13 +135,11 @@ class AnnotateNullableMethodsTest implements RewriteTest {
             """
               import org.jspecify.annotations.Nullable;
               
-              import java.util.HashMap;
               import java.util.Map;
               
               public class Test {
               
-                  public @Nullable String getString() {
-                      Map<String, String> map = new HashMap<>();
+                  public @Nullable String getString(Map<String, String> map) {
                       return map.get("key");
                   }
               }
@@ -182,7 +176,6 @@ class AnnotateNullableMethodsTest implements RewriteTest {
     @Test
     void privateMethodsShouldNotBeAnnotated() {
         rewriteRun(
-          spec -> spec.recipe(new AnnotateNullableMethods()),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -83,8 +83,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
             import org.jspecify.annotations.Nullable;
             
             public class Test {
-                @Nullable
-                public String getString() {
+                public @Nullable String getString() {
                     return null;
                 }
             

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -27,9 +27,7 @@ import static org.openrewrite.java.Assertions.javaVersion;
 class AnnotateNullableMethodsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AnnotateNullableMethods()).parser(JavaParser.fromJavaVersion()
-            .classpath("jspecify"))
-          .allSources(sourceSpec -> sourceSpec.markers(javaVersion(17)));
+        spec.recipe(new AnnotateNullableMethods()).parser(JavaParser.fromJavaVersion().classpath("jspecify"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -188,4 +188,48 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void returnWithinNewClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.Callable;
+              
+              public class Test {
+              
+                  public Callable<String> getString() {
+                      return new Callable<String>() {
+                          @Override
+                          public String call() throws Exception {
+                              return null;
+                          }
+                      };
+                  }
+              
+              }
+              """,
+            """
+              import org.jspecify.annotations.Nullable;
+              
+              import java.util.concurrent.Callable;
+              
+              public class Test {
+              
+                  public Callable<String> getString() {
+                      return new Callable<String>() {
+              
+                          @Override
+                          public @Nullable String call() throws Exception {
+                              return null;
+                          }
+                      };
+                  }
+              
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+
+class AnnotateNullableMethodsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AnnotateNullableMethods()).parser(JavaParser.fromJavaVersion()
+            .classpath("jspecify"))
+          .allSources(sourceSpec -> sourceSpec.markers(javaVersion(17)));
+    }
+
+    @Test
+    void methodReturnsNullLiteral() {
+        rewriteRun(
+          spec -> spec.recipe(new AnnotateNullableMethods()),
+          //language=java
+          java(
+            """
+              public class Test {
+                  public String getString() {
+                      return null;
+                  }
+              
+                  public String getStringWithMultipleReturn() {
+                      if (System.currentTimeMillis() % 2 == 0) {
+                          return "Not null";
+                      }
+                      return null;
+                  }
+              }
+              """,
+            """
+              import org.jspecify.annotations.Nullable;
+              
+              public class Test {
+                  @Nullable
+                  public String getString() {
+                      return null;
+                  }
+              
+                  @Nullable
+                  public String getStringWithMultipleReturn() {
+                      if (System.currentTimeMillis() % 2 == 0) {
+                          return "Not null";
+                      }
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodReturnNullButIsAlreadyAnnotated() {
+        rewriteRun(
+          spec -> spec.recipe(new AnnotateNullableMethods()),
+          //language=java
+          java("""
+            import org.jspecify.annotations.Nullable;
+            
+            public class Test {
+                @Nullable
+                public String getString() {
+                    return null;
+                }
+            
+                @Nullable
+                public String getStringWithMultipleReturn() {
+                    if (System.currentTimeMillis() % 2 == 0) {
+                        return "Not null";
+                    }
+                    return null;
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void methodDoesNotReturnNull() {
+        rewriteRun(
+          spec -> spec.recipe(new AnnotateNullableMethods()),
+          //language=java
+          java(
+            """
+              package org.example;
+              
+              public class Test {
+                  public String getString() {
+                      return "Hello";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodReturnsDelegateKnowNullableMethod() {
+        rewriteRun(
+          spec -> spec.recipe(new AnnotateNullableMethods()),
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+              
+              public class Test {
+                  public String getString() {
+                      Map<String, String> map = new HashMap<>();
+                      return map.get("key");
+                  }
+              }
+              """,
+            """
+              import org.jspecify.annotations.Nullable;
+              
+              import java.util.HashMap;
+              import java.util.Map;
+              
+              public class Test {
+                  @Nullable
+                  public String getString() {
+                      Map<String, String> map = new HashMap<>();
+                      return map.get("key");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodWithLambdaShouldNotBeAnnotated() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+                import java.util.stream.Stream;
+              class A {
+                  public Runnable getRunnable() {
+                      return () -> null;
+                  }
+              
+                  public Integer someStream(){
+                      // Stream with lambda class.
+                        return Stream.of(1, 2, 3)
+                            .map(i -> {if (i == 2) return null; else return i;})
+                            .reduce((a, b) -> a + b)
+                            .orElse(null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void privateMethodsShouldNotBeAnnotated() {
+        rewriteRun(
+          spec -> spec.recipe(new AnnotateNullableMethods()),
+          //language=java
+          java(
+            """
+              public class Test {
+                  private String getString() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.Assertions.javaVersion;
 
 class AnnotateNullableMethodsTest implements RewriteTest {
     @Override
@@ -39,6 +38,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           java(
             """
               public class Test {
+    
                   public String getString() {
                       return null;
                   }
@@ -54,9 +54,9 @@ class AnnotateNullableMethodsTest implements RewriteTest {
             """
               import org.jspecify.annotations.Nullable;
               
-              public class Test {
-                  @Nullable
-                  public String getString() {
+              public class Test {      
+    
+                  public @Nullable String getString() {
                       return null;
                   }
               
@@ -78,22 +78,22 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           spec -> spec.recipe(new AnnotateNullableMethods()),
           //language=java
           java(
-                """
-            import org.jspecify.annotations.Nullable;
-            
-            public class Test {
-                public @Nullable String getString() {
-                    return null;
-                }
-            
-                public @Nullable String getStringWithMultipleReturn() {
-                    if (System.currentTimeMillis() % 2 == 0) {
-                        return "Not null";
-                    }
-                    return null;
-                }
-            }
             """
+              import org.jspecify.annotations.Nullable;
+              
+              public class Test {
+                  public @Nullable String getString() {
+                      return null;
+                  }
+              
+                  public @Nullable String getStringWithMultipleReturn() {
+                      if (System.currentTimeMillis() % 2 == 0) {
+                          return "Not null";
+                      }
+                      return null;
+                  }
+              }
+              """
           )
         );
     }
@@ -128,6 +128,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
               import java.util.Map;
               
               public class Test {
+              
                   public String getString() {
                       Map<String, String> map = new HashMap<>();
                       return map.get("key");
@@ -141,6 +142,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
               import java.util.Map;
               
               public class Test {
+              
                   public @Nullable String getString() {
                       Map<String, String> map = new HashMap<>();
                       return map.get("key");

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -31,6 +32,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           .allSources(sourceSpec -> sourceSpec.markers(javaVersion(17)));
     }
 
+    @DocumentExample
     @Test
     void methodReturnsNullLiteral() {
         rewriteRun(
@@ -78,7 +80,8 @@ class AnnotateNullableMethodsTest implements RewriteTest {
         rewriteRun(
           spec -> spec.recipe(new AnnotateNullableMethods()),
           //language=java
-          java("""
+          java(
+                """
             import org.jspecify.annotations.Nullable;
             
             public class Test {

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -60,8 +60,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
                       return null;
                   }
               
-                  @Nullable
-                  public String getStringWithMultipleReturn() {
+                  public @Nullable String getStringWithMultipleReturn() {
                       if (System.currentTimeMillis() % 2 == 0) {
                           return "Not null";
                       }
@@ -87,8 +86,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
                     return null;
                 }
             
-                @Nullable
-                public String getStringWithMultipleReturn() {
+                public @Nullable String getStringWithMultipleReturn() {
                     if (System.currentTimeMillis() % 2 == 0) {
                         return "Not null";
                     }
@@ -143,8 +141,7 @@ class AnnotateNullableMethodsTest implements RewriteTest {
               import java.util.Map;
               
               public class Test {
-                  @Nullable
-                  public String getString() {
+                  public @Nullable String getString() {
                       Map<String, String> map = new HashMap<>();
                       return map.get("key");
                   }


### PR DESCRIPTION
## What's changed?
The PR implements the recipe outlined in https://github.com/openrewrite/rewrite-static-analysis/issues/328. The new recipe will automatically add a `@org.jspecify.annotation.Nullable` to _non-private_ methods that may return null. It does so by scanning methods and checking their return statements for potential null values. Apart from the literal `return null` it will also take methods on collection which are know to be null (based on : [error-prone](https://github.com/google/error-prone/blob/5ada179028452868623a1aa8f11eee2996886454/core/src/main/java/com/google/errorprone/bugpatterns/nullness/ReturnMissingNullable.java#L127-L191l)), such as `Map.get`, `Map.put`, `Queue.poll`..etc. Null that are the result of `lambda`, or streams, are currently ignored.

## What's your motivation?
To quote this issue  https://github.com/openrewrite/rewrite-static-analysis/issues/328:

> Nullability annotations on method return types help tools and devs to better understand and reason about the code. Folks might forget to add these annotations though. A recipe could look through the body of a method and add the missing nullability annotations on the return type.

- Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/328

## Anything in particular you'd like reviewers to focus on?
This is my first recipe, so I might have formatted make some call, etc.

## Anyone you would like to review specifically?
@timtebeek

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
