### PR TITLE
Cap the lengths of generate names in the ReplaceDuplicateStringLiterals recipe

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
@@ -190,11 +190,7 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                 String newNameString = newName.toString();
                 while (newNameString.length() > maxVariableLength){
                     int indexOf = newNameString.lastIndexOf("_");
-                    if (indexOf > -1) {
-                        newNameString = newNameString.substring(0, indexOf);
-                    } else {
-                        newNameString = newNameString.substring(0, maxVariableLength);
-                    }
+                    newNameString = newNameString.substring(0, indexOf > -1 ? indexOf : maxVariableLength);
                 }
                 return VariableNameUtils.normalizeName(newNameString);
             }

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
@@ -188,11 +188,11 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                     }
                 }
                 String newNameString = newName.toString();
-                while(newNameString.length() > maxVariableLength){
+                while (newNameString.length() > maxVariableLength){
                     int indexOf = newNameString.lastIndexOf("_");
-                    if(indexOf > -1) {
+                    if (indexOf > -1) {
                         newNameString = newNameString.substring(0, indexOf);
-                    } else{
+                    } else {
                         newNameString = newNameString.substring(0, maxVariableLength);
                     }
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
@@ -44,6 +44,12 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
     @Nullable
     Boolean includeTestSources;
 
+    @Option(displayName = "Maximum length of the generate variable names",
+            description = "By default this is set to 100 characters",
+            required = false)
+    @Nullable
+    Integer maxVariableLength = 100;
+
     @Override
     public String getDisplayName() {
         return "Replace duplicate `String` literals";
@@ -181,7 +187,16 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                         prevIsLower = Character.isLowerCase(c);
                     }
                 }
-                return VariableNameUtils.normalizeName(newName.toString());
+                String newNameString = newName.toString();
+                while(newNameString.length() > maxVariableLength){
+                    int indexOf = newNameString.lastIndexOf("_");
+                    if(indexOf > -1) {
+                        newNameString = newNameString.substring(0, indexOf);
+                    } else{
+                        newNameString = newNameString.substring(0, maxVariableLength);
+                    }
+                }
+                return VariableNameUtils.normalizeName(newNameString);
             }
         });
     }

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
@@ -149,6 +149,32 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
     }
 
     @Test
+    void generatedNameIsVeryLong() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.foo;
+              class A {
+                  final String val1 = "ThisIsAnUnreasonablyLongVariableNameItGoesOnAndOnForAVeryLongTimeItMightNeverEndWhoIsToKnowHowLongItWillKeepGoingAndGoing";
+                  final String val2 = "ThisIsAnUnreasonablyLongVariableNameItGoesOnAndOnForAVeryLongTimeItMightNeverEndWhoIsToKnowHowLongItWillKeepGoingAndGoing";
+                  final String val3 = "ThisIsAnUnreasonablyLongVariableNameItGoesOnAndOnForAVeryLongTimeItMightNeverEndWhoIsToKnowHowLongItWillKeepGoingAndGoing";
+              }
+              """,
+            """
+              package org.foo;
+              class A {
+                  private static final String THIS_IS_AN_UNREASONABLY_LONG_VARIABLE_NAME_IT_GOES_ON_AND_ON_FOR_AVERY_LONG_TIME_IT_MIGHT_NEVER_END = "ThisIsAnUnreasonablyLongVariableNameItGoesOnAndOnForAVeryLongTimeItMightNeverEndWhoIsToKnowHowLongItWillKeepGoingAndGoing";
+                  final String val1 = THIS_IS_AN_UNREASONABLY_LONG_VARIABLE_NAME_IT_GOES_ON_AND_ON_FOR_AVERY_LONG_TIME_IT_MIGHT_NEVER_END;
+                  final String val2 = THIS_IS_AN_UNREASONABLY_LONG_VARIABLE_NAME_IT_GOES_ON_AND_ON_FOR_AVERY_LONG_TIME_IT_MIGHT_NEVER_END;
+                  final String val3 = THIS_IS_AN_UNREASONABLY_LONG_VARIABLE_NAME_IT_GOES_ON_AND_ON_FOR_AVERY_LONG_TIME_IT_MIGHT_NEVER_END;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void replaceRedundantLiteralInMethodInvocation() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
We could generate some unreasonably long variable names. By default, we will cap variable names at 100 characters but people can change this was desired.

We will crop the generated variable name to the nearest "_" if there is one available


