### PR TITLE
Updating ReplaceDuplicateStringLiterals recipe to use VariableNameUtils to track variable names

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
@@ -28,6 +28,7 @@ import org.openrewrite.java.tree.*;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -97,8 +98,9 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                 if (duplicateLiteralsMap.isEmpty()) {
                     return classDecl;
                 }
-                Set<String> variableNames = duplicateLiteralInfo.getVariableNames();
                 Map<String, String> fieldValueToFieldName = duplicateLiteralInfo.getFieldValueToFieldName();
+                Set<String> variableNames = VariableNameUtils.findNamesInScope(getCursor()).stream()
+                        .filter(i -> !fieldValueToFieldName.containsValue(i)).collect(Collectors.toSet());
                 String classFqn = classDecl.getType().getFullyQualifiedName();
                 Map<J.Literal, String> replacements = new HashMap<>();
                 for (Map.Entry<String, List<J.Literal>> entry : duplicateLiteralsMap.entrySet()) {
@@ -107,7 +109,13 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                     String classFieldName = fieldValueToFieldName.get(valueOfLiteral);
                     String variableName;
                     if (classFieldName != null) {
-                        variableName = getNameWithoutShadow(classFieldName, variableNames);
+                        String maybeVariableName = getNameWithoutShadow(classFieldName, variableNames);
+                        if (duplicateLiteralInfo.existingFieldValueToFieldName.get(maybeVariableName) != null) {
+                            variableNames.add(maybeVariableName);
+                            maybeVariableName = getNameWithoutShadow(classFieldName, variableNames);
+                        }
+
+                        variableName = maybeVariableName;
                         if (StringUtils.isBlank(variableName)) {
                             continue;
                         }
@@ -199,14 +207,14 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
 
     @Value
     private static class DuplicateLiteralInfo {
-        Set<String> variableNames;
         Map<String, String> fieldValueToFieldName;
+        Map<String, String> existingFieldValueToFieldName;
 
         @NonFinal
         Map<String, List<J.Literal>> duplicateLiterals;
 
         public static DuplicateLiteralInfo find(J.ClassDeclaration inClass) {
-            DuplicateLiteralInfo result = new DuplicateLiteralInfo(new LinkedHashSet<>(), new LinkedHashMap<>(), new HashMap<>());
+            DuplicateLiteralInfo result = new DuplicateLiteralInfo(new LinkedHashMap<>(), new LinkedHashMap<>(), new HashMap<>());
             new JavaIsoVisitor<Integer>() {
 
                 @Override
@@ -221,11 +229,11 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                     Cursor parentScope = getCursor().dropParentUntil(is -> is instanceof J.ClassDeclaration || is instanceof J.MethodDeclaration);
                     boolean privateStaticFinalVariable = isPrivateStaticFinalVariable(variable);
                     // `private static final String`(s) are handled separately by `FindExistingPrivateStaticFinalFields`.
-                    if (parentScope.getValue() instanceof J.MethodDeclaration ||
-                        parentScope.getValue() instanceof J.ClassDeclaration &&
-                        !(privateStaticFinalVariable && v.getInitializer() instanceof J.Literal &&
-                          ((J.Literal) v.getInitializer()).getValue() instanceof String)) {
-                        result.variableNames.add(v.getSimpleName());
+                    if (v.getInitializer() instanceof J.Literal &&
+                        (parentScope.getValue() instanceof J.MethodDeclaration || parentScope.getValue() instanceof J.ClassDeclaration) &&
+                            !(privateStaticFinalVariable && ((J.Literal) v.getInitializer()).getValue() instanceof String)) {
+                        String value = (((J.Literal) v.getInitializer()).getValue()).toString();
+                        result.existingFieldValueToFieldName.put(v.getSimpleName(), value);
                     }
                     if (parentScope.getValue() instanceof J.ClassDeclaration &&
                         privateStaticFinalVariable && v.getInitializer() instanceof J.Literal &&

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
@@ -149,6 +149,68 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
     }
 
     @Test
+    void fieldNameCollidesWithNewStringLiteral() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.foo;
+              class A {
+                  final String val1 = "value";
+                  final String val2 = "value";
+                  final String val3 = "value";
+                  final int VALUE = 1;
+              }
+              """,
+            """
+              package org.foo;
+              class A {
+                  private static final String VALUE_1 = "value";
+                  final String val1 = VALUE_1;
+                  final String val2 = VALUE_1;
+                  final String val3 = VALUE_1;
+                  final int VALUE = 1;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void staticImportCollidesWithNewStringLiteral() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.foo;
+              
+              import static java.lang.Long.MAX_VALUE;
+              
+              class A {
+                  final String val1 = "max_value";
+                  final String val2 = "max_value";
+                  final String val3 = "max_value";
+                  final long value = MAX_VALUE;
+              }
+              """,
+            """
+              package org.foo;
+              
+              import static java.lang.Long.MAX_VALUE;
+              
+              class A {
+                  private static final String MAX_VALUE_1 = "max_value";
+                  final String val1 = MAX_VALUE_1;
+                  final String val2 = MAX_VALUE_1;
+                  final String val3 = MAX_VALUE_1;
+                  final long value = MAX_VALUE;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void generatedNameIsVeryLong() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
@@ -149,6 +149,44 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
     }
 
     @Test
+    void enumCollidesWithNewStringLiteral() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.foo;
+              enum TYPES {
+                  VALUE, NUMBER, TEXT
+              }
+
+              class A {
+                  final String val1 = "types";
+                  final String val2 = "types";
+                  final String val3 = "types";
+                  TYPES type = TYPES.VALUE;
+              }
+
+              """,
+            """
+              package org.foo;
+              enum TYPES {
+                  VALUE, NUMBER, TEXT
+              }
+
+              class A {
+                  private static final String TYPES_1 = "types";
+                  final String val1 = TYPES_1;
+                  final String val2 = TYPES_1;
+                  final String val3 = TYPES_1;
+                  TYPES type = TYPES.VALUE;
+              }
+
+              """
+          )
+        );
+    }
+
+    @Test
     void fieldNameCollidesWithNewStringLiteral() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
VariableNameUtils already provides a list of used names in the scope :). We need to handle some edges slightly different

1: When the constant already exists, in this case by default this existing constant name wouldn't be used because it's already being used. In this case, we need to allow the recipe to use this variable 

2: We want to prevent namespace shadowing on existing constants (preventNamespaceShadowingOnExistingConstant is the associated test). When we solve edge 1, by allowing existing constants to be used, we break this edge case. As such we need to validate that we are assigning a name to the value which makes sense.

