### PR TITLE
Updating MoveFieldAnnotationToType to handle moving annotation which are fully defined

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
@@ -26,7 +26,6 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 
 import java.util.ArrayList;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 

--- a/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
@@ -153,16 +153,20 @@ public class MoveFieldAnnotationToType extends Recipe {
             private TypeTree annotateInnerClass(TypeTree qualifiedClassRef, J.Annotation annotation) {
                 J.Annotation usedAnnotation = annotation;
                 if (annotation.getAnnotationType() instanceof J.FieldAccess) {
+                    J.Identifier identifier = new J.Identifier(
+                            Tree.randomId(),
+                            annotation.getAnnotationType().getPrefix(),
+                            annotation.getAnnotationType().getMarkers(),
+                            new ArrayList<>(),
+                            annotation.getSimpleName(),
+                            annotation.getType(),
+                            null
+                    );
+                    if (identifier.getType() != null) {
+                        maybeAddImport(((JavaType.Class) identifier.getType()).getFullyQualifiedName());
+                    }
                     usedAnnotation = usedAnnotation.withAnnotationType(
-                            new J.Identifier(
-                                    Tree.randomId(),
-                                    annotation.getAnnotationType().getPrefix(),
-                                    annotation.getAnnotationType().getMarkers(),
-                                    new ArrayList<>(),
-                                    annotation.getSimpleName(),
-                                    annotation.getType(),
-                                    null
-                            ));
+                            identifier);
                 }
                 if (qualifiedClassRef instanceof J.FieldAccess) {
                     J.FieldAccess q = (J.FieldAccess) qualifiedClassRef;

--- a/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
@@ -156,7 +156,7 @@ public class MoveFieldAnnotationToType extends Recipe {
                 if (annotation.getAnnotationType() instanceof J.FieldAccess) {
                     usedAnnotation = usedAnnotation.withAnnotationType(
                             new J.Identifier(
-                                    UUID.randomUUID(),
+                                    Tree.randomId(),
                                     annotation.getAnnotationType().getPrefix(),
                                     annotation.getAnnotationType().getMarkers(),
                                     new ArrayList<>(),

--- a/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
@@ -25,6 +25,8 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 
+import java.util.ArrayList;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
@@ -150,10 +152,23 @@ public class MoveFieldAnnotationToType extends Recipe {
             }
 
             private TypeTree annotateInnerClass(TypeTree qualifiedClassRef, J.Annotation annotation) {
+                J.Annotation usedAnnotation = annotation;
+                if (annotation.getAnnotationType() instanceof J.FieldAccess) {
+                    usedAnnotation = usedAnnotation.withAnnotationType(
+                            new J.Identifier(
+                                    UUID.randomUUID(),
+                                    annotation.getAnnotationType().getPrefix(),
+                                    annotation.getAnnotationType().getMarkers(),
+                                    new ArrayList<>(),
+                                    annotation.getSimpleName(),
+                                    annotation.getType(),
+                                    null
+                            ));
+                }
                 if (qualifiedClassRef instanceof J.FieldAccess) {
                     J.FieldAccess q = (J.FieldAccess) qualifiedClassRef;
                     q = q.withName(q.getName().withAnnotations(
-                            ListUtils.concat(annotation.withPrefix(Space.EMPTY), q.getName().getAnnotations())));
+                            ListUtils.concat(usedAnnotation.withPrefix(Space.EMPTY), q.getName().getAnnotations())));
                     if (q.getName().getPrefix().getWhitespace().isEmpty()) {
                         q = q.withName(q.getName().withPrefix(q.getName().getPrefix().withWhitespace(" ")));
                     }
@@ -161,7 +176,7 @@ public class MoveFieldAnnotationToType extends Recipe {
                 } else if (qualifiedClassRef instanceof J.ParameterizedType &&
                            ((J.ParameterizedType) qualifiedClassRef).getClazz() instanceof TypeTree) {
                     J.ParameterizedType pt = (J.ParameterizedType) qualifiedClassRef;
-                    return pt.withClazz(annotateInnerClass((TypeTree) pt.getClazz(), annotation));
+                    return pt.withClazz(annotateInnerClass((TypeTree) pt.getClazz(), usedAnnotation));
                 } else if (qualifiedClassRef instanceof J.ArrayType) {
                     J.ArrayType at = (J.ArrayType) qualifiedClassRef;
                     at = at.withAnnotations(ListUtils.concat(annotation.withPrefix(Space.SINGLE_SPACE), at.getAnnotations()));

--- a/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
@@ -212,6 +212,8 @@ class MoveFieldAnnotationToTypeTest implements RewriteTest {
             """
               package org.openrewrite;
               
+              import org.openrewrite.internal.lang.Nullable;
+              
               public class Test {
                  public void someFunction(org.openrewrite.internal.@Nullable MetricsHelper metrics) {
                  }

--- a/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
@@ -196,4 +196,28 @@ class MoveFieldAnnotationToTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void fullyDefinedAnnotationInMethodDeclaration() {
+        rewriteRun(
+          java(
+            """
+              package org.openrewrite;
+              
+              public class Test {
+                 public void someFunction(@org.openrewrite.internal.lang.Nullable org.openrewrite.internal.MetricsHelper metrics) {
+                 }
+              }
+              """,
+            """
+              package org.openrewrite;
+              
+              public class Test {
+                 public void someFunction(org.openrewrite.internal.@Nullable MetricsHelper metrics) {
+                 }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
The previous behaviour, move the fully qualified name which won't compile

The previous behaviour
`public void someFunction(@org.openrewrite.internal.lang.Nullable org.openrewrite.internal.MetricsHelper metrics)` -->
`public void someFunction(org.openrewrite.internal.@org.openrewrite.internal.lang.Nullable MetricsHelper metrics)`

New behaviour
`public void someFunction(@org.openrewrite.internal.lang.Nullable org.openrewrite.internal.MetricsHelper metrics)` -->
`public void someFunction(org.openrewrite.internal.@Nullable MetricsHelper metrics)`




related issue 
- https://github.com/moderneinc/ops/issues/477
