### PR TITLE
Unnecessary `return` as last statement in `void` method

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -44,12 +44,12 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
                 if (TypeUtils.asPrimitive(m.getType()) == JavaType.Primitive.Void) {
-                    return m.withBody(maybeRemoveReturnAsLastStatement(m.getBody()));
+                    return m.withBody(maybeRemoveReturnFromBlock(m.getBody()));
                 }
                 return m;
             }
 
-            private J.@Nullable Block maybeRemoveReturnAsLastStatement(J.@Nullable Block b) {
+            private J.@Nullable Block maybeRemoveReturnFromBlock(J.@Nullable Block b) {
                 if (b == null) {
                     return null;
                 }
@@ -58,27 +58,27 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
                     if (lastStatement instanceof J.Return && ((J.Return) lastStatement).getExpression() == null) {
                         return null;
                     } else if (lastStatement instanceof J.If) {
-                        return maybeRemoveReturnAsLastStatement((J.If) lastStatement);
+                        return maybeRemoveReturnFromIf((J.If) lastStatement);
                     } else {
                         return lastStatement;
                     }
                 }));
             }
 
-            private J.If maybeRemoveReturnAsLastStatement(J.If ifStatement) {
-                ifStatement = ifStatement.withThenPart(maybeRemoveReturnAsLastStatement(ifStatement.getThenPart()));
+            private J.If maybeRemoveReturnFromIf(J.If ifStatement) {
+                ifStatement = ifStatement.withThenPart(maybeRemoveReturnFromStatement(ifStatement.getThenPart()));
                 J.If.Else elze = ifStatement.getElsePart();
                 if (elze != null) {
-                    return ifStatement.withElsePart(elze.withBody(maybeRemoveReturnAsLastStatement(elze.getBody())));
+                    return ifStatement.withElsePart(elze.withBody(maybeRemoveReturnFromStatement(elze.getBody())));
                 }
                 return ifStatement;
             }
 
-            private Statement maybeRemoveReturnAsLastStatement(Statement s) {
+            private Statement maybeRemoveReturnFromStatement(Statement s) {
                 if (s instanceof J.Block) {
-                    return maybeRemoveReturnAsLastStatement((J.Block) s);
+                    return maybeRemoveReturnFromBlock((J.Block) s);
                 } else if (s instanceof J.If) {
-                    return maybeRemoveReturnAsLastStatement((J.If) s);
+                    return maybeRemoveReturnFromIf((J.If) s);
                 } else {
                     return s;
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -20,7 +20,9 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +60,7 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
                 }
                 Statement lastStatement = statements.get(statements.size() - 1);
                 List<Statement> allButLast = statements.subList(0, statements.size() - 1);
-                if (lastStatement instanceof J.Return) {
+                if (lastStatement instanceof J.Return && ((J.Return) lastStatement).getExpression() == null) {
                     return b.withStatements(allButLast);
                 } else if (lastStatement instanceof J.If) {
                     J.If ifStatement = (J.If) lastStatement;
@@ -77,7 +79,11 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                return m.withBody(maybeRemoveReturnAsLastStatement(m.getBody()));
+                if (TypeUtils.asPrimitive(m.getType()) == JavaType.Primitive.Void) {
+                    return m.withBody(maybeRemoveReturnAsLastStatement(m.getBody()));
+                } else {
+                    return m;
+                }
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -1,0 +1,72 @@
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UnnecessaryReturnAsLastStatement extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Unnecessary `return` as last statement in void method";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes `return` from a `void` method if it's the last statement.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            private Statement maybeRemoveReturnAsLastStatement(Statement s) {
+                if (s instanceof J.Block) {
+                    return maybeRemoveReturnAsLastStatement((J.Block) s);
+                } else {
+                    return s;
+                }
+            }
+
+            private J.Block maybeRemoveReturnAsLastStatement(J.Block b) {
+                if (b == null) {
+                    return null;
+                }
+
+                List<Statement> statements = b.getStatements();
+                if (statements.isEmpty()) {
+                    return b;
+                }
+                Statement lastStatement = statements.get(statements.size() - 1);
+                List<Statement> allButLast = statements.subList(0, statements.size() - 1);
+                if (lastStatement instanceof J.Return) {
+                    return b.withStatements(allButLast);
+                } else if (lastStatement instanceof J.If) {
+                    J.If ifStatement = (J.If) lastStatement;
+                    J.If.Else elze = ifStatement.getElsePart();
+                    J.If newIf = ifStatement
+                            .withThenPart(maybeRemoveReturnAsLastStatement(ifStatement.getThenPart()))
+                            .withElsePart(elze.withBody(maybeRemoveReturnAsLastStatement(elze.getBody())));
+                    List<Statement> newStatements = new ArrayList<>(allButLast);
+                    newStatements.add(newIf);
+                    return b.withStatements(newStatements);
+                } else {
+                    return b;
+                }
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(method, executionContext);
+                if (m == null) {
+                    return m;
+                }
+                return m.withBody(maybeRemoveReturnAsLastStatement(m.getBody()));
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.staticanalysis;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -25,9 +25,6 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class UnnecessaryReturnAsLastStatement extends Recipe {
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -81,9 +81,8 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
                 if (TypeUtils.asPrimitive(m.getType()) == JavaType.Primitive.Void) {
                     return m.withBody(maybeRemoveReturnAsLastStatement(m.getBody()));
-                } else {
-                    return m;
                 }
+               return m;
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -77,9 +77,6 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                if (m == null) {
-                    return m;
-                }
                 return m.withBody(maybeRemoveReturnAsLastStatement(m.getBody()));
             }
         };

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -58,21 +58,30 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
                     if (lastStatement instanceof J.Return && ((J.Return) lastStatement).getExpression() == null) {
                         return null;
                     } else if (lastStatement instanceof J.If) {
-                        J.If ifStatement = (J.If) lastStatement;
-                        ifStatement = ifStatement.withThenPart(maybeRemoveReturnAsLastStatement(ifStatement.getThenPart()));
-                        J.If.Else elze = ifStatement.getElsePart();
-                        if (elze != null) {
-                            return ifStatement.withElsePart(elze.withBody(maybeRemoveReturnAsLastStatement(elze.getBody())));
-                        }
-                        return ifStatement;
+                        return maybeRemoveReturnAsLastStatement((J.If) lastStatement);
                     } else {
                         return lastStatement;
                     }
                 }));
             }
 
+            private J.If maybeRemoveReturnAsLastStatement(J.If ifStatement) {
+                ifStatement = ifStatement.withThenPart(maybeRemoveReturnAsLastStatement(ifStatement.getThenPart()));
+                J.If.Else elze = ifStatement.getElsePart();
+                if (elze != null) {
+                    return ifStatement.withElsePart(elze.withBody(maybeRemoveReturnAsLastStatement(elze.getBody())));
+                }
+                return ifStatement;
+            }
+
             private Statement maybeRemoveReturnAsLastStatement(Statement s) {
-                return s instanceof J.Block ? maybeRemoveReturnAsLastStatement((J.Block) s) : s;
+                if (s instanceof J.Block) {
+                    return maybeRemoveReturnAsLastStatement((J.Block) s);
+                } else if (s instanceof J.If) {
+                    return maybeRemoveReturnAsLastStatement((J.If) s);
+                } else {
+                    return s;
+                }
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -64,7 +64,12 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
                     }
                     if (ifStatement.getElsePart() != null) {
                         Statement trimmedElse = maybeRemoveReturn(ifStatement.getElsePart().getBody());
-                        return ifStatement.withElsePart(trimmedElse == null ? null : ifStatement.getElsePart().withBody(trimmedElse));
+                        if (trimmedElse == null) {
+                            return ifStatement.withElsePart(null);
+                        }
+                        if (trimmedElse != ifStatement.getElsePart().getBody()) {
+                            return ifStatement.withElsePart(ifStatement.getElsePart().withBody(trimmedElse));
+                        }
                     }
                     return ifStatement;
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatement.java
@@ -75,8 +75,8 @@ public class UnnecessaryReturnAsLastStatement extends Recipe {
             }
 
             @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
-                J.MethodDeclaration m = super.visitMethodDeclaration(method, executionContext);
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
                 if (m == null) {
                     return m;
                 }

--- a/src/main/resources/META-INF/rewrite/common-static-analysis.yml
+++ b/src/main/resources/META-INF/rewrite/common-static-analysis.yml
@@ -84,6 +84,7 @@ recipeList:
   - org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments
   - org.openrewrite.staticanalysis.UnnecessaryParentheses
   - org.openrewrite.staticanalysis.UnnecessaryPrimitiveAnnotations
+  - org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement
   - org.openrewrite.staticanalysis.UpperCaseLiteralSuffixes
 #  - org.openrewrite.staticanalysis.UnnecessaryThrows
 #  - org.openrewrite.staticanalysis.UseCollectionInterfaces

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
+class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new UnnecessaryReturnAsLastStatement());

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -1,0 +1,93 @@
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new UnnecessaryReturnAsLastStatement());
+    }
+
+    @Test
+    @DocumentExample
+    void simpleReturn() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  void world() {
+                      System.out.println("Hello world");
+                      return;
+                  }
+              }
+              """,
+            """
+              class Hello {
+                  void world() {
+                      System.out.println("Hello world");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ifBranches() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                        return;
+                      } else {
+                        System.out.println("Zero or negative");
+                        return;
+                      }
+                  }
+              }
+              """,
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                      } else {
+                        System.out.println("Zero or negative");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ifIsNotTheLast() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                        return;
+                      } else {
+                        System.out.println("Zero or negative");
+                      }
+                      System.out.println("Some extra logic");
+                  }
+              }
+              """));
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -87,6 +87,72 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
     }
 
     @Test
+    void ifWithoutElse() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                        return;
+                      }
+                  }
+              }
+              """,
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ifElseIf() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                        return;
+                      } else if (i == 0) {
+                        System.out.println("Zero");
+                        return;
+                      } else {
+                        System.out.println("Negative");
+                        return;
+                      }
+                  }
+              }
+              """,
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                      } else if (i == 0) {
+                        System.out.println("Zero");
+                      } else {
+                        System.out.println("Negative");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void ifIsNotTheLast() {
         //language=java
         rewriteRun(
@@ -103,7 +169,9 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
                       System.out.println("Some extra logic");
                   }
               }
-              """));
+              """
+          )
+        );
     }
 
     @Test
@@ -117,7 +185,9 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
                       return i + 436;
                   }
               }
-              """));
+              """
+          )
+        );
     }
 
     @Test
@@ -131,7 +201,9 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
                     return;
                 };
               }
-              """));
+              """
+          )
+        );
     }
 
     @Test
@@ -147,7 +219,9 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
                   }
                 }
               }
-              """));
+              """
+          )
+        );
     }
 
     @Test
@@ -183,6 +257,8 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
                           }
                       };
               }
-              """));
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -194,7 +194,7 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
                   void world(int i) {
                       if (i > 0) {
                         System.out.println("Positive");
-                      } else return;
+                      }
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -105,4 +105,19 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
               }
               """));
     }
+
+    @Test
+    void notChangingNonVoidMethods() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  int world(int i) {
+                      return i + 436;
+                  }
+              }
+              """));
+    }
+
 }

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -175,6 +175,62 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
     }
 
     @Test
+    void elseWithJustAReturnStatement() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                        return;
+                      } else return;
+                  }
+              }
+              """,
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i > 0) {
+                        System.out.println("Positive");
+                      } else return;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ifThenBeingJustAReturnStatement() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i == 436) return; else {
+                        System.out.println("I don't like it");
+                        return;
+                      }
+                  }
+              }
+              """,
+            """
+              class Hello {
+                  void world(int i) {
+                      if (i == 436) return; else {
+                        System.out.println("I don't like it");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void notChangingNonVoidMethods() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -120,4 +120,69 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
               """));
     }
 
+    @Test
+    void notChangingLambdas() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Hello {
+                java.util.function.Consumer<Integer> c = i -> {
+                    return;
+                };
+              }
+              """));
+    }
+
+    @Test
+    void notChangingLoops() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Main {
+                public static void main(String[] argv) {
+                  while (true) {
+                      return;
+                  }
+                }
+              }
+              """));
+    }
+
+    @Test
+    void newClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.concurrent.Callable;
+              class Hello {
+                      Callable<String> callable = new Callable<>() {
+                          @Override
+                          public String call() throws Exception {
+                              otherMethod();
+                              return "success";
+                          }
+                          private void otherMethod() {
+                              return;
+                          }
+                      };
+              }
+              """,
+            """
+              import java.util.concurrent.Callable;
+              class Hello {
+                      Callable<String> callable = new Callable<>() {
+                          @Override
+                          public String call() throws Exception {
+                              otherMethod();
+                              return "success";
+                          }
+                          private void otherMethod() {
+                          }
+                      };
+              }
+              """));
+    }
 }


### PR DESCRIPTION
## What's changed?
Adding a new recipe to remove `return` if it's the last statement of a `void` method.

## What's your motivation?
- Closes #75 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
