### PR TITLE
Adjust `CatchClauseOnlyRethrows` to work with C#

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -17,7 +17,9 @@ package org.openrewrite.staticanalysis;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.csharp.tree.Cs;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.Expression;
@@ -113,6 +115,13 @@ public class CatchClauseOnlyRethrows extends Recipe {
                 }
 
                 Expression exception = ((J.Throw) aCatch.getBody().getStatements().get(0)).getException();
+
+                // In C# an implicit rethrow is possible
+                if (getCursor().firstEnclosing(SourceFile.class) instanceof Cs &&
+                    exception instanceof J.Empty) {
+                    return true;
+                }
+
                 JavaType catchParameterType = aCatch.getParameter().getType();
                 if (!(catchParameterType instanceof JavaType.MultiCatch)) {
                     JavaType.FullyQualified catchType = TypeUtils.asFullyQualified(catchParameterType);

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -16,19 +16,13 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.DocumentExample;
-import org.openrewrite.FileAttributes;
-import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.Tree;
+import org.openrewrite.*;
 import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
@@ -340,40 +334,52 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
 
     @Test
     void verifyCsharpImplicitThrow() {
-        Cs.CompilationUnit compilationUnit = new Cs.CompilationUnit(Tree.randomId(), Space.EMPTY,
-          Markers.EMPTY, Path.of("test.cs"),
-          new FileAttributes(null, null, null, true, true, true, 0l),
-          null, false, null, null, null, null,
-          List.of(JRightPadded.build(
-            new J.ClassDeclaration(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-              Collections.emptyList(), Collections.emptyList(),
-              new J.ClassDeclaration.Kind(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), J.ClassDeclaration.Kind.Type.Class),
-              new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "doSome", null, null),
-              null, null, null, null, null,
-              new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false),
-                List.of(JRightPadded.build(new J.Try(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null,
-                  new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false),
-                    List.of(JRightPadded.build(new J.Throw(Tree.randomId(), Space.EMPTY, Markers.EMPTY, new J.NewClass(
-                      Tree.randomId(), Space.EMPTY, Markers.EMPTY, null, Space.EMPTY, TypeTree.build("java.lang.IllegalAccessException"), JContainer.empty(), null, null)))),
-                    Space.EMPTY),
-                  List.of(new J.Try.Catch(Tree.randomId(), Space.EMPTY, Markers.EMPTY, new J.ControlParentheses<J.VariableDeclarations>(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-                    JRightPadded.build(new J.VariableDeclarations(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), Collections.emptyList(), TypeTree.build("java.lang.IllegalAccessException"), null, List.of(), List.of(JRightPadded.build(
-                      new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-                        new J.Identifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, Collections.emptyList(), "e", null, null),
-                        List.of(), null, null)))))),
-                    new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false),
-                      List.of(JRightPadded.build(new J.Throw(Tree.randomId(), Space.EMPTY, Markers.EMPTY, new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY)))),
-                      Space.EMPTY))),
-                  null))),
-                Space.EMPTY),
-              null)))
-          , Space.EMPTY);
+        rewriteRun(
+          spec -> spec.recipe(Recipe.noop()),
+          //language=java
+          java(
+            """
+              class A {
+                  void foo() throws IllegalAccessException {
+                      try {
+                          throw new IllegalAccessException();
+                      } catch (Exception e) {
+                          throw e;
+                      }
+                  }
+              }"""
+            , spec -> spec.beforeRecipe(compUnit -> {
+                  Cs.CompilationUnit cSharpCompUnit = (Cs.CompilationUnit) new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J visitThrow(J.Throw thrown, ExecutionContext executionContext) {
+                        if (thrown.getException() instanceof J.Identifier) {
+                            return thrown.withException(new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY));
+                        }
+                        return thrown;
+                    }
+                }.visit(JavaToCsharp.compilationUnit(compUnit), new InMemoryExecutionContext());
 
-        assertThat(compilationUnit.getMembers().get(0)).isInstanceOf(J.ClassDeclaration.class);
-        assertThat(((J.ClassDeclaration)compilationUnit.getMembers().get(0)).getBody().getStatements().get(0)).isInstanceOf(J.Try.class);
+                  assertThat(cSharpCompUnit.getMembers().get(0)).isInstanceOf(J.ClassDeclaration.class);
+                  assertThat(((J.ClassDeclaration)cSharpCompUnit.getMembers().get(0)).getBody().getStatements().get(0)).isInstanceOf(J.MethodDeclaration.class);
+                  J.MethodDeclaration md = (J.MethodDeclaration) ((J.ClassDeclaration)cSharpCompUnit.getMembers().get(0)).getBody().getStatements().get(0);
+                  assertThat(md.getBody().getStatements().get(0)).isInstanceOf(J.Try.class);
 
-        Cs.CompilationUnit output = (Cs.CompilationUnit) new CatchClauseOnlyRethrows().getVisitor().visit(compilationUnit, new InMemoryExecutionContext());
-        assertThat(output.getMembers().get(0)).isInstanceOf(J.ClassDeclaration.class);
-        assertThat(((J.ClassDeclaration)output.getMembers().get(0)).getBody().getStatements().get(0)).isInstanceOf(J.Throw.class);
+                  Cs.CompilationUnit output = (Cs.CompilationUnit) new CatchClauseOnlyRethrows().getVisitor().visit(cSharpCompUnit, new InMemoryExecutionContext());
+
+                  assertThat(output.getMembers().get(0)).isInstanceOf(J.ClassDeclaration.class);
+                  assertThat(((J.ClassDeclaration)output.getMembers().get(0)).getBody().getStatements().get(0)).isInstanceOf(J.MethodDeclaration.class);
+                   md = (J.MethodDeclaration) ((J.ClassDeclaration)output.getMembers().get(0)).getBody().getStatements().get(0);
+                  assertThat(md.getBody().getStatements().get(0)).isInstanceOf(J.Throw.class);
+            }
+            )
+          )
+        );
+    }
+
+    public JavaVisitor<ExecutionContext> getJavaToCsharpVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+
+
+        };
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -339,7 +339,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void testCsharpImplicitThrow() {
+    void verifyCsharpImplicitThrow() {
         Cs.CompilationUnit compilationUnit = new Cs.CompilationUnit(Tree.randomId(), Space.EMPTY,
           Markers.EMPTY, Path.of("test.cs"),
           new FileAttributes(null, null, null, true, true, true, 0l),

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -344,7 +344,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                       try {
                           throw new IllegalAccessException();
                       } catch (Exception e) {
-                          throw e;
+                          throw e; // C# can rethrow the caught exception implicitly and so the `e` Identifier is removed by the inline visitor below
                       }
                   }
               }"""

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -19,7 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.*;
 import org.openrewrite.csharp.tree.Cs;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -351,7 +352,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             , spec -> spec.beforeRecipe(compUnit -> {
                   Cs.CompilationUnit cSharpCompUnit = (Cs.CompilationUnit) new JavaVisitor<ExecutionContext>() {
                     @Override
-                    public J visitThrow(J.Throw thrown, ExecutionContext executionContext) {
+                    public J visitThrow(J.Throw thrown, ExecutionContext ctx) {
                         if (thrown.getException() instanceof J.Identifier) {
                             return thrown.withException(new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY));
                         }
@@ -377,7 +378,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     public JavaVisitor<ExecutionContext> getJavaToCsharpVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+        return new JavaVisitor<>() {
 
 
         };

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -17,9 +17,20 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.FileAttributes;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings("ALL")
@@ -38,7 +49,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-                            
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -63,7 +74,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-                            
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -90,7 +101,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-              
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -116,7 +127,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-                            
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -130,7 +141,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-                            
+
               class A {
                   void foo() throws IOException {
                       new FileReader("").read();
@@ -150,7 +161,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
               import java.io.FileReader;
               import java.io.IOException;
               import java.io.FileNotFoundException;
-              
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -166,16 +177,16 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
               }
               """,
             """
-            import java.io.FileReader;
-            import java.io.IOException;
-            import java.io.FileNotFoundException;
-              
-            class A {
-                void foo() throws IOException {
-                    new FileReader("").read();
-                }
-            }
-            """
+              import java.io.FileReader;
+              import java.io.IOException;
+              import java.io.FileNotFoundException;
+
+              class A {
+                  void foo() throws IOException {
+                      new FileReader("").read();
+                  }
+              }
+              """
           )
         );
     }
@@ -189,7 +200,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
               import java.io.FileReader;
               import java.io.IOException;
               import java.io.FileNotFoundException;
-              
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -214,7 +225,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-              
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -230,7 +241,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-              
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -253,7 +264,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-              
+
               class A {
                   void foo() throws IOException {
                       try(FileReader fr = new FileReader("")) {
@@ -267,7 +278,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-              
+
               class A {
                   void foo() throws IOException {
                       try(FileReader fr = new FileReader("")) {
@@ -288,7 +299,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-              
+
               class A {
                   void foo() {
                       try {
@@ -311,7 +322,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
             """
               import java.io.FileReader;
               import java.io.IOException;
-              
+
               class A {
                   void foo() throws IOException {
                       try {
@@ -325,5 +336,44 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void testCsharpImplicitThrow() {
+        Cs.CompilationUnit compilationUnit = new Cs.CompilationUnit(Tree.randomId(), Space.EMPTY,
+          Markers.EMPTY, Path.of("test.cs"),
+          new FileAttributes(null, null, null, true, true, true, 0l),
+          null, false, null, null, null, null,
+          List.of(JRightPadded.build(
+            new J.ClassDeclaration(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+              Collections.emptyList(), Collections.emptyList(),
+              new J.ClassDeclaration.Kind(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), J.ClassDeclaration.Kind.Type.Class),
+              new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "doSome", null, null),
+              null, null, null, null, null,
+              new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false),
+                List.of(JRightPadded.build(new J.Try(Tree.randomId(), Space.EMPTY, Markers.EMPTY, null,
+                  new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false),
+                    List.of(JRightPadded.build(new J.Throw(Tree.randomId(), Space.EMPTY, Markers.EMPTY, new J.NewClass(
+                      Tree.randomId(), Space.EMPTY, Markers.EMPTY, null, Space.EMPTY, TypeTree.build("java.lang.IllegalAccessException"), JContainer.empty(), null, null)))),
+                    Space.EMPTY),
+                  List.of(new J.Try.Catch(Tree.randomId(), Space.EMPTY, Markers.EMPTY, new J.ControlParentheses<J.VariableDeclarations>(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                    JRightPadded.build(new J.VariableDeclarations(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), Collections.emptyList(), TypeTree.build("java.lang.IllegalAccessException"), null, List.of(), List.of(JRightPadded.build(
+                      new J.VariableDeclarations.NamedVariable(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                        new J.Identifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, Collections.emptyList(), "e", null, null),
+                        List.of(), null, null)))))),
+                    new J.Block(Tree.randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false),
+                      List.of(JRightPadded.build(new J.Throw(Tree.randomId(), Space.EMPTY, Markers.EMPTY, new J.Empty(Tree.randomId(), Space.EMPTY, Markers.EMPTY)))),
+                      Space.EMPTY))),
+                  null))),
+                Space.EMPTY),
+              null)))
+          , Space.EMPTY);
+
+        assertThat(compilationUnit.getMembers().get(0)).isInstanceOf(J.ClassDeclaration.class);
+        assertThat(((J.ClassDeclaration)compilationUnit.getMembers().get(0)).getBody().getStatements().get(0)).isInstanceOf(J.Try.class);
+
+        Cs.CompilationUnit output = (Cs.CompilationUnit) new CatchClauseOnlyRethrows().getVisitor().visit(compilationUnit, new InMemoryExecutionContext());
+        assertThat(output.getMembers().get(0)).isInstanceOf(J.ClassDeclaration.class);
+        assertThat(((J.ClassDeclaration)output.getMembers().get(0)).getBody().getStatements().get(0)).isInstanceOf(J.Throw.class);
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
+++ b/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
@@ -21,7 +21,6 @@ import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Statement;
 
 import java.util.List;
-import static java.util.stream.Collectors.toList;
 
 public class JavaToCsharp {
 
@@ -41,7 +40,7 @@ public class JavaToCsharp {
           cu.getClasses().stream()
             .map(Statement.class::cast)
             .map(JRightPadded::build)
-            .collect(toList()),
+            .toList(),
           cu.getEof());
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
+++ b/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JavaToCsharp {
+
+    public static Cs.CompilationUnit compilationUnit(J.CompilationUnit cu) {
+        return new Cs.CompilationUnit(cu.getId(), cu.getPrefix(), cu.getMarkers(), cu.getSourcePath(),
+          cu.getFileAttributes(), cu.getCharset().name(), cu.isCharsetBomMarked(), cu.getChecksum(), List.of(), List.of(), List.of(), cu.getClasses().stream().map(Statement.class::cast).map(cd -> JRightPadded.build(cd)).collect(Collectors.toList()), cu.getEof());
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
+++ b/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
@@ -21,8 +21,6 @@ import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Statement;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
 import static java.util.stream.Collectors.toList;
 
 public class JavaToCsharp {

--- a/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
+++ b/src/test/java/org/openrewrite/staticanalysis/JavaToCsharp.java
@@ -23,10 +23,27 @@ import org.openrewrite.java.tree.Statement;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
+
 public class JavaToCsharp {
 
     public static Cs.CompilationUnit compilationUnit(J.CompilationUnit cu) {
-        return new Cs.CompilationUnit(cu.getId(), cu.getPrefix(), cu.getMarkers(), cu.getSourcePath(),
-          cu.getFileAttributes(), cu.getCharset().name(), cu.isCharsetBomMarked(), cu.getChecksum(), List.of(), List.of(), List.of(), cu.getClasses().stream().map(Statement.class::cast).map(cd -> JRightPadded.build(cd)).collect(Collectors.toList()), cu.getEof());
+        return new Cs.CompilationUnit(
+          cu.getId(),
+          cu.getPrefix(),
+          cu.getMarkers(),
+          cu.getSourcePath(),
+          cu.getFileAttributes(),
+          cu.getCharset().name(),
+          cu.isCharsetBomMarked(),
+          cu.getChecksum(),
+          List.of(),
+          List.of(),
+          List.of(),
+          cu.getClasses().stream()
+            .map(Statement.class::cast)
+            .map(JRightPadded::build)
+            .collect(toList()),
+          cu.getEof());
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Take into account a possible `J.Empty` expression for a throws statement

## Anyone you would like to review specifically?
<!-- @mention them here -->
@OlegDokuka @knutwannheden @timtebeek 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
In C# an implicit throw like this
```
catch (Exception ex)
{
    throw;
}
```
is valid code and it's mapped to a `J.Empty` expression

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
