### PR TITLE
`EqualsAvoidsNull` should flip arguments for constants

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -80,7 +80,10 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
             return true;
         }
         if (firstArgument instanceof J.FieldAccess) {
-            JavaType.Variable fieldType = ((J.FieldAccess) firstArgument).getName().getFieldType();
+            firstArgument = ((J.FieldAccess) firstArgument).getName();
+        }
+        if (firstArgument instanceof J.Identifier) {
+            JavaType.Variable fieldType = ((J.Identifier) firstArgument).getFieldType();
             return fieldType != null && fieldType.hasFlags(Flag.Static, Flag.Final);
         }
         return false;

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import fj.P;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -57,25 +57,22 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
     @Override
     public J visitMethodInvocation(J.MethodInvocation method, P p) {
         J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, p);
-        final boolean stringComparisonMethod = isStringComparisonMethod(m);
         if (m.getSelect() != null &&
-            !(m.getSelect() instanceof J.Literal) &&
-            m.getArguments().get(0) instanceof J.Literal &&
-                stringComparisonMethod) {
-            final Expression expression = literalsFirstInComparisonsBinaryCheck(m,
-                    getCursor().getParentTreeCursor().getValue());
-            return expression;
+                !(m.getSelect() instanceof J.Literal) &&
+                m.getArguments().get(0) instanceof J.Literal &&
+                isStringComparisonMethod(m)) {
+            return literalsFirstInComparisonsBinaryCheck(m, getCursor().getParentTreeCursor().getValue());
         }
         return m;
     }
 
     private boolean isStringComparisonMethod(J.MethodInvocation methodInvocation) {
         return EQUALS.matches(methodInvocation) ||
-               !style.getIgnoreEqualsIgnoreCase() &&
-               EQUALS_IGNORE_CASE.matches(methodInvocation) ||
-               COMPARE_TO.matches(methodInvocation) ||
-               COMPARE_TO_IGNORE_CASE.matches(methodInvocation) ||
-               CONTENT_EQUALS.matches(methodInvocation);
+                !style.getIgnoreEqualsIgnoreCase() &&
+                        EQUALS_IGNORE_CASE.matches(methodInvocation) ||
+                COMPARE_TO.matches(methodInvocation) ||
+                COMPARE_TO_IGNORE_CASE.matches(methodInvocation) ||
+                CONTENT_EQUALS.matches(methodInvocation);
     }
 
     private Expression literalsFirstInComparisonsBinaryCheck(J.MethodInvocation m, P parent) {
@@ -110,7 +107,8 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
         if (binary.getOperator() == J.Binary.Type.And && binary.getLeft() instanceof J.Binary) {
             J.Binary potentialNullCheck = (J.Binary) binary.getLeft();
             if (isNullLiteral(potentialNullCheck.getLeft()) && matchesSelect(potentialNullCheck.getRight(), requireNonNull(m.getSelect())) ||
-                isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(), requireNonNull(m.getSelect()))) {
+                    isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(),
+                            requireNonNull(m.getSelect()))) {
                 doAfterVisit(new RemoveUnnecessaryNullCheck<>(binary));
             }
         }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -107,8 +107,7 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
         if (binary.getOperator() == J.Binary.Type.And && binary.getLeft() instanceof J.Binary) {
             J.Binary potentialNullCheck = (J.Binary) binary.getLeft();
             if (isNullLiteral(potentialNullCheck.getLeft()) && matchesSelect(potentialNullCheck.getRight(), requireNonNull(m.getSelect())) ||
-                    isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(),
-                            requireNonNull(m.getSelect()))) {
+                isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(), requireNonNull(m.getSelect()))) {
                 doAfterVisit(new RemoveUnnecessaryNullCheck<>(binary));
             }
         }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import fj.P;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
@@ -79,9 +80,8 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
             return true;
         }
         if (firstArgument instanceof J.FieldAccess) {
-            return ((J.FieldAccess) firstArgument)
-                    .getName().getFieldType()
-                    .hasFlags(Flag.Static, Flag.Final);
+            JavaType.Variable fieldType = ((J.FieldAccess) firstArgument).getName().getFieldType();
+            return fieldType != null && fieldType.hasFlags(Flag.Static, Flag.Final);
         }
         return false;
     }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -57,10 +57,11 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
     @Override
     public J visitMethodInvocation(J.MethodInvocation method, P p) {
         J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, p);
+        final boolean stringComparisonMethod = isStringComparisonMethod(m);
         if (m.getSelect() != null &&
             !(m.getSelect() instanceof J.Literal) &&
             m.getArguments().get(0) instanceof J.Literal &&
-            isStringComparisonMethod(m)) {
+                stringComparisonMethod) {
             final Expression expression = literalsFirstInComparisonsBinaryCheck(m,
                     getCursor().getParentTreeCursor().getValue());
             return expression;

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -61,7 +61,9 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
             !(m.getSelect() instanceof J.Literal) &&
             m.getArguments().get(0) instanceof J.Literal &&
             isStringComparisonMethod(m)) {
-            return literalsFirstInComparisonsBinaryCheck(m, getCursor().getParentTreeCursor().getValue());
+            final Expression expression = literalsFirstInComparisonsBinaryCheck(m,
+                    getCursor().getParentTreeCursor().getValue());
+            return expression;
         }
         return m;
     }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -60,9 +60,15 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
         if (m.getSelect() != null &&
             !(m.getSelect() instanceof J.Literal) &&
             !m.getArguments().isEmpty() &&
-            m.getArguments().get(0) instanceof J.Literal &&
+            (m.getArguments().get(0) instanceof J.Literal || m.getArguments().get(0) instanceof J.FieldAccess) &&
             isStringComparisonMethod(m)) {
-            return literalsFirstInComparisonsBinaryCheck(m, getCursor().getParentTreeCursor().getValue());
+
+            maybeHandleParentBinary(m);
+
+            Expression firstArgument = m.getArguments().get(0);
+            return firstArgument.getType() == JavaType.Primitive.Null ?
+                    literalsFirstInComparisonsNull(m, firstArgument) :
+                    literalsFirstInComparisons(m, firstArgument);
         }
         return m;
     }
@@ -76,17 +82,26 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
                CONTENT_EQUALS.matches(methodInvocation);
     }
 
-    private Expression literalsFirstInComparisonsBinaryCheck(J.MethodInvocation m, P parent) {
+    private void maybeHandleParentBinary(J.MethodInvocation m) {
+        P parent = getCursor().getParentTreeCursor().getValue();
         if (parent instanceof J.Binary) {
-            handleBinaryExpression(m, (J.Binary) parent);
+            if (((J.Binary) parent).getOperator() == J.Binary.Type.And && ((J.Binary) parent).getLeft() instanceof J.Binary) {
+                J.Binary potentialNullCheck = (J.Binary) ((J.Binary) parent).getLeft();
+                if (isNullLiteral(potentialNullCheck.getLeft()) && matchesSelect(potentialNullCheck.getRight(), requireNonNull(m.getSelect())) ||
+                    isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(), requireNonNull(m.getSelect()))) {
+                    doAfterVisit(new RemoveUnnecessaryNullCheck<>((J.Binary) parent));
+                }
+            }
         }
-        return getExpression(m, m.getArguments().get(0));
     }
 
-    private static Expression getExpression(J.MethodInvocation m, Expression firstArgument) {
-        return firstArgument.getType() == JavaType.Primitive.Null ?
-                literalsFirstInComparisonsNull(m, firstArgument) :
-                literalsFirstInComparisons(m, firstArgument);
+    private boolean isNullLiteral(Expression expression) {
+        return expression instanceof J.Literal && ((J.Literal) expression).getType() == JavaType.Primitive.Null;
+    }
+
+    private boolean matchesSelect(Expression expression, Expression select) {
+        return expression.printTrimmed(getCursor()).replaceAll("\\s", "")
+                .equals(select.printTrimmed(getCursor()).replaceAll("\\s", ""));
     }
 
     private static J.Binary literalsFirstInComparisonsNull(J.MethodInvocation m, Expression firstArgument) {
@@ -102,25 +117,6 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
     private static J.MethodInvocation literalsFirstInComparisons(J.MethodInvocation m, Expression firstArgument) {
         return m.withSelect(firstArgument.withPrefix(requireNonNull(m.getSelect()).getPrefix()))
                 .withArguments(singletonList(m.getSelect().withPrefix(Space.EMPTY)));
-    }
-
-    private void handleBinaryExpression(J.MethodInvocation m, J.Binary binary) {
-        if (binary.getOperator() == J.Binary.Type.And && binary.getLeft() instanceof J.Binary) {
-            J.Binary potentialNullCheck = (J.Binary) binary.getLeft();
-            if (isNullLiteral(potentialNullCheck.getLeft()) && matchesSelect(potentialNullCheck.getRight(), requireNonNull(m.getSelect())) ||
-                isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(), requireNonNull(m.getSelect()))) {
-                doAfterVisit(new RemoveUnnecessaryNullCheck<>(binary));
-            }
-        }
-    }
-
-    private boolean isNullLiteral(Expression expression) {
-        return expression instanceof J.Literal && ((J.Literal) expression).getType() == JavaType.Primitive.Null;
-    }
-
-    private boolean matchesSelect(Expression expression, Expression select) {
-        return expression.printTrimmed(getCursor()).replaceAll("\\s", "")
-                .equals(select.printTrimmed(getCursor()).replaceAll("\\s", ""));
     }
 
     private static class RemoveUnnecessaryNullCheck<P> extends JavaVisitor<P> {

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -15,10 +15,10 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -30,71 +30,6 @@ class EqualsAvoidsNullTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new EqualsAvoidsNull());
-    }
-
-    @Nested
-    @Disabled
-    class replaceMethodArg {
-
-        @DocumentExample
-        @Test
-        void one() {
-            rewriteRun(
-              // language=java
-              java(
-                """
-                  public class Constants {
-                      public static final String FOO = "FOO";
-                  }
-                  class A {
-                      private boolean isFoo(String foo) {
-                          return foo.contentEquals(Constants.FOO);
-                      }
-                  }
-                  """,
-                """
-                  public class Constants {
-                      public static final String FOO = "FOO";
-                  }
-                  class A {
-                      private boolean isFoo(String foo) {
-                          return Constants.FOO.contentEquals(foo);
-                      }
-                  }
-                  """)
-            );
-        }
-
-        @DocumentExample
-        @Test
-        void multiple() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  public class Constants {
-                      public static final String FOO = "FOO";
-                  }
-                  class A {
-                      private boolean isFoo(String foo, String bar) {
-                          return foo.contentEquals(Constants.FOO)
-                              || bar.compareToIgnoreCase(Constants.FOO);
-                      }
-                  }
-                  """,
-                """
-                  public class Constants {
-                      public static final String FOO = "FOO";
-                  }
-                  class A {
-                      private boolean isFoo(String foo, String bar) {
-                          return Constants.FOO.contentEquals(foo)
-                              || Constants.FOO.compareToIgnoreCase(bar);
-                      }
-                  }
-                  """)
-            );
-        }
     }
 
     @DocumentExample
@@ -161,8 +96,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
     @Test
     void nullLiteral() {
         rewriteRun(
-            //language=java
-            java("""
+          //language=java
+          java("""
               public class A {
                     void foo(String s) {
                         if(s.equals(null)) {
@@ -170,7 +105,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
                     }
                 }
               """,
-              """
+            """
 
               public class A {
                     void foo(String s) {
@@ -180,5 +115,68 @@ class EqualsAvoidsNullTest implements RewriteTest {
                 }
               """)
         );
+    }
+
+    @Nested
+    class ReplaceConstantMethodArg {
+
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/398")
+        @Test
+        void one() {
+            rewriteRun(
+              // language=java
+              java(
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  class A {
+                      private boolean isFoo(String foo) {
+                          return foo.contentEquals(Constants.FOO);
+                      }
+                  }
+                  """,
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  class A {
+                      private boolean isFoo(String foo) {
+                          return Constants.FOO.contentEquals(foo);
+                      }
+                  }
+                  """)
+            );
+        }
+
+        @Test
+        void multiple() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  class A {
+                      private boolean isFoo(String foo, String bar) {
+                          return foo.contentEquals(Constants.FOO)
+                              || bar.compareToIgnoreCase(Constants.FOO);
+                      }
+                  }
+                  """,
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  class A {
+                      private boolean isFoo(String foo, String bar) {
+                          return Constants.FOO.contentEquals(foo)
+                              || Constants.FOO.compareToIgnoreCase(bar);
+                      }
+                  }
+                  """)
+            );
+        }
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -42,7 +42,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
               public class Constants {
                   public static final String FOO = "FOO";
               }
-              public class A {
+              class A {
                   private boolean isFoo(String foo) {
                       return foo.contentEquals(Constants.FOO)
                           || foo.equalsIgnoreCase(Constants.FOO)
@@ -54,7 +54,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
               public class Constants {
                   public static final String FOO = "FOO";
               }
-              public class A {
+              class A {
                   private boolean isFoo(String foo) {
                       return Constants.FOO.contentEquals(foo)
                           || Constants.FOO.equalsIgnoreCase(foo)

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -69,7 +69,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
         @Test
         void multiple() {
             rewriteRun(
-              // language=java
+              //language=java
               java(
                 """
                   public class Constants {

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -81,7 +81,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
                   public static final String FOO = "FOO";
               }
               class A {
-                  private boolean isFoo(String foo) {
+                  private boolean isFoo(String foo, String bar) {
                       return Constants.FOO.contentEquals(foo)
                           || Constants.FOO.compareToIgnoreCase(bar);
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -28,6 +29,40 @@ class EqualsAvoidsNullTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new EqualsAvoidsNull());
+    }
+
+    @DocumentExample
+    @Test
+    @Disabled
+    void replaceMethodArgs() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              public class Constants {
+                  public static final String FOO = "FOO";
+              }
+              public class A {
+                  private boolean isFoo(String foo) {
+                      return foo.contentEquals(Constants.FOO)
+                          || foo.equalsIgnoreCase(Constants.FOO)
+                          || foo.compareToIgnoreCase(Constants.FOO);
+                  }
+              }
+              """,
+            """
+              public class Constants {
+                  public static final String FOO = "FOO";
+              }
+              public class A {
+                  private boolean isFoo(String foo) {
+                      return Constants.FOO.contentEquals(foo)
+                          || Constants.FOO.equalsIgnoreCase(foo)
+                          || Constants.FOO.compareToIgnoreCase(foo);
+                  }
+              }
+              """)
+        );
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -30,64 +32,69 @@ class EqualsAvoidsNullTest implements RewriteTest {
         spec.recipe(new EqualsAvoidsNull());
     }
 
-    @DocumentExample
-    @Test
-    void replaceMethodArg() {
-        rewriteRun(
-          // language=java
-          java(
-            """
-              public class Constants {
-                  public static final String FOO = "FOO";
-              }
-              class A {
-                  private boolean isFoo(String foo) {
-                      return foo.contentEquals(Constants.FOO);
-                  }
-              }
-              """,
-            """
-              public class Constants {
-                  public static final String FOO = "FOO";
-              }
-              class A {
-                  private boolean isFoo(String foo) {
-                      return Constants.FOO.contentEquals(foo);
-                  }
-              }
-              """)
-        );
-    }
+    @Nested
+    @Disabled
+    class replaceMethodArg {
 
-    @DocumentExample
-    @Test
-    void replaceMethodArgs() {
-        rewriteRun(
-          // language=java
-          java(
-            """
-              public class Constants {
-                  public static final String FOO = "FOO";
-              }
-              class A {
-                  private boolean isFoo(String foo, String bar) {
-                      return foo.contentEquals(Constants.FOO)
-                          || bar.compareToIgnoreCase(Constants.FOO);
+        @DocumentExample
+        @Test
+        void one() {
+            rewriteRun(
+              // language=java
+              java(
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
                   }
-              }
-              """,
-            """
-              public class Constants {
-                  public static final String FOO = "FOO";
-              }
-              class A {
-                  private boolean isFoo(String foo, String bar) {
-                      return Constants.FOO.contentEquals(foo)
-                          || Constants.FOO.compareToIgnoreCase(bar);
+                  class A {
+                      private boolean isFoo(String foo) {
+                          return foo.contentEquals(Constants.FOO);
+                      }
                   }
-              }
-              """)
-        );
+                  """,
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  class A {
+                      private boolean isFoo(String foo) {
+                          return Constants.FOO.contentEquals(foo);
+                      }
+                  }
+                  """)
+            );
+        }
+
+        @DocumentExample
+        @Test
+        void multiple() {
+            rewriteRun(
+              // language=java
+              java(
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  class A {
+                      private boolean isFoo(String foo, String bar) {
+                          return foo.contentEquals(Constants.FOO)
+                              || bar.compareToIgnoreCase(Constants.FOO);
+                      }
+                  }
+                  """,
+                """
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  class A {
+                      private boolean isFoo(String foo, String bar) {
+                          return Constants.FOO.contentEquals(foo)
+                              || Constants.FOO.compareToIgnoreCase(bar);
+                      }
+                  }
+                  """)
+            );
+        }
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -33,7 +32,6 @@ class EqualsAvoidsNullTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    @Disabled
     void replaceMethodArgs() {
         rewriteRun(
           // language=java

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -32,6 +32,35 @@ class EqualsAvoidsNullTest implements RewriteTest {
 
     @DocumentExample
     @Test
+    void replaceMethodArg() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              public class Constants {
+                  public static final String FOO = "FOO";
+              }
+              class A {
+                  private boolean isFoo(String foo) {
+                      return foo.contentEquals(Constants.FOO);
+                  }
+              }
+              """,
+            """
+              public class Constants {
+                  public static final String FOO = "FOO";
+              }
+              class A {
+                  private boolean isFoo(String foo) {
+                      return Constants.FOO.contentEquals(foo);
+                  }
+              }
+              """)
+        );
+    }
+
+    @DocumentExample
+    @Test
     void replaceMethodArgs() {
         rewriteRun(
           // language=java
@@ -43,7 +72,6 @@ class EqualsAvoidsNullTest implements RewriteTest {
               class A {
                   private boolean isFoo(String foo, String bar) {
                       return foo.contentEquals(Constants.FOO)
-                          || foo.equalsIgnoreCase(Constants.FOO)
                           || bar.compareToIgnoreCase(Constants.FOO);
                   }
               }
@@ -55,7 +83,6 @@ class EqualsAvoidsNullTest implements RewriteTest {
               class A {
                   private boolean isFoo(String foo) {
                       return Constants.FOO.contentEquals(foo)
-                          || Constants.FOO.equalsIgnoreCase(foo)
                           || Constants.FOO.compareToIgnoreCase(bar);
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -41,10 +41,10 @@ class EqualsAvoidsNullTest implements RewriteTest {
                   public static final String FOO = "FOO";
               }
               class A {
-                  private boolean isFoo(String foo) {
+                  private boolean isFoo(String foo, String bar) {
                       return foo.contentEquals(Constants.FOO)
                           || foo.equalsIgnoreCase(Constants.FOO)
-                          || foo.compareToIgnoreCase(Constants.FOO);
+                          || bar.compareToIgnoreCase(Constants.FOO);
                   }
               }
               """,
@@ -56,7 +56,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
                   private boolean isFoo(String foo) {
                       return Constants.FOO.contentEquals(foo)
                           || Constants.FOO.equalsIgnoreCase(foo)
-                          || Constants.FOO.compareToIgnoreCase(foo);
+                          || Constants.FOO.compareToIgnoreCase(bar);
                   }
               }
               """)

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -106,7 +106,6 @@ class EqualsAvoidsNullTest implements RewriteTest {
                 }
               """,
             """
-
               public class A {
                     void foo(String s) {
                         if(s == null) {
@@ -145,7 +144,42 @@ class EqualsAvoidsNullTest implements RewriteTest {
                           return Constants.FOO.contentEquals(foo);
                       }
                   }
-                  """)
+                  """
+              )
+            );
+        }
+
+        @Test
+        void staticImport() {
+            rewriteRun(
+              // language=java
+              java(
+                """
+                  package c;
+                  public class Constants {
+                      public static final String FOO = "FOO";
+                  }
+                  """
+              ),
+              // language=java
+              java(
+                """
+                  import static c.Constants.FOO;
+                  class A {
+                      private boolean isFoo(String foo) {
+                          return foo.contentEquals(FOO);
+                      }
+                  }
+                  """,
+                """
+                  import static c.Constants.FOO;
+                  class A {
+                      private boolean isFoo(String foo) {
+                          return FOO.contentEquals(foo);
+                      }
+                  }
+                  """
+              )
             );
         }
 
@@ -175,7 +209,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
                               || Constants.FOO.compareToIgnoreCase(bar);
                       }
                   }
-                  """)
+                  """
+              )
             );
         }
 

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -178,5 +178,28 @@ class EqualsAvoidsNullTest implements RewriteTest {
                   """)
             );
         }
+
+        @Test
+        void nonStaticNonFinalNoChange() {
+            rewriteRun(
+              // language=java
+              java(
+                """
+                  public class Constants {
+                      public final String FOO = "FOO";
+                      public static String BAR = "BAR";
+                  }
+                  class A {
+                      private boolean isFoo(String foo) {
+                          return foo.contentEquals(new Constants().FOO);
+                      }
+                      private boolean isBar(String bar) {
+                          return bar.contentEquals(Constants.BAR);
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
Hi,

I might have found an issue in my local project where around 90 violations flagged by PMD are not being replaced correctly. Some of these violations seem related to a list and method arguments.

Could you please take over and enable the necessary tests to confirm if this is indeed an issue?

Thanks in advance!  

@timtebeek 
@knutwannheden 
@ggerbaud