### PR TITLE
Prove C# support for ExplicitInitialization recipe

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitInitializationVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitInitializationVisitor.java
@@ -67,12 +67,9 @@ public class ExplicitInitializationVisitor<P> extends JavaIsoVisitor<P> {
         if (service(AnnotationService.class).matches(variableDeclsCursor, LOMBOK_BUILDER_DEFAULT)) {
             return v;
         }
-        J.Literal literalInit = variable.getInitializer() instanceof J.Literal ?
-                (J.Literal) variable.getInitializer() :
-                null;
-        if (literalInit != null && !variableDecls.hasModifier(J.Modifier.Type.Final)) {
-            if (TypeUtils.asFullyQualified(variable.getType()) != null &&
-                JavaType.Primitive.Null.equals(literalInit.getType())) {
+        if (variable.getInitializer() instanceof J.Literal && !variableDecls.hasModifier(J.Modifier.Type.Final)) {
+            J.Literal literalInit = (J.Literal) variable.getInitializer();
+            if (TypeUtils.asFullyQualified(variable.getType()) != null && JavaType.Primitive.Null.equals(literalInit.getType())) {
                 v = v.withInitializer(null);
             } else if (primitive != null && !Boolean.TRUE.equals(style.getOnlyObjectReferences())) {
                 switch (primitive) {

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -20,9 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Tree;
-import org.openrewrite.csharp.tree.Cs;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
@@ -30,7 +28,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.test.RewriteTest.toRecipe;
+import static org.openrewrite.staticanalysis.charp.JavaToCsharp.toCsRecipe;
 
 @SuppressWarnings("ALL")
 class CatchClauseOnlyRethrowsTest implements RewriteTest {
@@ -340,14 +338,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     @Test
     void verifyCsharpImplicitThrow() {
         rewriteRun(
-          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
-              @Override
-              public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                  Cs.CompilationUnit cscu = JavaToCsharp.compilationUnit(cu);
-                  // Exercise the regular recipe with the now modified CSharp compilation unit
-                  return (J) new CatchClauseOnlyRethrows().getVisitor().visit(cscu, ctx);
-              }
-          })),
+          spec -> spec.recipe(toCsRecipe(new CatchClauseOnlyRethrows())),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
@@ -81,16 +81,29 @@ class ExplicitInitializationTest implements RewriteTest {
     }
 
     @Test
+    void ignoreVariablesInMethods() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  private void test() {
+                      int i = 0;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void ignoreInterfaces() {
         rewriteRun(
           //language=java
           java(
             """
               interface Test {
-                  private int a = 0;
-                  void s() {
-                      int i = 0;
-                  }
+                  int a = 0;
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/charp/ExplicitInitializationVisitorCsharpTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/charp/ExplicitInitializationVisitorCsharpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/staticanalysis/charp/ExplicitInitializationVisitorCsharpTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/charp/ExplicitInitializationVisitorCsharpTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis.charp;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.staticanalysis.ExplicitInitialization;
 import org.openrewrite.test.RecipeSpec;
@@ -46,6 +47,7 @@ class ExplicitInitializationVisitorCsharpTest implements RewriteTest {
           );
     }
 
+    @DocumentExample
     @Test
     void removeExplicitInitialization() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/charp/ExplicitInitializationVisitorCsharpTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/charp/ExplicitInitializationVisitorCsharpTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.charp;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.staticanalysis.ExplicitInitialization;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.staticanalysis.charp.JavaToCsharp.toCsRecipe;
+
+class ExplicitInitializationVisitorCsharpTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toCsRecipe(new ExplicitInitialization()))
+          .parser(JavaParser.fromJavaVersion()
+            .dependsOn(
+              // C# defines nullable primitive. These are actually in the CLR wrapper objects.
+              //language=java
+              """
+                class Nullable<T> {
+                    Integer a;
+
+                    Nullable(Integer a) {
+                        this.a = a;
+                    }
+                }
+                """
+            )
+          );
+    }
+
+    @Test
+    void removeExplicitInitialization() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  // C#: int? a
+                  Nullable<Integer> a = null;
+                  // C#: int? a = 0
+                  Nullable<Integer> a = new Nullable<>(0);
+              }
+              """,
+            """
+              class A {
+                  // C#: int? a
+                  Nullable<Integer> a;
+                  // C#: int? a = 0
+                  Nullable<Integer> a = new Nullable<>(0);
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/charp/JavaToCsharp.java
+++ b/src/test/java/org/openrewrite/staticanalysis/charp/JavaToCsharp.java
@@ -13,18 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.staticanalysis;
+package org.openrewrite.staticanalysis.charp;
 
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
 import org.openrewrite.csharp.tree.Cs;
+import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.test.AdHocRecipe;
 
 import java.util.List;
 
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
 public class JavaToCsharp {
 
-    public static Cs.CompilationUnit compilationUnit(J.CompilationUnit cu) {
+    public static AdHocRecipe toCsRecipe(Recipe recipe) {
+        return toRecipe(() -> new JavaVisitor<>() {
+            @Override
+            public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                Cs.CompilationUnit cscu = compilationUnit(cu);
+                // Exercise the regular recipe with the now modified CSharp compilation unit
+                return (J) recipe.getVisitor().visit(cscu, ctx);
+            }
+        });
+    }
+
+    private static Cs.CompilationUnit compilationUnit(J.CompilationUnit cu) {
         return new Cs.CompilationUnit(
           cu.getId(),
           cu.getPrefix(),


### PR DESCRIPTION
## What's changed?
Nothing, it just adds a test to prove C# works with the ExplicitInitialization recipe.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
