### PR TITLE
Use compileOnly configuration for optional language dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,9 +14,12 @@ dependencies {
 
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
     implementation("org.openrewrite:rewrite-java")
-    implementation("org.openrewrite:rewrite-groovy:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-csharp:${rewriteVersion}")
+    compileOnly("org.openrewrite:rewrite-groovy:${rewriteVersion}")
+    testImplementation("org.openrewrite:rewrite-groovy:${rewriteVersion}")
+    compileOnly("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
+    testImplementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
+    compileOnly("org.openrewrite:rewrite-csharp:${rewriteVersion}")
+    testImplementation("org.openrewrite:rewrite-csharp:${rewriteVersion}")
     implementation("org.openrewrite.meta:rewrite-analysis:${rewriteVersion}")
     implementation("org.apache.commons:commons-text:latest.release")
 

--- a/src/main/java/org/openrewrite/staticanalysis/csharp/CSharpFileChecker.java
+++ b/src/main/java/org/openrewrite/staticanalysis/csharp/CSharpFileChecker.java
@@ -20,14 +20,17 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.csharp.tree.Cs;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.staticanalysis.internal.ClassPathUtils;
 
 /**
  * Add a search marker if vising a CSharp file
  */
 public class CSharpFileChecker<P> extends TreeVisitor<Tree, P> {
+    private static final boolean IS_CSHARP_AVAILABLE = ClassPathUtils.isAvailable("org.openrewrite.csharp.tree.Cs$CompilationUnit");
+
     @Override
     public @Nullable Tree visit(@Nullable Tree tree, P p) {
-        if (tree instanceof Cs.CompilationUnit) {
+        if (IS_CSHARP_AVAILABLE && tree instanceof Cs.CompilationUnit) {
             return SearchResult.found(tree);
         }
         return tree;

--- a/src/main/java/org/openrewrite/staticanalysis/groovy/GroovyFileChecker.java
+++ b/src/main/java/org/openrewrite/staticanalysis/groovy/GroovyFileChecker.java
@@ -20,14 +20,17 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.staticanalysis.internal.ClassPathUtils;
 
 /**
  * Add a search marker if vising a Groovy file
  */
 public class GroovyFileChecker<P> extends TreeVisitor<Tree, P> {
+    private static final boolean IS_GROOVY_AVAILABLE = ClassPathUtils.isAvailable("org.openrewrite.groovy.tree.G$CompilationUnit");
+
     @Override
     public @Nullable Tree visit(@Nullable Tree tree, P p) {
-        if (tree instanceof G.CompilationUnit) {
+        if (IS_GROOVY_AVAILABLE && tree instanceof G.CompilationUnit) {
             return SearchResult.found(tree);
         }
         return tree;

--- a/src/main/java/org/openrewrite/staticanalysis/internal/ClassPathUtils.java
+++ b/src/main/java/org/openrewrite/staticanalysis/internal/ClassPathUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.internal;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ClassPathUtils {
+    public static boolean isAvailable(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/kotlin/KotlinFileChecker.java
+++ b/src/main/java/org/openrewrite/staticanalysis/kotlin/KotlinFileChecker.java
@@ -20,14 +20,17 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.staticanalysis.internal.ClassPathUtils;
 
 /**
  * Add a search marker if vising a Kotlin file
  */
 public class KotlinFileChecker<P> extends TreeVisitor<Tree, P> {
+    private static final boolean IS_KOTLIN_AVAILABLE = ClassPathUtils.isAvailable("org.openrewrite.kotlin.tree.K$CompilationUnit");
+
     @Override
     public @Nullable Tree visit(@Nullable Tree tree, P p) {
-        if (tree instanceof K.CompilationUnit) {
+        if (IS_KOTLIN_AVAILABLE && tree instanceof K.CompilationUnit) {
             return SearchResult.found(tree);
         }
         return tree;


### PR DESCRIPTION
## What's changed?
Groovy, Kotlin and CSharp dependencies are changed to `compileOnly`. The filechecker-classes have been adjusted with a reflection check 

## What's your motivation?
- https://github.com/openrewrite/rewrite-static-analysis/issues/410

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
