### PR TITLE
`UseLambdaForFunctionalInterface` recipe should not convert when code uses a static field from enum constructor

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -96,6 +96,10 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         StringBuilder templateBuilder = new StringBuilder();
                         J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) n.getBody().getStatements().get(0);
 
+                        if (isLambdaInEnumConstructorWithStaticField(getCursor(), methodDeclaration)) {
+                            return n;
+                        }
+
                         // If the functional interface method has type parameters, we can't replace it with a lambda.
                         if (methodDeclaration.getTypeParameters() != null && !methodDeclaration.getTypeParameters().isEmpty()) {
                             return n;
@@ -135,6 +139,37 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                     }
                 }
                 return n;
+            }
+
+            private boolean isLambdaInEnumConstructorWithStaticField(Cursor cursor, J.MethodDeclaration md) {
+                if (md.getBody() == null) {
+                    return false;
+                }
+
+                for (Statement s : md.getBody().getStatements()) {
+                    J.MethodInvocation e = null;
+                    if (s instanceof J.VariableDeclarations && ((J.VariableDeclarations) s).getVariables().size() == 1 && ((J.VariableDeclarations) s).getVariables().get(0).getInitializer() instanceof J.MethodInvocation) {
+                        e = (J.MethodInvocation) ((J.VariableDeclarations) s).getVariables().get(0).getInitializer();
+                    } else if (s instanceof J.MethodInvocation) {
+                        e = (J.MethodInvocation) s;
+                    }
+
+                    if (e != null && e.getSelect() instanceof J.Identifier) {
+                        JavaType.Variable v = ((J.Identifier) e.getSelect()).getFieldType();
+                        if (v != null && v.hasFlags(Flag.Static)) {
+                            JavaType owner = v.getOwner();
+                            if (owner instanceof JavaType.Class && ((JavaType.Class) owner).getKind() == JavaType.Class.Kind.Enum) {
+                                J.MethodDeclaration parentMethodDeclaration = cursor.dropParentUntil(p -> p instanceof J.MethodDeclaration).getValue();
+                                J.ClassDeclaration parentClass = cursor.dropParentUntil(p -> p instanceof J.ClassDeclaration).getValue();
+                                if (parentMethodDeclaration.isConstructor() && owner.equals(parentClass.getType())) {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return false;
             }
 
             private J maybeAddCast(J.Lambda lambda, J.NewClass original) {

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -833,7 +833,7 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
-    void dontUseLambdaWhenEnumAccessesNonStaticFieldFromConstructor() {
+    void doUseLambdaWhenEnumAccessesNonStaticFieldFromConstructor() {
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -805,77 +805,7 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
-    void dontUseLambdaWhenEnumAccessesStaticFieldFromConstructorWithAssignment() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import java.time.LocalDate;
-              import java.time.format.DateTimeFormatter;
-              enum Test {
-                  A, B;
-
-                  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-                  Test() {
-                      Runnable r = new Runnable() {
-                          @Override
-                          public void run() {
-                              String s = DATE_FORMAT.format(LocalDate.now());
-                          }
-                      };
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
-    void doUseLambdaWhenEnumAccessesNonStaticFieldFromConstructor() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import java.time.LocalDate;
-              import java.time.format.DateTimeFormatter;
-              enum Test {
-                  A, B;
-
-                  private final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-                  Test() {
-                      Runnable r = new Runnable() {
-                          @Override
-                          public void run() {
-                              DATE_FORMAT.format(LocalDate.now());
-                          }
-                      };
-                  }
-              }
-              """,
-            """
-              import java.time.LocalDate;
-              import java.time.format.DateTimeFormatter;
-              enum Test {
-                  A, B;
-
-                  private final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-                  Test() {
-                      Runnable r = () ->
-                              DATE_FORMAT.format(LocalDate.now());
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
-    void doUseLambdaWhenEnumAccessesStaticFieldFromMethod() {
+    void dontUseLambdaWhenEnumAccessesStaticFieldFromFromMethod() {
         rewriteRun(
           //language=java
           java(
@@ -894,20 +824,6 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
                               DATE_FORMAT.format(LocalDate.now());
                           }
                       };
-                  }
-              }
-              """,
-            """
-              import java.time.LocalDate;
-              import java.time.format.DateTimeFormatter;
-              enum Test {
-                  A, B;
-
-                  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-                  void test() {
-                      Runnable r = () ->
-                              DATE_FORMAT.format(LocalDate.now());
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
No more lambda conversion for `UseLambdaForFunctionalInterface` recipe when the anonymous class is within a constructor of a Enum class and uses a static field of this very class.

## What's your motivation?
- https://github.com/openrewrite/rewrite-static-analysis/issues/413

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
