### PR TITLE
Recipe(s) not found: org.openrewrite.staticanalysis.CommonStaticAnalysis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
     id("org.openrewrite.build.moderne-source-available-license") version "latest.release"
-    pmd
+    id("org.openrewrite.rewrite") version("6.29.0")
 }
 
 group = "org.openrewrite.recipe"
@@ -37,11 +37,10 @@ dependencies {
 
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
+    rewrite("org.openrewrite.recipe:rewrite-static-analysis:1.22.0")
 }
-pmd {
-    isConsoleOutput = true
-    ruleSetFiles = files("${projectDir}/src/test/resources/pmd/pmd-rules.xml")
-//    rulesMinimumPriority = 5
-//    rulesMinimumPriority = 1
-//    ruleSets = listOf("category/java/errorprone.xml", "category/java/bestpractices.xml")
+
+rewrite {
+    activeRecipe("org.openrewrite.staticanalysis.CommonStaticAnalysis")
+    setExportDatatables(true)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
     id("org.openrewrite.build.moderne-source-available-license") version "latest.release"
+    pmd
 }
 
 group = "org.openrewrite.recipe"
@@ -36,4 +37,11 @@ dependencies {
 
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
+}
+pmd {
+    isConsoleOutput = true
+    ruleSetFiles = files("${projectDir}/src/test/resources/pmd/pmd-rules.xml")
+//    rulesMinimumPriority = 5
+//    rulesMinimumPriority = 1
+//    ruleSets = listOf("category/java/errorprone.xml", "category/java/bestpractices.xml")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,20 @@
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
     id("org.openrewrite.build.moderne-source-available-license") version "latest.release"
-    id("org.openrewrite.rewrite") version("6.29.0")
+    id("org.openrewrite.rewrite") version("6.29.2")
 }
 
+val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 group = "org.openrewrite.recipe"
 description = "The first Static Analysis and REMEDIATION tool"
 
-val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
+    annotationProcessor("org.openrewrite:rewrite-templating:${rewriteVersion}")
+    annotationProcessor("org.projectlombok:lombok:latest.release")
     compileOnly("org.projectlombok:lombok:latest.release")
     compileOnly("com.google.errorprone:error_prone_core:2.+:with-dependencies") {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
-    annotationProcessor("org.openrewrite:rewrite-templating:${rewriteVersion}")
-    annotationProcessor("org.projectlombok:lombok:latest.release")
     implementation("org.apache.commons:commons-text:latest.release")
     implementation("org.openrewrite.meta:rewrite-analysis:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-csharp:${rewriteVersion}")
@@ -23,7 +23,6 @@ dependencies {
     implementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-templating:${rewriteVersion}")
     implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
-    rewrite("org.openrewrite.recipe:rewrite-static-analysis:1.22.0")
     testImplementation("com.google.code.gson:gson:latest.release")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains:annotations:24.+")
@@ -33,9 +32,14 @@ dependencies {
     testImplementation("org.projectlombok:lombok:latest.release")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
+    rewrite("org.openrewrite.recipe:rewrite-static-analysis:1.22.0")
 }
-
+repositories {
+    mavenCentral()
+}
 rewrite {
     activeRecipe("org.openrewrite.staticanalysis.CommonStaticAnalysis")
+//    activeRecipe("org.openrewrite.staticanalysis.EqualsAvoidsNull") // not found
+//    activeRecipe("org.openrewrite.java.RemoveObjectsIsNull") // found
     setExportDatatables(true)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,34 +10,29 @@ description = "The first Static Analysis and REMEDIATION tool"
 val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
-    annotationProcessor("org.projectlombok:lombok:latest.release")
-    testImplementation("org.projectlombok:lombok:latest.release")
-
-    implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
-    implementation("org.openrewrite:rewrite-java")
-    implementation("org.openrewrite:rewrite-groovy:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-csharp:${rewriteVersion}")
-    implementation("org.openrewrite.meta:rewrite-analysis:${rewriteVersion}")
-    implementation("org.apache.commons:commons-text:latest.release")
-
-    annotationProcessor("org.openrewrite:rewrite-templating:${rewriteVersion}")
-    implementation("org.openrewrite:rewrite-templating:${rewriteVersion}")
     compileOnly("com.google.errorprone:error_prone_core:2.+:with-dependencies") {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
-
+    annotationProcessor("org.openrewrite:rewrite-templating:${rewriteVersion}")
+    annotationProcessor("org.projectlombok:lombok:latest.release")
+    implementation("org.apache.commons:commons-text:latest.release")
+    implementation("org.openrewrite.meta:rewrite-analysis:${rewriteVersion}")
+    implementation("org.openrewrite:rewrite-csharp:${rewriteVersion}")
+    implementation("org.openrewrite:rewrite-groovy:${rewriteVersion}")
+    implementation("org.openrewrite:rewrite-java")
+    implementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
+    implementation("org.openrewrite:rewrite-templating:${rewriteVersion}")
+    implementation(platform("org.openrewrite:rewrite-bom:${rewriteVersion}"))
+    rewrite("org.openrewrite.recipe:rewrite-static-analysis:1.22.0")
+    testImplementation("com.google.code.gson:gson:latest.release")
+    testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains:annotations:24.+")
+    testImplementation("org.junit-pioneer:junit-pioneer:2.+")
     testImplementation("org.openrewrite:rewrite-groovy")
     testImplementation("org.openrewrite:rewrite-test")
-    testImplementation("org.junit-pioneer:junit-pioneer:2.+")
-    testImplementation("junit:junit:4.13.2")
-
-    testImplementation("com.google.code.gson:gson:latest.release")
-
-    testRuntimeOnly("org.openrewrite:rewrite-java-17")
+    testImplementation("org.projectlombok:lombok:latest.release")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
-    rewrite("org.openrewrite.recipe:rewrite-static-analysis:1.22.0")
+    testRuntimeOnly("org.openrewrite:rewrite-java-17")
 }
 
 rewrite {


### PR DESCRIPTION
I am trying to add `CommonStaticAnalysis` to see what the findings are, but I am unable to proceed as it is not found. 

```
13:18:11: Executing 'rewriteRun'…

Starting Gradle Daemon...
Gradle Daemon started in 1 s 195 ms

> Configure project :
Inferred project: rewrite-static-analysis, version: 1.23.0-SNAPSHOT

> Task :compileJava UP-TO-DATE
> Task :rewriteRecipeAuthorAttributionJava UP-TO-DATE
> Task :rewriteRecipeAuthorAttributionResources UP-TO-DATE
> Task :copyAttribution UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava UP-TO-DATE
> Task :rewriteRun FAILED
7 actionable tasks: 1 executed, 6 up-to-date

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rewriteRun'.
> org.openrewrite.RecipeException: Recipe(s) not found: org.openrewrite.staticanalysis.CommonStaticAnalysis
  Did you mean: org.openrewrite.search.FindCommitters

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 26s
13:18:38: Execution finished 'rewriteRun'.
```
Recipes from Java, like `java.RemoveObjectsIsNull`, are found, so it seems to be an import-related issue. I remember encountering this earlier when using the plugin with Maven too, but I don't know how I fixed it then.

Could you please give me a hint on how to resolve the missing recipe dependency?

Thanks!

---

### CLI Issues  

In addition, the CLI is not working. When there is an error, it is unfortunate that no output is generated to show at least the partially successful parsing of the actual files.  

With even one tiny error, it becomes not very "useful" at all. Is there a parameter to enforce partial parsing and flush results into the result files?  


```

    ▛▀▀▚▖  ▗▄▟▜6QF rewrite-static-analysis % mod run . --recipe CommonStaticAnalysis
    ▌   ▜▄▟▀  ▐
    ▛▀▀█▀▛▀▀▀▀▜
    ▌▟▀  ▛▀▀▀▀▜
    ▀▀▀▀▀▀▀▀▀▀▀
Moderne CLI 3.20.8

> Selecting repositories

> openrewrite/rewrite-static-analysis@CommonStaticAnalysis
Selected 1 repository (0.08s)

> Running recipe org.openrewrite.staticanalysis.CommonStaticAnalysis

> openrewrite/rewrite-static-analysis@CommonStaticAnalysis
    ! Found 92 errors while running the recipe. Look at org.openrewrite.table.SourcesFileErrors data table for more details.
    ! Recipe run produced an error. Since this is the first error, its stack trace will be shown at the completion of the run. An error log was created at file:///Users/u/IdeaProjects/rewrite-static-analysis/.moderne/run/20241229131358-H90sD/run-error.log
    No changes
 
No results found; 1 repository generated errors (7s)

1m 6s saved by using previously built LSTs

FAILURE: mod failed with an exception

* Where:
org.openrewrite.polyglot.RemoteException: java.lang.IllegalStateException: Source file changed but no recipe reported making a change. The following diff highlights the places where unexpected changes were made:
```
```diff
diff --git a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
index fe624a7..8d1a4da 100644
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnreachableCodeVisitor.java
@@ -13,50 +13,50 @@ 
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.staticanalysis;
+package /*~~>*/org./*~~>*/openrewrite./*~~>*/staticanalysis;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.Statement;
+import /*~~>*/org./*~~>*/openrewrite./*~~>*/ExecutionContext;
+import /*~~>*/org./*~~>*/openrewrite./*~~>*/java./*~~>*/JavaVisitor;
+import /*~~>*/org./*~~>*/openrewrite./*~~>*/java./*~~>*/tree./*~~>*/J;
+import /*~~>*/org./*~~>*/openrewrite./*~~>*/java./*~~>*/tree./*~~>*/Statement;
 
-import java.util.List;
-import java.util.Optional;
+import /*~~>*/java./*~~>*/util./*~~>*/List;
+import /*~~>*/java./*~~>*/util./*~~>*/Optional;
 
-class RemoveUnreachableCodeVisitor extends JavaVisitor<ExecutionContext> {
+class /*~~>*/RemoveUnreachableCodeVisitor extends /*~~>*/JavaVisitor</*~~>*/ExecutionContext> {
 
-  @Override
-  public J visitBlock(J.Block block, ExecutionContext executionContext) {
-    block = (J.Block) super.visitBlock(block, executionContext);
+  @/*~~>*/Override
+  /*~~>*/public /*~~>*/J /*~~>*/visitBlock(/*~~>*/J./*~~>*/Block /*~~>*/block, /*~~>*/ExecutionContext /*~~>*/executionContext) {
+    /*~~>*/block = (/*~~>*/J./*~~>*/Block) /*~~>*/super./*~~>*/visitBlock(/*~~>*/block, /*~~>*/executionContext);
 
-    List<Statement> statements = block.getStatements();
-    Optional<Integer> maybeFirstJumpIndex = findFirstJump(statements);
-    if (!maybeFirstJumpIndex.isPresent()) {
-      return block;
+    /*~~>*/List</*~~>*/Statement> /*~~>*/statements = /*~~>*/block./*~~>*/getStatements(/*~~>*/);
+    /*~~>*/Optional</*~~>*/Integer> /*~~>*/maybeFirstJumpIndex = /*~~>*/findFirstJump(/*~~>*/statements);
+    if (!/*~~>*/maybeFirstJumpIndex./*~~>*/isPresent(/*~~>*/)) {
+      return /*~~>*/block;
     }
-    int firstJumpIndex = maybeFirstJumpIndex.get();
+    /*~~>*/int /*~~>*/firstJumpIndex = /*~~>*/maybeFirstJumpIndex./*~~>*/get(/*~~>*/);
 
-    if (firstJumpIndex == statements.size() - 1) {
+    if (/*~~>*/firstJumpIndex == /*~~>*/statements./*~~>*/size(/*~~>*/) - /*~~>*/1) {
       // Jump is at the end of the block, so nothing to do
-      return block;
+      return /*~~>*/block;
     }
 
-    List<Statement> newStatements = statements.subList(0, firstJumpIndex + 1);
-    return block.withStatements(newStatements);
+    /*~~>*/List</*~~>*/Statement> /*~~>*/newStatements = /*~~>*/statements./*~~>*/subList(/*~~>*/0, /*~~>*/firstJumpIndex + /*~~>*/1);
+    return /*~~>*/block./*~~>*/withStatements(/*~~>*/newStatements);
   }
 
-  private Optional<Integer> findFirstJump(List<Statement> statements) {
-    for (int i = 0; i < statements.size(); i++) {
-      Statement statement = statements.get(i);
+  /*~~(Service interface org.openrewrite.internal.NamingService not supported)~~>*//*~~>*/private /*~~>*/Optional</*~~>*/Integer> /*~~>*/findFirstJump(/*~~>*/List</*~~>*/Statement> /*~~>*/statements) {
+    for (/*~~>*/int /*~~>*/i = /*~~>*/0; /*~~>*/i < /*~~>*/statements./*~~>*/size(/*~~>*/); /*~~>*/i++) {
+      /*~~>*/Statement /*~~>*/statement = /*~~>*/statements./*~~>*/get(/*~~>*/i);
       if (
-          statement instanceof J.Return ||
-          statement instanceof J.Throw ||
-          statement instanceof J.Break ||
-          statement instanceof J.Continue
+          /*~~>*/statement instanceof /*~~>*/J./*~~>*/Return ||
+          /*~~>*/statement instanceof /*~~>*/J./*~~>*/Throw ||
+          /*~~>*/statement instanceof /*~~>*/J./*~~>*/Break ||
+          /*~~>*/statement instanceof /*~~>*/J./*~~>*/Continue
       ) {
-        return Optional.of(i);
+        return /*~~>*/Optional./*~~>*/of(/*~~>*/i);
       }
     }
-    return Optional.empty();
+    return /*~~>*/Optional./*~~>*/empty(/*~~>*/);
   }
 }
\ No newline at end of file
```
```
  org.openrewrite.polyglot.RemoteProgressBarReceiver.maybeThrow(RemoteProgressBarReceiver.java:136)
  org.openrewrite.polyglot.RemoteProgressBarReceiver.close(RemoteProgressBarReceiver.java:130)
  io.moderne.cli.commands.Run.runRecipe(Run.java:353)
  io.moderne.cli.commands.Run.runAndShowNextSteps(Run.java:129)
  io.moderne.cli.commands.Run.run(Run.java:114)
  io.moderne.cli.commands.StandardCommand.call(StandardCommand.java:129)
  io.moderne.cli.commands.StandardCommand.call(StandardCommand.java:38)
  picocli.CommandLine.executeUserObject(CommandLine.java:2045)
  ...

* What went wrong:
A repository failed to run. The exception for the failure on openrewrite/rewrite-static-analysis@CommonStaticAnalysis is shown above.

* Try:
> Report to support@moderne.io


MOD FAILED in (7s)
G3Q0CXV6QF rewrite-static-analysis % 
```