### PR TITLE
Don't remove necessary whitespace in EqualsAvoidNull

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -157,7 +157,7 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
         public J visitBinary(J.Binary binary, P p) {
             if (scope.isScope(binary)) {
                 done = true;
-                return binary.getRight().withPrefix(Space.EMPTY);
+                return binary.getRight();
             }
             return super.visitBinary(binary, p);
         }

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -157,7 +157,7 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
         public J visitBinary(J.Binary binary, P p) {
             if (scope.isScope(binary)) {
                 done = true;
-                return binary.getRight();
+                return binary.getRight().withPrefix(binary.getPrefix());
             }
             return super.visitBinary(binary, p);
         }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -407,5 +407,33 @@ class EqualsAvoidsNullTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/434")
+        void missingWhitespace() {
+            rewriteRun(
+              // language=java
+              java(
+                """
+                  class A {
+                      private static final String FOO = "FOO";
+
+                      boolean withParentExpression(String foo) {
+                          return foo != null && foo.equals(FOO);
+                      }
+                  }
+                  """,              
+                """
+                  class A {
+                      private static final String FOO = "FOO";
+
+                      boolean withParentExpression(String foo) {
+                          return FOO.equals(foo);
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -422,7 +422,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
                           return foo != null && foo.equals(FOO);
                       }
                   }
-                  """,              
+                  """,
                 """
                   class A {
                       private static final String FOO = "FOO";


### PR DESCRIPTION
- Fixes #434, but makes another test fail.

## What's changed?
<!-- A brief description of the changes in this pull request -->
Avoid unconditionally removing the whitespace prefix of the optimized expression.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
It depends on the parent, whether removing whitespace is syntactially valid.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
This is incomplete, as another test fails now. We get `if( "test".equals(s)) {}` (note the unwanted space after the opening brace) in another test case, which comes from optimizing `if(s != null && s.equals("test"))` and still using the space character which was after the `&&` operator.

I'm not sure about the correct way to proceed. When I worked with domain specific languages in another project, the formatter of the language (used in the serializer) would enforce additional whitespace in a case like this ("return", ADDITIONAL_SPACE_INSERTED_HERE, returnValue) when processing the return statement. But I've not found any concept like that in the source. It looks like the expressions really only hold their own parsed space, which makes conditionally removing unwanted space like in this visitor much harder.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
