### PR TITLE
Restore double negation test in `SimplifyBooleanExpressionTest`

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
@@ -271,6 +271,13 @@ class SimplifyBooleanExpressionTest implements RewriteTest {
             """
               public class A {
                   public void doubleNegation(boolean g) {
+                      boolean h = !!g;
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void doubleNegation(boolean g) {
                       boolean h = g;
                   }
               }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The test wasn't implemented according to its intention. The intended double negation was completely missing.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Someone might want to check if this was optimized away at some point in the past by applying the rewrite recipes to its own code. If so, other places (in test code) might be affected by wrongly having been refactored.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
