### PR TITLE
Skip constructors in `UnnecessaryThrows` for now

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryThrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryThrows.java
@@ -142,7 +142,7 @@ public class UnnecessaryThrows extends Recipe {
 
     private Set<JavaType.FullyQualified> findExceptionCandidates(J.@Nullable MethodDeclaration method) {
 
-        if (method == null || method.getMethodType() == null || method.isAbstract()) {
+        if (method == null || method.getMethodType() == null || method.isAbstract() || method.isConstructor()) {
             return Collections.emptySet();
         }
 
@@ -154,7 +154,7 @@ public class UnnecessaryThrows extends Recipe {
                 if (exception.getType() == null || exception.getType() instanceof JavaType.Unknown) {
                     return Collections.emptySet();
                 }
-                if (exception.getType() instanceof JavaType.FullyQualified && !TypeUtils.isAssignableTo(JavaType.ShallowClass.build("java.lang.RuntimeException"), exception.getType())) {
+                if (exception.getType() instanceof JavaType.FullyQualified && !TypeUtils.isAssignableTo("java.lang.RuntimeException", exception.getType())) {
                     candidates.add(TypeUtils.asFullyQualified(exception.getType()));
                 }
             }

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
@@ -183,6 +184,28 @@ class UnnecessaryThrowsTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/443")
     @Test
     void necessaryThrowsFromConstructor() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.IOException;
+
+              class Test {
+                  String str = test();
+                  Test() throws IOException {}
+                  String test() throws IOException {
+                      throw new IOException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @ExpectedToFail("Not yet implemented")
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/443")
+    @Test
+    void necessaryThrowsFromConstructorWithUnused() {
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
@@ -180,6 +180,39 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/443")
+    @Test
+    void necessaryThrowsFromConstructor() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.IOException;
+              import java.util.concurrent.ExecutionException;
+
+              class Test {
+                  String str = test();
+                  Test() throws IOException, ExecutionException {}
+                  String test() throws IOException {
+                      throw new IOException();
+                  }
+              }
+              """,
+            """
+              import java.io.IOException;
+
+              class Test {
+                  String str = test();
+                  Test() throws IOException {}
+                  String test() throws IOException {
+                      throw new IOException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/897")
     @Test
     void necessaryThrowsOnInterfaceWithExplicitOverride() {


### PR DESCRIPTION
## What's changed?
This adds a test for issue #443

