### PR TITLE
recipe: On abstract classes make constructors protected

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AbstractClassPublicConstructor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AbstractClassPublicConstructor.java
@@ -1,0 +1,55 @@
+package org.openrewrite.staticanalysis;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+public class AbstractClassPublicConstructor extends Recipe {
+  @Override
+  public String getDisplayName() {
+    return "Make constructors of abstract classes protected";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Constructors of abstract classes can only be called in constructors of their subclasses. "
+      + "Therefore the visibility of public constructors are reduced to protected.";
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return Collections.singleton("RSPEC-S5993");
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getVisitor() {
+    return new JavaIsoVisitor<ExecutionContext>() {
+      @Override
+      public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+        J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+        if (cd.getModifiers().stream().anyMatch(mod -> mod.getType() == J.Modifier.Type.Abstract)) {
+          doAfterVisit(CHANGE_CONSTRUCTOR_ACCESS_LEVEL_VISITOR);
+        }
+        return cd;
+      }
+    };
+  }
+
+  static final TreeVisitor<?, ExecutionContext> CHANGE_CONSTRUCTOR_ACCESS_LEVEL_VISITOR = new JavaIsoVisitor<ExecutionContext>() {
+    @Override
+    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+      J.MethodDeclaration md = super.visitMethodDeclaration(method, ctx);
+      if (md.isConstructor() && md.getModifiers().stream().anyMatch(mod -> mod.getType() == J.Modifier.Type.Public)) {
+        md = md.withModifiers(ListUtils.map(md.getModifiers(),
+          mod -> mod.getType() == J.Modifier.Type.Public ? mod.withType(J.Modifier.Type.Protected) : mod));
+      }
+      return md;
+    }
+  };
+}

--- a/src/test/java/org/openrewrite/staticanalysis/AbstractClassPublicConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AbstractClassPublicConstructorTest.java
@@ -1,0 +1,60 @@
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings("java:S2699")
+class AbstractClassPublicConstructorTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AbstractClassPublicConstructor());
+    }
+
+    @DocumentExample
+    @Test
+    void replacePublicByProtected() {
+        rewriteRun(
+          //language=java
+          java("""
+            abstract class Test {
+                public Test() {
+                }
+            }
+            """, """
+            abstract class Test {
+                protected Test() {
+                }
+            }
+            """));
+    }
+
+    @Test
+    void noReplaceOnNonAbstractClass() {
+        rewriteRun(
+          //language=java
+          java("""
+            class Test {
+                public Test() {
+                }
+            }
+            """));
+    }
+
+    @Test
+    void noReplaceOnPackageProtectedConstructor() {
+        rewriteRun(
+          //language=java
+          java("""
+            abstract class Test {
+                Test() {
+                }
+            }
+            """));
+    }
+}
+


### PR DESCRIPTION
This recipe resolves Sonar issues of type S5993: Constructors of an "abstract" class should not be declared "public"

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
A new recipe

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
closes #449

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
nothing special

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
