### PR TITLE
feat: prevent UnnecessaryCatch from removing `catch (Throwable t)`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
@@ -43,6 +43,14 @@ public class UnnecessaryCatch extends Recipe {
             required = false)
     boolean includeJavaLangException;
 
+    @Option(displayName = "Include `java.lang.Throwable`",
+        description = "Whether to include java.lang.Throwable in the list of checked exceptions to remove. " +
+            "Unlike other checked exceptions, `java.lang.Throwable` is also the superclass of unchecked exceptions. " +
+            "So removing `catch(Throwable e)` may result in changed runtime behavior in the presence of unchecked exceptions. " +
+            "Default `false`",
+        required = false)
+    boolean includeJavaLangThrowable;
+
     @Override
     public String getDisplayName() {
         return "Remove catch for a checked exception if the try block does not throw that exception";
@@ -106,6 +114,9 @@ public class UnnecessaryCatch extends Recipe {
                         return aCatch;
                     }
                     if (!includeJavaLangException && TypeUtils.isOfClassType(parameterType, "java.lang.Exception")) {
+                        return aCatch;
+                    }
+                    if (!includeJavaLangThrowable && TypeUtils.isOfClassType(parameterType, "java.lang.Throwable")) {
                         return aCatch;
                     }
                     for (JavaType e : thrownExceptions) {

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
@@ -36,19 +36,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class UnnecessaryCatch extends Recipe {
 
     @Option(displayName = "Include `java.lang.Exception`",
-            description = "Whether to include java.lang.Exception in the list of checked exceptions to remove. " +
-                          "Unlike other checked exceptions, `java.lang.Exception` is also the superclass of unchecked exceptions. " +
-                          "So removing `catch(Exception e)` may result in changed runtime behavior in the presence of unchecked exceptions. " +
-                          "Default `false`",
+            description = "Whether to include `java.lang.Exception` in the list of checked exceptions to remove. " +
+                    "Unlike other checked exceptions, `java.lang.Exception` is also the superclass of unchecked exceptions. " +
+                    "So removing `catch(Exception e)` may result in changed runtime behavior in the presence of unchecked exceptions. " +
+                    "Default `false`",
             required = false)
     boolean includeJavaLangException;
 
     @Option(displayName = "Include `java.lang.Throwable`",
-        description = "Whether to include java.lang.Throwable in the list of checked exceptions to remove. " +
-            "Unlike other checked exceptions, `java.lang.Throwable` is also the superclass of unchecked exceptions. " +
-            "So removing `catch(Throwable e)` may result in changed runtime behavior in the presence of unchecked exceptions. " +
-            "Default `false`",
-        required = false)
+            description = "Whether to include `java.lang.Throwable` in the list of exceptions to remove. " +
+                    "Unlike other checked exceptions, `java.lang.Throwable` is also the superclass of unchecked exceptions. " +
+                    "So removing `catch(Throwable e)` may result in changed runtime behavior in the presence of unchecked exceptions. " +
+                    "Default `false`",
+            required = false)
     boolean includeJavaLangThrowable;
 
     @Override
@@ -128,7 +128,6 @@ public class UnnecessaryCatch extends Recipe {
                     return null;
                 }));
             }
-
         };
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
@@ -27,7 +27,7 @@ class UnnecessaryCatchTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new UnnecessaryCatch(false));
+        spec.recipe(new UnnecessaryCatch(false, false));
     }
 
     @DocumentExample
@@ -157,6 +157,26 @@ class UnnecessaryCatchTest implements RewriteTest {
               }
               """
           )
+        );
+    }
+
+    @Test
+    void doNotRemoveJavaLangThrowable() {
+        rewriteRun(
+            //language=java
+            java(
+                """
+                  class Scratch {
+                      void method() {
+                          try {
+                              throw new RuntimeException();
+                          } catch (Throwable e) {
+                              System.out.println("an exception!");
+                          }
+                      }
+                  }
+                  """
+            )
         );
     }
 }


### PR DESCRIPTION
Similar to `catch (Exception e)` it is undesired to remove `catch (Throwable t)` blocks as it changes the runtime behavior.

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The UnnecessaryCatch rule did always remove `catch (Throwable t)`, which changes runtime behavior.

## What's your motivation?
Although the use of Throwable isn't recommended there are use cases. When `catch (Throwable t)` is removed it changes the runtime behavior.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
