### PR TITLE
fix: consider constructors in UnnecessaryCatch

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
@@ -24,6 +24,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.NewClass;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
@@ -88,6 +89,18 @@ public class UnnecessaryCatch extends Recipe {
                 AtomicBoolean missingTypeInformation = new AtomicBoolean(false);
                 //Collect any checked exceptions thrown from the try block.
                 new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public NewClass visitNewClass(NewClass newClass, Integer integer) {
+                        JavaType.Method methodType = newClass.getMethodType();
+                        if (methodType == null) {
+                            //Do not make any changes if there is missing type information.
+                            missingTypeInformation.set(true);
+                        } else {
+                            thrownExceptions.addAll(methodType.getThrownExceptions());
+                        }
+                        return super.visitNewClass(newClass, integer);
+                    }
+
                     @Override
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer integer) {
                         JavaType.Method methodType = method.getMethodType();

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
@@ -141,6 +141,33 @@ class UnnecessaryCatchTest implements RewriteTest {
     }
 
     @Test
+    void doNotRemoveThrownExceptionFromConstructor() {
+        rewriteRun(
+            //language=java
+            java(
+                """
+                  import java.io.IOException;
+
+                  public class AnExample {
+                      public void method() {
+                          try {
+                              new Fred();
+                          } catch (IOException e) {
+                              System.out.println("an exception!");
+                          }
+                      }
+
+                      public static class Fred {
+                          public Fred() throws IOException {}
+                      }
+
+                  }
+                  """
+            )
+        );
+    }
+
+    @Test
     void doNotRemoveJavaLangException() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Constructors weren't considered when the list of thrown exceptions was determined.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Constructors can also declare exceptions, they should be considered before removing unnecessary catch blocks.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files

I did not find any documentation about applying the code formatter and could not find a gradle task.