### PR TITLE
Improve CatchClauseOnlyRethrows to support MultiCatch completely

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -30,8 +30,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static org.openrewrite.staticanalysis.csharp.CSharpFileChecker.isInstanceOfCs;
 
 public class CatchClauseOnlyRethrows extends Recipe {
@@ -98,10 +97,13 @@ public class CatchClauseOnlyRethrows extends Recipe {
                     JavaType.MultiCatch multiCatch = (JavaType.MultiCatch) next.getParameter().getType();
                     return multiCatch.getThrowableTypes();
                 }
-                return singletonList(next.getParameter().getType());
+                return next.getParameter().getType() != null ? singletonList(next.getParameter().getType()) : emptyList();
             }
 
             private boolean isAnyAssignableTo(List<JavaType> nextTypes, List<JavaType> aCatchTypes) {
+                if (nextTypes.isEmpty()) {
+                    return false;
+                }
                 for (JavaType aCatchType : aCatchTypes) {
                     for (JavaType nextType : nextTypes) {
                         if (TypeUtils.isAssignableTo(nextType, aCatchType)) {

--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -80,7 +80,7 @@ public class CatchClauseOnlyRethrows extends Recipe {
                 J.Try t = super.visitTry(tryable, ctx);
                 return t.withCatches(ListUtils.map(t.getCatches(), (i, aCatch) -> {
                     if (onlyRethrows(aCatch)) {
-                        // if a subsequent catch is a wider exception type and doesn't rethrow, we should  keep this one
+                        // if a subsequent catch is a wider exception type and doesn't rethrow, we should keep this one
                         for (int j = i + 1; j < tryable.getCatches().size(); j++) {
                             J.Try.Catch next = tryable.getCatches().get(j);
                             if (isAnyAssignableTo(getJavaTypes(next), getJavaTypes(aCatch)) && !onlyRethrows(next)) {

--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -27,9 +27,11 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.openrewrite.staticanalysis.csharp.CSharpFileChecker.isInstanceOfCs;
 
 public class CatchClauseOnlyRethrows extends Recipe {
@@ -78,14 +80,10 @@ public class CatchClauseOnlyRethrows extends Recipe {
                 J.Try t = super.visitTry(tryable, ctx);
                 return t.withCatches(ListUtils.map(t.getCatches(), (i, aCatch) -> {
                     if (onlyRethrows(aCatch)) {
-                        // if a subsequent catch is a wider exception type and doesn't rethrow, we should
-                        // keep this one
+                        // if a subsequent catch is a wider exception type and doesn't rethrow, we should  keep this one
                         for (int j = i + 1; j < tryable.getCatches().size(); j++) {
                             J.Try.Catch next = tryable.getCatches().get(j);
-                            if (hasWiderExceptionType(aCatch, next)) {
-                                if (onlyRethrows(next)) {
-                                    return null;
-                                }
+                            if (isAnyAssignableTo(getJavaTypes(next), getJavaTypes(aCatch)) && !onlyRethrows(next)) {
                                 return aCatch;
                             }
                         }
@@ -95,17 +93,23 @@ public class CatchClauseOnlyRethrows extends Recipe {
                 }));
             }
 
-            private boolean hasWiderExceptionType(J.Try.Catch aCatch, J.Try.Catch next) {
+            private List<JavaType> getJavaTypes(J.Try.Catch next) {
                 if (next.getParameter().getType() instanceof JavaType.MultiCatch) {
                     JavaType.MultiCatch multiCatch = (JavaType.MultiCatch) next.getParameter().getType();
-                    for (JavaType throwableType : multiCatch.getThrowableTypes()) {
-                        if (TypeUtils.isAssignableTo(throwableType, aCatch.getParameter().getType())) {
+                    return multiCatch.getThrowableTypes();
+                }
+                return singletonList(next.getParameter().getType());
+            }
+
+            private boolean isAnyAssignableTo(List<JavaType> nextTypes, List<JavaType> aCatchTypes) {
+                for (JavaType aCatchType : aCatchTypes) {
+                    for (JavaType nextType : nextTypes) {
+                        if (TypeUtils.isAssignableTo(nextType, aCatchType)) {
                             return true;
                         }
                     }
-                    return false;
                 }
-                return TypeUtils.isAssignableTo(next.getParameter().getType(), aCatch.getParameter().getType());
+                return false;
             }
 
             private boolean onlyRethrows(J.Try.Catch aCatch) {
@@ -116,9 +120,8 @@ public class CatchClauseOnlyRethrows extends Recipe {
 
                 Expression exception = ((J.Throw) aCatch.getBody().getStatements().get(0)).getException();
 
-                // In C# an implicit rethrow is possible
-                if (isInstanceOfCs(getCursor().firstEnclosing(SourceFile.class)) &&
-                    exception instanceof J.Empty) {
+                // In C# an implicit rethrow is possible, which means a `throw` statement without a variable
+                if (isInstanceOfCs(getCursor().firstEnclosing(SourceFile.class)) && exception instanceof J.Empty) {
                     return true;
                 }
 

--- a/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrows.java
@@ -97,13 +97,10 @@ public class CatchClauseOnlyRethrows extends Recipe {
                     JavaType.MultiCatch multiCatch = (JavaType.MultiCatch) next.getParameter().getType();
                     return multiCatch.getThrowableTypes();
                 }
-                return next.getParameter().getType() != null ? singletonList(next.getParameter().getType()) : emptyList();
+                return next.getParameter().getType() == null ? emptyList() : singletonList(next.getParameter().getType());
             }
 
             private boolean isAnyAssignableTo(List<JavaType> nextTypes, List<JavaType> aCatchTypes) {
-                if (nextTypes.isEmpty()) {
-                    return false;
-                }
                 for (JavaType aCatchType : aCatchTypes) {
                     for (JavaType nextType : nextTypes) {
                         if (TypeUtils.isAssignableTo(nextType, aCatchType)) {

--- a/src/main/java/org/openrewrite/staticanalysis/NoEqualityInForCondition.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoEqualityInForCondition.java
@@ -50,6 +50,7 @@ public class NoEqualityInForCondition extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitForControl(J.ForLoop.Control control, ExecutionContext ctx) {
@@ -57,8 +58,8 @@ public class NoEqualityInForCondition extends Recipe {
                     J.Binary condition = (J.Binary) control.getCondition();
 
                     if (isNumericalType(condition) &&
-                        control.getUpdate().size() == 1 &&
-                        control.getUpdate().get(0) instanceof J.Unary) {
+                            control.getUpdate().size() == 1 &&
+                            control.getUpdate().get(0) instanceof J.Unary) {
                         J.Unary update = (J.Unary) control.getUpdate().get(0);
                         if (updatedExpressionInConditional(update.getExpression(), condition)) {
                             if (condition.getOperator() == J.Binary.Type.NotEqual) {
@@ -104,9 +105,9 @@ public class NoEqualityInForCondition extends Recipe {
             private boolean isNumericalType(J.Binary condition) {
                 JavaType type = condition.getRight().getType();
                 return type == JavaType.Primitive.Short ||
-                       type == JavaType.Primitive.Byte ||
-                       type == JavaType.Primitive.Int ||
-                       type == JavaType.Primitive.Long;
+                        type == JavaType.Primitive.Byte ||
+                        type == JavaType.Primitive.Int ||
+                        type == JavaType.Primitive.Long;
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/NoEqualityInForCondition.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoEqualityInForCondition.java
@@ -50,7 +50,6 @@ public class NoEqualityInForCondition extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitForControl(J.ForLoop.Control control, ExecutionContext ctx) {
@@ -58,8 +57,8 @@ public class NoEqualityInForCondition extends Recipe {
                     J.Binary condition = (J.Binary) control.getCondition();
 
                     if (isNumericalType(condition) &&
-                            control.getUpdate().size() == 1 &&
-                            control.getUpdate().get(0) instanceof J.Unary) {
+                        control.getUpdate().size() == 1 &&
+                        control.getUpdate().get(0) instanceof J.Unary) {
                         J.Unary update = (J.Unary) control.getUpdate().get(0);
                         if (updatedExpressionInConditional(update.getExpression(), condition)) {
                             if (condition.getOperator() == J.Binary.Type.NotEqual) {
@@ -105,9 +104,9 @@ public class NoEqualityInForCondition extends Recipe {
             private boolean isNumericalType(J.Binary condition) {
                 JavaType type = condition.getRight().getType();
                 return type == JavaType.Primitive.Short ||
-                        type == JavaType.Primitive.Byte ||
-                        type == JavaType.Primitive.Int ||
-                        type == JavaType.Primitive.Long;
+                       type == JavaType.Primitive.Byte ||
+                       type == JavaType.Primitive.Int ||
+                       type == JavaType.Primitive.Long;
             }
         };
     }

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -20,7 +20,6 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static java.util.Collections.singletonList;
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings("ALL")

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -83,6 +83,31 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
+    void multiCastCatchShouldBePreservedFoBecauseLessSpecificCatchFollows() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileReader;
+              import java.io.IOException;
+
+              class A {
+                  void foo() throws IOException {
+                      try {
+                          new FileReader("").read();
+                      } catch (IOException | RuntimeException e) {
+                          throw e;
+                      } catch(Exception e) {
+                          System.out.println(e.getMessage());
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMultiCast() {
         rewriteRun(
           //language=java
@@ -96,6 +121,31 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                       try {
                           new FileReader("").read();
                       } catch (IOException e) {
+                          throw e;
+                      } catch(Exception | Throwable t) {
+                          t.printStackTrace();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multiCastCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMultiCast() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileReader;
+              import java.io.IOException;
+
+              class A {
+                  void foo() throws IOException {
+                      try {
+                          new FileReader("").read();
+                      } catch (IOException | RuntimeException e) {
                           throw e;
                       } catch(Exception | Throwable t) {
                           t.printStackTrace();

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -162,7 +162,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void mltiCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMultiCatch() {
+    void mltiCatchShouldBePreservedBecauseLessSpecificCatchFollowsWithMultiCatch() {
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -111,7 +111,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void multiCatchShouldBePreservedFoBecauseLessSpecificCatchFollows() {
+    void multiCatchShouldBePreservedBecauseLessSpecificCatchFollows() {
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -137,7 +137,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMulticatch() {
+    void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMultiCatch() {
         rewriteRun(
           //language=java
           java(
@@ -162,7 +162,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void mltiCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMulticatch() {
+    void mltiCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMultiCatch() {
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Collections.singletonList;
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings("ALL")
@@ -45,7 +46,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                           new FileReader("").read();
                       } catch (IOException e) {
                           throw new IOException("another message", e);
-                      } catch(Exception e) {
+                      } catch (Exception e) {
                           throw new Exception("another message");
                       }
                   }
@@ -70,9 +71,9 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                           new FileReader("").read();
                       } catch (IOException e) {
                           throw e;
-                      } catch(Exception e) {
+                      } catch (Exception e) {
                           System.out.println(e.getMessage());
-                      } catch(Throwable t) {
+                      } catch (Throwable t) {
                           t.printStackTrace();
                       }
                   }
@@ -83,7 +84,35 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void multiCastCatchShouldBePreservedFoBecauseLessSpecificCatchFollows() {
+    void catchShouldBePreservedBecauseLessSpecificCatchFollowsLater() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileReader;
+              import java.io.IOException;
+              import java.io.FileNotFoundException;
+
+              class A {
+                  void foo() throws IOException {
+                      try {
+                          new FileReader("").read();
+                      } catch (FileNotFoundException e) {
+                          throw e;
+                      } catch (IOException e) {
+                          throw e;
+                      } catch (Exception e) {
+                          System.out.println(e.getMessage());
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multiCatchShouldBePreservedFoBecauseLessSpecificCatchFollows() {
         rewriteRun(
           //language=java
           java(
@@ -97,7 +126,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                           new FileReader("").read();
                       } catch (IOException | RuntimeException e) {
                           throw e;
-                      } catch(Exception e) {
+                      } catch (Exception e) {
                           System.out.println(e.getMessage());
                       }
                   }
@@ -108,7 +137,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMultiCast() {
+    void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMulticatch () {
         rewriteRun(
           //language=java
           java(
@@ -122,7 +151,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                           new FileReader("").read();
                       } catch (IOException e) {
                           throw e;
-                      } catch(Exception | Throwable t) {
+                      } catch (Exception | Throwable t) {
                           t.printStackTrace();
                       }
                   }
@@ -133,7 +162,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void multiCastCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMultiCast() {
+    void mltiCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMulticatch () {
         rewriteRun(
           //language=java
           java(
@@ -147,7 +176,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                           new FileReader("").read();
                       } catch (IOException | RuntimeException e) {
                           throw e;
-                      } catch(Exception | Throwable t) {
+                      } catch (Exception | Throwable t) {
                           t.printStackTrace();
                       }
                   }
@@ -192,7 +221,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void tryCanBeRemovedWithMultiCatch() {
+    void tryCanBeRemovedWithMulticatch () {
         rewriteRun(
           //language=java
           java(
@@ -207,9 +236,9 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                           new FileReader("").read();
                       } catch (FileNotFoundException e) {
                           throw e;
-                      } catch(IOException | ArrayIndexOutOfBoundsException e) {
+                      } catch (IOException | ArrayIndexOutOfBoundsException e) {
                           throw e;
-                      } catch(Exception e) {
+                      } catch (Exception e) {
                           throw e;
                       }
                   }
@@ -246,7 +275,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
                           new FileReader("").read();
                       } catch (FileNotFoundException e) {
                           throw e;
-                      } catch(IOException | ArrayIndexOutOfBoundsException e) {
+                      } catch (IOException | ArrayIndexOutOfBoundsException e) {
                           throw new IOException("another message", e);
                       }
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -137,7 +137,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMulticatch () {
+    void catchShouldBePreservedBecauseLessSpecificCatchFollowsWithMulticatch() {
         rewriteRun(
           //language=java
           java(
@@ -162,7 +162,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void mltiCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMulticatch () {
+    void mltiCatchShouldBePreservedFoBecauseLessSpecificCatchFollowsWithMulticatch() {
         rewriteRun(
           //language=java
           java(
@@ -221,7 +221,7 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
     }
 
     @Test
-    void tryCanBeRemovedWithMulticatch () {
+    void tryCanBeRemovedWithMultiCatch() {
         rewriteRun(
           //language=java
           java(


### PR DESCRIPTION
## What's changed?
The recipe `CatchClauseOnlyRethrows` supports multiple exception types now completely.

## What's your motivation?
Code like

```java
try {
  // something
} catch (SomeException | SomeOtherException e) {
  throw e;
} catch (Exception e) {
  throw new WhateverException(e);
}
```

will currently be altered by the recipe, which is incorrect.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
