### PR TITLE
Invert conditional keep order on object for compare

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNullVisitor.java
@@ -47,11 +47,16 @@ import static java.util.Objects.requireNonNull;
 public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
 
     private static final String JAVA_LANG_STRING = "java.lang.String ";
-    private static final MethodMatcher EQUALS = new MethodMatcher(JAVA_LANG_STRING + "equals(java.lang.Object)");
-    private static final MethodMatcher EQUALS_IGNORE_CASE = new MethodMatcher(JAVA_LANG_STRING + "equalsIgnoreCase(java.lang.String)");
-    private static final MethodMatcher COMPARE_TO = new MethodMatcher(JAVA_LANG_STRING + "compareTo(java.lang.String)");
-    private static final MethodMatcher COMPARE_TO_IGNORE_CASE = new MethodMatcher(JAVA_LANG_STRING + "compareToIgnoreCase(java.lang.String)");
-    private static final MethodMatcher CONTENT_EQUALS = new MethodMatcher(JAVA_LANG_STRING + "contentEquals(java.lang.CharSequence)");
+    private static final MethodMatcher EQUALS = new MethodMatcher(JAVA_LANG_STRING +
+            "equals(java.lang.Object)");
+    private static final MethodMatcher EQUALS_IGNORE_CASE = new MethodMatcher(JAVA_LANG_STRING +
+            "equalsIgnoreCase(java.lang.String)");
+    private static final MethodMatcher COMPARE_TO = new MethodMatcher(JAVA_LANG_STRING +
+            "compareTo(java.lang.String)");
+    private static final MethodMatcher COMPARE_TO_IGNORE_CASE = new MethodMatcher(JAVA_LANG_STRING +
+            "compareToIgnoreCase(java.lang.String)");
+    private static final MethodMatcher CONTENT_EQUALS = new MethodMatcher(JAVA_LANG_STRING +
+            "contentEquals(java.lang.CharSequence)");
 
     EqualsAvoidsNullStyle style;
 
@@ -59,7 +64,7 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
     public J visitMethodInvocation(J.MethodInvocation method, P p) {
         J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, p);
         if (m.getSelect() != null && !(m.getSelect() instanceof J.Literal) &&
-            isStringComparisonMethod(m) && hasCompatibleArgument(m)) {
+                isStringComparisonMethod(m) && hasCompatibleArgument(m)) {
 
             maybeHandleParentBinary(m);
 
@@ -91,11 +96,11 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
 
     private boolean isStringComparisonMethod(J.MethodInvocation methodInvocation) {
         return EQUALS.matches(methodInvocation) ||
-               !style.getIgnoreEqualsIgnoreCase() &&
-               EQUALS_IGNORE_CASE.matches(methodInvocation) ||
-               COMPARE_TO.matches(methodInvocation) ||
-               COMPARE_TO_IGNORE_CASE.matches(methodInvocation) ||
-               CONTENT_EQUALS.matches(methodInvocation);
+                !style.getIgnoreEqualsIgnoreCase() &&
+                        EQUALS_IGNORE_CASE.matches(methodInvocation) ||
+                COMPARE_TO.matches(methodInvocation) ||
+                COMPARE_TO_IGNORE_CASE.matches(methodInvocation) ||
+                CONTENT_EQUALS.matches(methodInvocation);
     }
 
     private void maybeHandleParentBinary(J.MethodInvocation m) {
@@ -103,8 +108,10 @@ public class EqualsAvoidsNullVisitor<P> extends JavaVisitor<P> {
         if (parent instanceof J.Binary) {
             if (((J.Binary) parent).getOperator() == J.Binary.Type.And && ((J.Binary) parent).getLeft() instanceof J.Binary) {
                 J.Binary potentialNullCheck = (J.Binary) ((J.Binary) parent).getLeft();
-                if (isNullLiteral(potentialNullCheck.getLeft()) && matchesSelect(potentialNullCheck.getRight(), requireNonNull(m.getSelect())) ||
-                    isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(), requireNonNull(m.getSelect()))) {
+                if (isNullLiteral(potentialNullCheck.getLeft()) && matchesSelect(potentialNullCheck.getRight(),
+                        requireNonNull(m.getSelect())) ||
+                        isNullLiteral(potentialNullCheck.getRight()) && matchesSelect(potentialNullCheck.getLeft(),
+                                requireNonNull(m.getSelect()))) {
                     doAfterVisit(new RemoveUnnecessaryNullCheck<>((J.Binary) parent));
                 }
             }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -67,6 +67,42 @@ class EqualsAvoidsNullTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
+    @Test
+    void invertConditionalKeepOrderOnObjectForCompare() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  {
+                      Object s1 = null;
+                      Object s2 = null;
+                      if(s1.equals(s2)) {}
+                      if(s1.equalsIgnoreCase(s2)) {}
+                      System.out.println(s1.compareTo(s2));
+                      System.out.println(s1.compareToIgnoreCase(s2));
+                      System.out.println(s1.contentEquals(s2));
+                  }
+              }
+              """,
+            """
+              public class A {
+                  {
+                      Object s1 = null;
+                      Object s2 = null;
+                      if(s1.equals(s2)) {}
+                      if(s1.equalsIgnoreCase(s2)) {}
+                      System.out.println(s1.compareTo(s2));
+                      System.out.println(s1.compareToIgnoreCase(s2));
+                      System.out.println(s1.contentEquals(s2));
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void removeUnnecessaryNullCheck() {
         rewriteRun(


### PR DESCRIPTION
test: https://github.com/openrewrite/rewrite-static-analysis/pull/448#discussion_r1946375720

currently not working locally 
```
error: constructor SwitchExpression in class SwitchExpression cannot be applied to given types;
            return new J.SwitchExpression(
                   ^
  required: UUID,Space,Markers,ControlParentheses<Expression>,Block,JavaType
  found:    UUID,Space,Markers,ControlParentheses<Identifier>,Block
  reason: actual and formal argument lists differ in length
```