### PR TITLE
DefaultComesLast should work on Java 21 Object switch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation("com.google.code.gson:gson:latest.release")
 
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
+    testRuntimeOnly("org.openrewrite:rewrite-java-21")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,3 +40,9 @@ dependencies {
     testRuntimeOnly("org.openrewrite:rewrite-java-17")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
@@ -15,15 +15,13 @@
  */
 package org.openrewrite.staticanalysis;
 
-import com.sun.source.tree.TreeVisitor;
-import jdk.vm.ci.meta.JavaType;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.SemanticallyEqual;
-import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
-import sun.jvm.hotspot.gc.shared.Space;
 
 import java.time.Duration;
 import java.util.*;

--- a/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
@@ -15,13 +15,15 @@
  */
 package org.openrewrite.staticanalysis;
 
+import com.sun.source.tree.TreeVisitor;
+import jdk.vm.ci.meta.JavaType;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.*;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.SemanticallyEqual;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.Markers;
+import sun.jvm.hotspot.gc.shared.Space;
 
 import java.time.Duration;
 import java.util.*;
@@ -603,7 +605,7 @@ public class CombineSemanticallyEqualCatchBlocks extends Recipe {
                         return _case;
                     }
 
-                    this.visit(_case.getExpressions().get(0), compareTo.getExpressions().get(0));
+                    this.visit(_case.getCaseLabels().get(0), compareTo.getCaseLabels().get(0));
                     for (int i = 0; i < _case.getStatements().size(); i++) {
                         this.visit(_case.getStatements().get(i), compareTo.getStatements().get(i));
                     }

--- a/src/main/java/org/openrewrite/staticanalysis/DefaultComesLastVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/DefaultComesLastVisitor.java
@@ -21,7 +21,6 @@ import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.DefaultComesLastStyle;
-import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
@@ -186,7 +185,7 @@ public class DefaultComesLastVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private boolean isDefaultCase(J.Case case_) {
-        Expression elem = case_.getExpressions().get(0);
+        J elem = case_.getCaseLabels().get(0);
         return elem instanceof J.Identifier && ((J.Identifier) elem).getSimpleName().equals("default");
     }
 

--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import jdk.vm.ci.meta.JavaType;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import lombok.With;
@@ -28,6 +27,7 @@ import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.service.ImportService;
+import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.csharp.CSharpFileChecker;

--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import jdk.vm.ci.meta.JavaType;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import lombok.With;
@@ -27,7 +28,6 @@ import org.openrewrite.internal.RecipeRunException;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.service.ImportService;
-import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.csharp.CSharpFileChecker;
@@ -123,7 +123,7 @@ public class MinimumSwitchCases extends Recipe {
                         if (statement instanceof J.Case) {
                             J.Case aCase = (J.Case) statement;
                             if (aCase.getType() == J.Case.Type.Rule) {
-                                if (aCase.getExpressions().size() > 1 || !(aCase.getBody() instanceof Statement)) {
+                                if (aCase.getCaseLabels().size() > 1 || !(aCase.getBody() instanceof Statement)) {
                                     return super.visitSwitch(switch_, ctx);
                                 }
                             } else {
@@ -224,7 +224,7 @@ public class MinimumSwitchCases extends Recipe {
                     return false;
                 }
                 return switch_.getCases().getStatements().stream()
-                               .reduce(0, (a, b) -> a + ((J.Case) b).getExpressions().size(), Integer::sum) < 3;
+                               .reduce(0, (a, b) -> a + ((J.Case) b).getCaseLabels().size(), Integer::sum) < 3;
             }
 
             private List<Statement> getStatements(J.Case aCase) {

--- a/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
@@ -16,7 +16,10 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.Tree;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.style.DefaultComesLastStyle;
@@ -289,6 +292,28 @@ class DefaultComesLastTest implements RewriteTest {
                           case C -> { var = 3; }
                       }
                       return var;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/461")
+    @Test
+    void exhaustiveSwitch(){
+        //language=java
+        rewriteRun(
+          java(
+            """
+              public class ExhaustiveSwitch {
+                  static int coverage(Object obj) {
+                      return switch (obj) {
+                          case String s -> s.length();
+                          case Integer i -> i;
+                          default -> 0;
+                      };
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.SourceSpec;
 
 import static org.openrewrite.java.Assertions.java;
 


### PR DESCRIPTION
- Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/461

Fails for now with what likely needs an upstream fix first:
```
Caused by: java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "org.openrewrite.java.tree.J$Identifier.getSimpleName()" is null
	at org.openrewrite.java.JavaPrinter.visitCase(JavaPrinter.java:488)
	at org.openrewrite.java.JavaPrinter.visitCase(JavaPrinter.java:35)
	at org.openrewrite.java.tree.J$Case.acceptJava(J.java:1118)
	at org.openrewrite.java.tree.J.accept(J.java:58)
	at org.openrewrite.TreeVisitor.visit(TreeVisitor.java:250)
	... 57 more
```