### PR TITLE
recipe: replace Arrays#asList() by List#of()

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceArraysAsListWithListOf.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceArraysAsListWithListOf.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import java.time.Duration;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+public class ReplaceArraysAsListWithListOf extends Recipe {
+
+  private static final MethodMatcher ARRAYS_AS_LIST = new MethodMatcher("java.util.Arrays asList(..)");
+
+  @Override
+  public String getDisplayName() {
+    return "Replace Arrays.asList() with List.of()";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Replace `Arrays.asList()` with `List.of()` when the number of arguments is less than 11.";
+  }
+
+  @Override
+  public Duration getEstimatedEffortPerOccurrence() {
+    return Duration.ofMinutes(1);
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getVisitor() {
+    return Preconditions.check(new UsesMethod<>(ARRAYS_AS_LIST), new JavaVisitor<ExecutionContext>() {
+
+      private final JavaTemplate template = JavaTemplate.builder("List.of(#{any(java.lang.Object[])})")
+        .imports("java.util.List")
+        .build();
+
+      @Override
+      public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        J.MethodInvocation result = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+        if (ARRAYS_AS_LIST.matches(method) && method.getArguments().size() < 11) {
+          result = template.apply(updateCursor(result), result.getCoordinates().replace(),
+            result.getArguments().toArray());
+          maybeAddImport("java.util.List");
+          maybeRemoveImport("java.util.Arrays");
+        }
+        return result;
+      }
+    });
+  }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceArraysAsListWithListOfTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceArraysAsListWithListOfTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings("java:S2699")
+class ReplaceArraysAsListWithListOfTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceArraysAsListWithListOf());
+    }
+
+    @DocumentExample
+    @Test
+    void replaceWithSingleArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Arrays;
+
+              class A {
+                  void foo() {
+                      Arrays.asList("A");
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class A {
+                  void foo() {
+                      List.of("A");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceWith10Arguments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Arrays;
+
+              class A {
+                  void foo() {
+                      Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class A {
+                  void foo() {
+                      List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotReplaceWith11Arguments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Arrays;
+
+              class A {
+                  void foo() {
+                      Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Adds a new recipe

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
We have lots of usages in our code base and they are reported as warnings by default

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
The second test is failing. I need help here with the implementation to fix it.
```
Failed to run recipe at Cursor{MethodInvocation->JRightPadded(element=Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), after=Space(comments=<0 comments>, whitespace=<empty>))->Block->MethodDeclaration->JRightPadded(element=MethodDeclaration{A{name=foo,return=void,parameters=[]}}, after=Space(comments=<0 comments>, whitespace=<empty>))->Block->ClassDeclaration->CompilationUnit->root}
```

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
