### PR TITLE
Adding test case to `RemoveExtraSemicolons` for enum with no values

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
@@ -247,4 +247,19 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5146")
+    void noValuesJustSemicolon() {
+        rewriteRun(
+          java(
+            """
+             public enum A {
+                 ;
+                 public static final String X = "receipt-id";
+             }
+             """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Adding a single test case for `RemoveExtraSemicolons` recipe test.
This requires https://github.com/openrewrite/rewrite/pull/5147 to work.

## What's your motivation?
- fixing https://github.com/openrewrite/rewrite/issues/5146
