### PR TITLE
Fixed primitive wrapper for double to float conversion

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
@@ -98,6 +98,8 @@ public class PrimitiveWrapperClassConstructorToValueOf extends Recipe {
                             JavaType argType = arg.getType();
                             if (TypeUtils.isOfClassType(argType, "java.lang.Double")) {
                                 valueOf = JavaTemplate.builder("Float.valueOf(#{any(java.lang.Double)}.floatValue())");
+                            } else if (JavaType.Primitive.Double == arg.getType()) {
+                                valueOf = JavaTemplate.builder("Float.valueOf((float) #{any(double)})");
                             } else {
                                 valueOf = JavaTemplate.builder("Float.valueOf(#{any(float)})");
                             }

--- a/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
@@ -186,10 +186,12 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
             """
               class T {
                   Double d1 = Double.valueOf(1.0);
+                  double d2 = 2.0d;
                   void makeFloats() {
                       Float f = new Float(2.0d);
                       Float f2 = new Float(getD());
                       Float f3 = new Float(d1);
+                      Float f4 = new Float(d2);
                   }
                   Double getD() {
                       return Double.valueOf(2.0d);
@@ -199,10 +201,12 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
             """
               class T {
                   Double d1 = Double.valueOf(1.0);
+                  double d2 = 2.0d;
                   void makeFloats() {
                       Float f = Float.valueOf("2.0");
                       Float f2 = Float.valueOf(getD().floatValue());
                       Float f3 = Float.valueOf(d1.floatValue());
+                      Float f4 = Float.valueOf((float) d2);
                   }
                   Double getD() {
                       return Double.valueOf(2.0d);
@@ -220,64 +224,64 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
           java(
             """
               public enum Options {
-              
+
                   JAR("instance.jar.file"),
                   JVM_ARGUMENTS("instance.vm.args"),
                   QUICKSTART_OPTIONS("instance.options"),
                   INSTALLATIONS("instance.installations"),
                   START_TIMEOUT("instance.timeout");
-              
+
                   private String name;
-              
+
                   Options(String name) {
                       this.name = name;
                   }
-              
+
                   public String asString() {
                       return System.getProperty(name);
                   }
-                  
+
                   public Integer asInteger(int defaultValue) {
                       String string  = asString();
-              
+
                       if (string == null) {
                           return defaultValue;
                       }
-              
+
                       return new Integer(asString());
                   }
-              
+
               }
               """,
             """
               public enum Options {
-              
+
                   JAR("instance.jar.file"),
                   JVM_ARGUMENTS("instance.vm.args"),
                   QUICKSTART_OPTIONS("instance.options"),
                   INSTALLATIONS("instance.installations"),
                   START_TIMEOUT("instance.timeout");
-              
+
                   private String name;
-              
+
                   Options(String name) {
                       this.name = name;
                   }
-              
+
                   public String asString() {
                       return System.getProperty(name);
                   }
-                  
+
                   public Integer asInteger(int defaultValue) {
                       String string  = asString();
-              
+
                       if (string == null) {
                           return defaultValue;
                       }
-              
+
                       return Integer.valueOf(asString());
                   }
-              
+
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Conversion of Float(double) constructor handles primitive double use case.  Float.valueOf(double) does not exist.

## What's your motivation?
- Fixes #476 

## Anything in particular you'd like reviewers to focus on?
Fix took the simplest approach to conversion of double to float and used the Java Float.java constructors as the example.

## Have you considered any alternatives or workarounds?
Could not find any workarounds.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
