### PR TITLE
Fixing `EmptyBlock` recipe not to alter code for unsupported operators

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
@@ -139,7 +139,7 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
         }
         J.Binary binary = (J.Binary) cond.getTree();
 
-        // only boolean operators are valid for if conditions
+        // only some operators are supported
         switch (binary.getOperator()) {
             case Equal:
                 cond = cond.withTree(binary.withOperator(J.Binary.Type.NotEqual));
@@ -160,7 +160,7 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
                 cond = cond.withTree(binary.withOperator(J.Binary.Type.LessThan));
                 break;
             default:
-                break;
+                return i;
         }
         i = i.withIfCondition(cond);
 

--- a/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
@@ -435,4 +435,22 @@ class EmptyBlockTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void empty2() {
+        rewriteRun(
+          java(
+            """
+            public class WithEmptyBlock {
+              public void shouldNotFlipCondition() {
+                  if (1 > 0 || 0 > 1) {
+                  } else {
+                    System.out.println("wrong");
+                  }
+              }
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing `EmptyBlock` recipe not to corrupt the code.

## What's your motivation?

- fixes #314 
