### PR TITLE
Don't swap if select is a literal in EqualsAvoidsNull

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
@@ -78,7 +78,7 @@ public class EqualsAvoidsNull extends Recipe {
                     public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
-                        if (!isStringComparisonMethod(m) || !hasCompatibleArgument(m)) {
+                        if (!isStringComparisonMethod(m) || !hasCompatibleArgument(m) || m.getSelect() instanceof J.Literal) {
                             return m;
                         }
 

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -490,4 +490,37 @@ class EqualsAvoidsNullTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void literalAndConstant() {
+        rewriteRun(
+          spec -> spec.recipe(new EqualsAvoidsNull()),
+          // language=java
+          java(
+            """
+            package com.helloworld;
+
+            public class Foo {
+                private static final String FOO = "";
+
+                public void foo() {
+                    FOO.equals("");
+                    "".equals(FOO);
+                }
+            }
+            """,
+            """
+            package com.helloworld;
+
+            public class Foo {
+                private static final String FOO = "";
+
+                public void foo() {
+                    "".equals(FOO);
+                    "".equals(FOO);
+                }
+            }
+            """
+            ));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
