### PR TITLE
rewise early exit to positive condition in `EqualsAvoidsNull`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
@@ -76,10 +76,10 @@ public class EqualsAvoidsNull extends Recipe {
                 new JavaVisitor<ExecutionContext>() {
                     @Override
                     public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                        return visitMethodInvocation((J.MethodInvocation) super.visitMethodInvocation(method, ctx));
+                        return checkLiteralsFirstInComparisons((J.MethodInvocation) super.visitMethodInvocation(method, ctx));
                     }
 
-                    private J visitMethodInvocation(J.MethodInvocation m) {
+                    private J checkLiteralsFirstInComparisons(J.MethodInvocation m) {
                         if (isStringComparisonMethod(m) &&
                                 hasCompatibleArgument(m) &&
                                 !(m.getSelect() instanceof J.Literal)) {

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
@@ -89,22 +89,22 @@ public class EqualsAvoidsNull extends Recipe {
                     }
 
                     private J applyLiteralsFirstInComparisons(J.MethodInvocation m, Expression firstArgument) {
-                        maybePotentialNullCheck(m, getCursor().getParentTreeCursor().getValue());
+                        checkPotentialNullCheck(m, getCursor().getParentTreeCursor().getValue());
                         return firstArgument.getType() == JavaType.Primitive.Null ?
                                 literalsFirstInComparisonsNull(m, firstArgument) :
                                 literalsFirstInComparisons(m, firstArgument);
                     }
 
-                    private void maybePotentialNullCheck(J.MethodInvocation m, final Tree parent) {
+                    private void checkPotentialNullCheck(J.MethodInvocation m, final Tree parent) {
                         if (parent instanceof J.Binary &&
                                 ((J.Binary) parent).getOperator() == J.Binary.Type.And &&
                                 ((J.Binary) parent).getLeft() instanceof J.Binary) {
-                            potentialNullCheck(m, (J.Binary) parent, (J.Binary) ((J.Binary) parent).getLeft());
+                            avoidPotentialNullCheck(m, (J.Binary) parent, (J.Binary) ((J.Binary) parent).getLeft());
                         }
                     }
 
-                    private void potentialNullCheck(J.MethodInvocation m, J.Binary parent,
-                                                    J.Binary potentialNullCheck) {
+                    private void avoidPotentialNullCheck(J.MethodInvocation m, J.Binary parent,
+                                                         J.Binary potentialNullCheck) {
                         if (isNullLiteral(potentialNullCheck.getLeft()) &&
                                 matchesSelect(getCursor(), potentialNullCheck.getRight(),
                                         requireNonNull(m.getSelect())) ||

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
@@ -89,18 +89,17 @@ public class EqualsAvoidsNull extends Recipe {
                     }
 
                     private J applyLiteralsFirstInComparisons(J.MethodInvocation m, Expression firstArgument) {
-                        maybeHandleParentBinary(m, getCursor().getParentTreeCursor().getValue());
+                        maybePotentialNullCheck(m, getCursor().getParentTreeCursor().getValue());
                         return firstArgument.getType() == JavaType.Primitive.Null ?
                                 literalsFirstInComparisonsNull(m, firstArgument) :
                                 literalsFirstInComparisons(m, firstArgument);
                     }
 
-                    private void maybeHandleParentBinary(J.MethodInvocation m, final Tree parent) {
-                        if (parent instanceof J.Binary) {
-                            if (((J.Binary) parent).getOperator() == J.Binary.Type.And &&
-                                    ((J.Binary) parent).getLeft() instanceof J.Binary) {
-                                potentialNullCheck(m, (J.Binary) parent, (J.Binary) ((J.Binary) parent).getLeft());
-                            }
+                    private void maybePotentialNullCheck(J.MethodInvocation m, final Tree parent) {
+                        if (parent instanceof J.Binary &&
+                                ((J.Binary) parent).getOperator() == J.Binary.Type.And &&
+                                ((J.Binary) parent).getLeft() instanceof J.Binary) {
+                            potentialNullCheck(m, (J.Binary) parent, (J.Binary) ((J.Binary) parent).getLeft());
                         }
                     }
 

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
@@ -99,12 +99,12 @@ public class EqualsAvoidsNull extends Recipe {
                         if (parent instanceof J.Binary &&
                                 ((J.Binary) parent).getOperator() == J.Binary.Type.And &&
                                 ((J.Binary) parent).getLeft() instanceof J.Binary) {
-                            avoidPotentialNullCheck(m, (J.Binary) parent, (J.Binary) ((J.Binary) parent).getLeft());
+                            preparePotentialNullCheck(m, (J.Binary) parent, (J.Binary) ((J.Binary) parent).getLeft());
                         }
                     }
 
-                    private void avoidPotentialNullCheck(J.MethodInvocation m, J.Binary parent,
-                                                         J.Binary potentialNullCheck) {
+                    private void preparePotentialNullCheck(J.MethodInvocation m, J.Binary parent,
+                                                           J.Binary potentialNullCheck) {
                         if (isNullLiteral(potentialNullCheck.getLeft()) &&
                                 matchesSelect(getCursor(), potentialNullCheck.getRight(),
                                         requireNonNull(m.getSelect())) ||

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -549,6 +549,25 @@ class EqualsAvoidsNullTest implements RewriteTest {
         }
 
         @Test
+        void referenceOnReference() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Foo {
+                      private static final String FOO = null;
+                      private static final String BAR = null;
+                      public void bar() {
+                          FOO.equals(FOO);
+                          FOO.equals(BAR);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void rawOverReference() {
             rewriteRun(
               //language=java
@@ -584,7 +603,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
         }
 
         @Test
-        void flipLocalReference() {
+        void rawOverLocalReference() {
             rewriteRun(
               //language=java
               java(

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -530,7 +530,7 @@ class EqualsAvoidsNullTest implements RewriteTest {
     class equalsAvoidsNullNonIdempotent {
 
         @Test
-        void raw() {
+        void rawOnRaw() {
             rewriteRun(
               //language=java
               java(

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -492,145 +492,36 @@ class EqualsAvoidsNullTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/472")
-    @Nested
-    class equalsAvoidsNullNonIdempotent {
+    @Test
+    void literalAndConstant() {
+        rewriteRun(
+          spec -> spec.recipe(new EqualsAvoidsNull()),
+          // language=java
+          java(
+            """
+            package com.helloworld;
 
-        @Test
-        void literalAndConstant() {
-            rewriteRun(
-              spec -> spec.recipe(new EqualsAvoidsNull()),
-              // language=java
-              java(
-                """
-                  public class Foo {
-                      private static final String FOO = "";
+            public class Foo {
+                private static final String FOO = "";
 
-                      public void foo() {
-                          FOO.equals("");
-                          "".equals(FOO);
-                      }
-                  }
-                  """,
-                """
-                  public class Foo {
-                      private static final String FOO = "";
+                public void foo() {
+                    FOO.equals("");
+                    "".equals(FOO);
+                }
+            }
+            """,
+            """
+            package com.helloworld;
 
-                      public void foo() {
-                          "".equals(FOO);
-                          "".equals(FOO);
-                      }
-                  }
-                  """
-              ));
-        }
+            public class Foo {
+                private static final String FOO = "";
 
-        @Test
-        void rawOnRaw() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  public class Foo {
-                      public void bar() {
-                          "FOO".equals("BAR");
-                          "FOO".equalsIgnoreCase("BAR");
-                          "FOO".compareTo("BAR");
-                          "FOO".compareToIgnoreCase("BAR");
-                      }
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void referenceOnReference() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  public class Foo {
-                      private static final String FOO = null;
-                      private static final String BAR = null;
-                      public void bar() {
-                          FOO.equals(FOO);
-                          FOO.equals(BAR);
-                      }
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void rawOverReference() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  public class Foo {
-                      private static final String FOO = null;
-                      public void bar(String _null) {
-                          String _null2 = null;
-                          FOO.equals("RAW");
-                          FOO.compareTo("RAW");
-                          FOO.compareToIgnoreCase("RAW");
-                          _null.equals("RAW");
-                          _null2.equals("RAW");
-                      }
-                  }
-                  """
-                , """
-                  public class Foo {
-                      private static final String FOO = null;
-                      public void bar(String _null) {
-                          String _null2 = null;
-                          "RAW".equals(FOO);
-                          "RAW".compareTo(FOO);
-                          "RAW".compareToIgnoreCase(FOO);
-                          "RAW".equals(_null);
-                          "RAW".equals(_null2);
-                      }
-                  }
-                  """
-              )
-            );
-        }
-
-        @Test
-        void rawOverLocalReference() {
-            rewriteRun(
-              //language=java
-              java(
-                """
-                  public class Foo {
-                      private static final String FOO = null;
-                      public void bar(String _null) {
-                          String _null2 = null;
-                          _null.equals(FOO);
-                          _null2.equals(FOO);
-                          _null.equals(_null);
-                          _null2.equals(_null2);
-                          "_null".equals("_null2");
-                      }
-                  }
-                  """
-                , """
-                  public class Foo {
-                      private static final String FOO = null;
-                      public void bar(String _null) {
-                          String _null2 = null;
-                          FOO.equals(_null);
-                          FOO.equals(_null2);
-                          _null.equals(_null);
-                          _null2.equals(_null2);
-                      }
-                  }
-                  """
-              )
-            );
-        }
-
+                public void foo() {
+                    "".equals(FOO);
+                    "".equals(FOO);
+                }
+            }
+            """
+            ));
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -492,42 +492,38 @@ class EqualsAvoidsNullTest implements RewriteTest {
         );
     }
 
-    @Test
-    void literalAndConstant() {
-        rewriteRun(
-          spec -> spec.recipe(new EqualsAvoidsNull()),
-          // language=java
-          java(
-            """
-            package com.helloworld;
-
-            public class Foo {
-                private static final String FOO = "";
-
-                public void foo() {
-                    FOO.equals("");
-                    "".equals(FOO);
-                }
-            }
-            """,
-            """
-            package com.helloworld;
-
-            public class Foo {
-                private static final String FOO = "";
-
-                public void foo() {
-                    "".equals(FOO);
-                    "".equals(FOO);
-                }
-            }
-            """
-            ));
-    }
-
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/472")
     @Nested
     class equalsAvoidsNullNonIdempotent {
+
+        @Test
+        void literalAndConstant() {
+            rewriteRun(
+              spec -> spec.recipe(new EqualsAvoidsNull()),
+              // language=java
+              java(
+                """
+                  public class Foo {
+                      private static final String FOO = "";
+
+                      public void foo() {
+                          FOO.equals("");
+                          "".equals(FOO);
+                      }
+                  }
+                  """,
+                """
+                  public class Foo {
+                      private static final String FOO = "";
+
+                      public void foo() {
+                          "".equals(FOO);
+                          "".equals(FOO);
+                      }
+                  }
+                  """
+              ));
+        }
 
         @Test
         void rawOnRaw() {


### PR DESCRIPTION

## What's changed?
* rewise early exit to positive condition in `EqualsAvoidsNull`
* separate concerns: `one thing only`

## What's your motivation?
* clean code