### PR TITLE
Added option to provide a custom FQN to AnnotateNullableMethods recipe

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AnnotateNullableMethods extends Recipe {
 
     @Option(displayName = "`@Nullable` annotation class",
-            description = "The fully qualified name of the @Nullable annotation. The annotation should have `@Target(TYPE_USE)`. Defaults to `org.jspecify.annotations.Nullable`",
+            description = "The fully qualified name of the @Nullable annotation. The annotation should be meta annotated with `@Target(TYPE_USE)`. Defaults to `org.jspecify.annotations.Nullable`",
             example = "org.jspecify.annotations.Nullable",
             required = false)
     @Nullable
@@ -52,7 +52,7 @@ public class AnnotateNullableMethods extends Recipe {
     public String getDescription() {
         return "Add `@Nullable` to non-private methods that may return `null`. " +
                 "By default `org.jspecify.annotations.Nullable` is used, but through the `nullableAnnotationClass` option a custom annotation can be provided." +
-                "When providing a custom `nullableAnnotationClass` that annotation should have `@Target(TYPE_USE)`." +
+                "When providing a custom `nullableAnnotationClass` that annotation should be meta annotated with `@Target(TYPE_USE)`." +
                 "This recipe scans for methods that do not already have a `@Nullable` annotation and checks their return " +
                 "statements for potential null values. It also identifies known methods from standard libraries that may " +
                 "return null, such as methods from `Map`, `Queue`, `Deque`, `NavigableSet`, and `Spliterator`. " +

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -60,20 +60,26 @@ public class AnnotateNullableMethods extends Recipe {
     }
 
     @Override
+    public Validated<Object> validate() {
+        return super.validate()
+                .and(Validated.test("nullableAnnotationClass", "<message>", nullableAnnotationClass,
+                        it -> it == null || it.contains(".")));
+    }
+
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         String fullyQualifiedName = nullableAnnotationClass != null ? nullableAnnotationClass : DEFAULT_NULLABLE_ANN_CLASS;
         String fullyQualifiedPackage = fullyQualifiedName.substring(0, fullyQualifiedName.lastIndexOf('.'));
         String simpleName = fullyQualifiedName.substring(fullyQualifiedName.lastIndexOf('.') + 1);
-        AnnotationMatcher nullableAnnotationMatcher = new AnnotationMatcher("@" + fullyQualifiedName);
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
                 if (!methodDeclaration.hasModifier(J.Modifier.Type.Public) ||
                         methodDeclaration.getMethodType() == null ||
                         methodDeclaration.getMethodType().getReturnType() instanceof JavaType.Primitive ||
-                        service(AnnotationService.class).matches(getCursor(), nullableAnnotationMatcher) ||
+                        service(AnnotationService.class).matches(getCursor(), new AnnotationMatcher("@" + fullyQualifiedName)) ||
                         (methodDeclaration.getReturnTypeExpression() != null &&
-                                service(AnnotationService.class).matches(new Cursor(null, methodDeclaration.getReturnTypeExpression()), nullableAnnotationMatcher))) {
+                                service(AnnotationService.class).matches(new Cursor(null, methodDeclaration.getReturnTypeExpression()), new AnnotationMatcher("@" + fullyQualifiedName)))) {
                     return methodDeclaration;
                 }
 

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -15,11 +15,10 @@
  */
 package org.openrewrite.staticanalysis;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.java.*;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.Expression;
@@ -31,10 +30,18 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@Value
+@EqualsAndHashCode(callSuper = false)
 public class AnnotateNullableMethods extends Recipe {
 
-    private static final String NULLABLE_ANN_CLASS = "org.jspecify.annotations.Nullable";
-    private static final AnnotationMatcher NULLABLE_ANNOTATION_MATCHER = new AnnotationMatcher("@" + NULLABLE_ANN_CLASS);
+    @Option(displayName = "`@Nullable` annotation class",
+            description = "The fully qualified name of the @Nullable annotation. The annotation should have `@Target(TYPE_USE)`. Defaults to `org.jspecify.annotations.Nullable`",
+            example = "org.jspecify.annotations.Nullable",
+            required = false)
+    @Nullable
+    String nullableAnnotationClass;
+
+    private static final String DEFAULT_NULLABLE_ANN_CLASS = "org.jspecify.annotations.Nullable";
 
     @Override
     public String getDisplayName() {
@@ -43,33 +50,39 @@ public class AnnotateNullableMethods extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Add the `@org.jspecify.annotation.Nullable` to non-private methods that may return `null`. " +
-               "This recipe scans for methods that do not already have a `@Nullable` annotation and checks their return " +
-               "statements for potential null values. It also identifies known methods from standard libraries that may " +
-               "return null, such as methods from `Map`, `Queue`, `Deque`, `NavigableSet`, and `Spliterator`. " +
-               "The return of streams, or lambdas are not taken into account.";
+        return "Add `@Nullable` to non-private methods that may return `null`. " +
+                "By default `org.jspecify.annotations.Nullable` is used, but through the `nullableAnnotationClass` option a custom annotation can be provided." +
+                "When providing a custom `nullableAnnotationClass` that annotation should have `@Target(TYPE_USE)`." +
+                "This recipe scans for methods that do not already have a `@Nullable` annotation and checks their return " +
+                "statements for potential null values. It also identifies known methods from standard libraries that may " +
+                "return null, such as methods from `Map`, `Queue`, `Deque`, `NavigableSet`, and `Spliterator`. " +
+                "The return of streams, or lambdas are not taken into account.";
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        String fullyQualifiedName = nullableAnnotationClass != null ? nullableAnnotationClass : DEFAULT_NULLABLE_ANN_CLASS;
+        String fullyQualifiedPackage = fullyQualifiedName.substring(0, fullyQualifiedName.lastIndexOf('.'));
+        String simpleName = fullyQualifiedName.substring(fullyQualifiedName.lastIndexOf('.') + 1);
+        AnnotationMatcher nullableAnnotationMatcher = new AnnotationMatcher("@" + fullyQualifiedName);
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
                 if (!methodDeclaration.hasModifier(J.Modifier.Type.Public) ||
-                    methodDeclaration.getMethodType() == null ||
-                    methodDeclaration.getMethodType().getReturnType() instanceof JavaType.Primitive ||
-                    service(AnnotationService.class).matches(getCursor(), NULLABLE_ANNOTATION_MATCHER) ||
-                    (methodDeclaration.getReturnTypeExpression() != null &&
-                    service(AnnotationService.class).matches(new Cursor(null, methodDeclaration.getReturnTypeExpression()), NULLABLE_ANNOTATION_MATCHER))) {
+                        methodDeclaration.getMethodType() == null ||
+                        methodDeclaration.getMethodType().getReturnType() instanceof JavaType.Primitive ||
+                        service(AnnotationService.class).matches(getCursor(), nullableAnnotationMatcher) ||
+                        (methodDeclaration.getReturnTypeExpression() != null &&
+                                service(AnnotationService.class).matches(new Cursor(null, methodDeclaration.getReturnTypeExpression()), nullableAnnotationMatcher))) {
                     return methodDeclaration;
                 }
 
                 J.MethodDeclaration md = super.visitMethodDeclaration(methodDeclaration, ctx);
                 updateCursor(md);
                 if (FindNullableReturnStatements.find(md.getBody(), getCursor().getParentTreeCursor())) {
-                    J.MethodDeclaration annotatedMethod = JavaTemplate.builder("@" + NULLABLE_ANN_CLASS)
+                    J.MethodDeclaration annotatedMethod = JavaTemplate.builder("@" + fullyQualifiedName)
                             .javaParser(JavaParser.fromJavaVersion().dependsOn(
-                                    "package org.jspecify.annotations;public @interface Nullable {}"))
+                                    String.format("package %s;public @interface %s {}", fullyQualifiedPackage, simpleName)))
                             .build()
                             .apply(getCursor(), md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
                     doAfterVisit(ShortenFullyQualifiedTypeReferences.modifyOnly(annotatedMethod));

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -62,7 +62,7 @@ public class AnnotateNullableMethods extends Recipe {
     @Override
     public Validated<Object> validate() {
         return super.validate()
-                .and(Validated.test("nullableAnnotationClass", "<message>", nullableAnnotationClass,
+                .and(Validated.test("nullableAnnotationClass", "Property `nullableAnnotationClass` must be a fully qualified classname.", nullableAnnotationClass,
                         it -> it == null || it.contains(".")));
     }
 

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -29,7 +28,6 @@ class AnnotateNullableMethodsTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .recipe(new AnnotateNullableMethods(null));
-          //.parser(JavaParser.fromJavaVersion().classpath("jspecify"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -20,8 +20,6 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -28,8 +28,8 @@ class AnnotateNullableMethodsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .recipe(new AnnotateNullableMethods())
-          .parser(JavaParser.fromJavaVersion().classpath("jspecify"));
+          .recipe(new AnnotateNullableMethods(null));
+          //.parser(JavaParser.fromJavaVersion().classpath("jspecify"));
     }
 
     @DocumentExample
@@ -229,6 +229,34 @@ class AnnotateNullableMethodsTest implements RewriteTest {
                       return callable;
                   }
 
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void provideCustomNullableAnnotationOption() {
+        rewriteRun(
+          spec -> spec.recipe(new AnnotateNullableMethods("my.custom.Nullable")),
+          //language=java
+          java(
+            """
+              public class Test {
+
+                  public String getString() {
+                      return null;
+                  }
+              }
+              """,
+            """
+              import my.custom.Nullable;
+
+              public class Test {
+
+                  public @Nullable String getString() {
+                      return null;
+                  }
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -20,6 +20,9 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 class AnnotateNullableMethodsTest implements RewriteTest {
@@ -259,6 +262,11 @@ class AnnotateNullableMethodsTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void validate() {
+        assertThat(new AnnotateNullableMethods("Nullable").validate().isInvalid()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## What's changed?
Added option to provide a custom FQN to AnnotateNullableMethods recipe

## What's your motivation?
As requested in https://github.com/openrewrite/rewrite-static-analysis/issues/428

## Anyone you would like to review specifically?
@jevanlingen 
@Laurens-W 
@greg-at-moderne 
