### PR TITLE
Increased idempotency of EqualsAvoidsNull by avoiding too many swaps

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
@@ -171,6 +171,14 @@ public class EqualsAvoidsNull extends Recipe {
 
                     private J.MethodInvocation literalsFirstInComparisons(J.MethodInvocation m,
                                                                           Expression firstArgument) {
+                        if (!(firstArgument instanceof J.Literal) && !(m.getSelect() instanceof J.Literal)) {
+                            if (firstArgument.toString().compareTo(m.getSelect().toString()) > 0) {
+                                // Don't swap the order to avoid thrashing.
+                                // toString() is a somewhat arbitrary criterion, but at least it's deterministic.
+                                return m;
+                            }
+                        }
+
                         return m.withSelect(firstArgument.withPrefix(requireNonNull(m.getSelect()).getPrefix()))
                                 .withArguments(singletonList(m.getSelect().withPrefix(Space.EMPTY)));
                     }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -532,8 +532,6 @@ class EqualsAvoidsNullTest implements RewriteTest {
                       public void bar() {
                           "FOO".equals("BAR");
                           "FOO".equalsIgnoreCase("BAR");
-                          "FOO".compareTo("BAR");
-                          "FOO".compareToIgnoreCase("BAR");
                       }
                   }
                   """
@@ -551,7 +549,6 @@ class EqualsAvoidsNullTest implements RewriteTest {
                       private static final String FOO = null;
                       private static final String BAR = null;
                       public void bar() {
-                          // FOO.equals(FOO);
                           BAR.equals(FOO);
                       }
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -492,36 +492,140 @@ class EqualsAvoidsNullTest implements RewriteTest {
         );
     }
 
-    @Test
-    void literalAndConstant() {
-        rewriteRun(
-          spec -> spec.recipe(new EqualsAvoidsNull()),
-          // language=java
-          java(
-            """
-            package com.helloworld;
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/472")
+    @Nested
+    class EqualsAvoidsNullNonIdempotent {
+        @Test
+        void literalAndConstant() {
+            rewriteRun(
+              spec -> spec.recipe(new EqualsAvoidsNull()),
+              // language=java
+              java(
+                """
+                  public class Foo {
+                      private static final String FOO = "";
+                      public void foo() {
+                          FOO.equals("");
+                          "".equals(FOO);
+                      }
+                  }
+                  """,
+                """
+                  public class Foo {
+                      private static final String FOO = "";
+                      public void foo() {
+                          "".equals(FOO);
+                          "".equals(FOO);
+                      }
+                  }
+                  """
+              ));
+        }
 
-            public class Foo {
-                private static final String FOO = "";
+        @Test
+        void rawOnRaw() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Foo {
+                      public void bar() {
+                          "FOO".equals("BAR");
+                          "FOO".equalsIgnoreCase("BAR");
+                          "FOO".compareTo("BAR");
+                          "FOO".compareToIgnoreCase("BAR");
+                      }
+                  }
+                  """
+              )
+            );
+        }
 
-                public void foo() {
-                    FOO.equals("");
-                    "".equals(FOO);
-                }
-            }
-            """,
-            """
-            package com.helloworld;
+        @Test
+        void referenceOnReference() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Foo {
+                      private static final String FOO = null;
+                      private static final String BAR = null;
+                      public void bar() {
+                          // FOO.equals(FOO);
+                          BAR.equals(FOO);
+                      }
+                  }
+                  """
+              )
+            );
+        }
 
-            public class Foo {
-                private static final String FOO = "";
+        @Test
+        void rawOverReference() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Foo {
+                      private static final String FOO = null;
+                      public void bar(String _null) {
+                          String _null2 = null;
+                          FOO.equals("RAW");
+                          _null.equals("RAW");
+                          _null2.equals("RAW");
+                      }
+                  }
+                  """
+                , """
+                  public class Foo {
+                      private static final String FOO = null;
+                      public void bar(String _null) {
+                          String _null2 = null;
+                          "RAW".equals(FOO);
+                          "RAW".equals(_null);
+                          "RAW".equals(_null2);
+                      }
+                  }
+                  """
+              )
+            );
+        }
 
-                public void foo() {
-                    "".equals(FOO);
-                    "".equals(FOO);
-                }
-            }
-            """
-            ));
+        @Test
+        void rawOverLocalReference() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Foo {
+                      private static final String FOO = null;
+                      public void bar(String _null) {
+                          String _null1 = null;
+                          String _null2 = null;
+                          _null.equals(FOO);
+                          _null2.equals(FOO);
+                          _null.equals(_null);
+                          _null2.equals(_null2);
+                          _null1.equals(_null2);
+                      }
+                  }
+                  """
+                , """
+                  public class Foo {
+                      private static final String FOO = null;
+                      public void bar(String _null) {
+                          String _null1 = null;
+                          String _null2 = null;
+                          FOO.equals(_null);
+                          FOO.equals(_null2);
+                          _null.equals(_null);
+                          _null2.equals(_null2);
+                          _null1.equals(_null2);
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?

Increasing the idempotency of `EqualsAvoidsNull` recipe. Specifically preventing thrashing between expressions like `FOO.equals(BAR)` changed to `BAR.equals(FOO)` changed to `FOO.equals(BAR)`, etc.

The test code has been taken from #487 (kudos to @pankratz76).

## What's your motivation?

- fixes additional problems reported in #472 
