### PR TITLE
Avoid double negation in SimplifyBooleanReturn

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanReturn.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanReturn.java
@@ -124,7 +124,7 @@ public class SimplifyBooleanReturn extends Recipe {
                                 if (ifCondition instanceof J.Unary) {
                                     J.Unary u = (J.Unary) ifCondition;
                                     if (u.getOperator() == J.Unary.Type.Not) {
-                                        return plainReturn.apply(updateCursor(i), i.getCoordinates().replace(), ((J.Unary) ifCondition).getExpression());
+                                        return plainReturn.apply(updateCursor(i), i.getCoordinates().replace(), u.getExpression());
                                     }
                                 }
                                 return notIfConditionReturn.apply(updateCursor(i), i.getCoordinates().replace(), ifCondition);

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanReturnTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.staticanalysis;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -45,7 +46,7 @@ class SimplifyBooleanReturnTest implements RewriteTest {
                       }
                       return false;
                   }
-                  
+
                   static boolean isOddMillis() {
                       boolean even = System.currentTimeMillis() % 2 == 0;
                       if (even == true) {
@@ -62,7 +63,7 @@ class SimplifyBooleanReturnTest implements RewriteTest {
                   boolean ifNoElse() {
                       return isOddMillis();
                   }
-                  
+
                   static boolean isOddMillis() {
                       boolean even = System.currentTimeMillis() % 2 == 0;
                       return !(even == true);
@@ -114,7 +115,7 @@ class SimplifyBooleanReturnTest implements RewriteTest {
               public class A {
                   public boolean absurdEquals(Object o) {
                       if(this == o)
-                          if(this == null) 
+                          if(this == null)
                               return true;
                       return false;
                   }
@@ -134,10 +135,10 @@ class SimplifyBooleanReturnTest implements RewriteTest {
                   public boolean foo(int n) {
                       if (n == 1) {
                           return false;
-                      } 
+                      }
                       else if (n == 2) {
                           return true;
-                      } 
+                      }
                       else {
                           return false;
                       }
@@ -158,11 +159,11 @@ class SimplifyBooleanReturnTest implements RewriteTest {
                   public boolean foo(int n) {
                       if (n == 1) {
                           return true;
-                      } 
+                      }
                       else {
                           System.out.println("side effect");
                           return false;
-                      } 
+                      }
                   }
               }
               """
@@ -220,6 +221,34 @@ class SimplifyBooleanReturnTest implements RewriteTest {
         );
     }
 
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/671#discussion_r1947004208")
+    @Test
+    void avoidDoubleNegation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  boolean foo(boolean bar) {
+                      if (!bar) {
+                          return false;
+                      }
+                      return true;
+                  }
+              }
+              """,
+            """
+              public class A {
+                  boolean foo(boolean bar) {
+                      return bar;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class RetainComments {
         @Test
@@ -233,10 +262,10 @@ class SimplifyBooleanReturnTest implements RewriteTest {
                           if (n == 1) {
                               // A comment that provides important context
                               return true;
-                          } 
+                          }
                           else {
                               return false;
-                          } 
+                          }
                       }
                   }
                   """
@@ -254,11 +283,11 @@ class SimplifyBooleanReturnTest implements RewriteTest {
                       boolean foo(int n) {
                           if (n == 1) {
                               return true;
-                          } 
+                          }
                           else {
                               // A comment that provides important context
                               return false;
-                          } 
+                          }
                       }
                   }
                   """
@@ -276,7 +305,7 @@ class SimplifyBooleanReturnTest implements RewriteTest {
                       boolean foo(int n) {
                           if (n == 1) {
                               return true;
-                          } 
+                          }
                           else
                               // A comment that provides important context
                               return false;


### PR DESCRIPTION
## What's changed?
When a `simplified boolean return` would result in `!(!aBool)`, `aBool` is returned.
