### PR TITLE
Ignoring combineSameSemanticallyEquivalentMethodTypes test case

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -142,6 +144,8 @@ class CombineSemanticallyEqualCatchBlocksTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/506")
+    @ExpectedToFail
     void combineSameSemanticallyEquivalentMethodTypes() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What's changed?

Ignoring a single test case of `combineSameSemanticallyEquivalentMethodTypes` in `CombineSemanticallyEqualCatchBlocksTest`.

## What's your motivation?

It started to fail after https://github.com/openrewrite/rewrite/pull/5286
and should be fixed in #506.
