### PR TITLE
Don't finalize try-with-resources vairables as they are implicitly final

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
@@ -62,6 +62,10 @@ public class FinalizeLocalVariables extends Recipe {
                     return mv;
                 }
 
+                if (isDeclaredInTryWithResources(getCursor())) {
+                    return mv;
+                }
+
                 // ignore fields (aka "instance variable" or "class variable")
                 if (mv.getVariables().stream().anyMatch(v -> v.isField(getCursor()))) {
                     return mv;
@@ -95,6 +99,11 @@ public class FinalizeLocalVariables extends Recipe {
     private boolean isDeclaredInForLoopControl(Cursor cursor) {
         return cursor.getParentTreeCursor()
                 .getValue() instanceof J.ForLoop.Control;
+    }
+
+    private boolean isDeclaredInTryWithResources(Cursor cursor) {
+        return cursor.getParentTreeCursor()
+              .getValue() instanceof J.Try.Resource;
     }
 
     @Value

--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
@@ -58,11 +58,10 @@ public class FinalizeLocalVariables extends Recipe {
                     return mv;
                 }
 
-                if (isDeclaredInForLoopControl(getCursor())) {
-                    return mv;
-                }
-
-                if (isDeclaredInTryWithResources(getCursor())) {
+                // Skip known cases where a `final` modifier looks out of place
+                J parentTreeCursor = getCursor().getParentTreeCursor().getValue();
+                if (parentTreeCursor instanceof J.ForLoop.Control ||
+                        parentTreeCursor instanceof J.Try.Resource) {
                     return mv;
                 }
 
@@ -94,16 +93,6 @@ public class FinalizeLocalVariables extends Recipe {
                 return cursor.dropParentUntil(is -> is instanceof J.NewClass || is instanceof J.ClassDeclaration);
             }
         };
-    }
-
-    private boolean isDeclaredInForLoopControl(Cursor cursor) {
-        return cursor.getParentTreeCursor()
-                .getValue() instanceof J.ForLoop.Control;
-    }
-
-    private boolean isDeclaredInTryWithResources(Cursor cursor) {
-        return cursor.getParentTreeCursor()
-              .getValue() instanceof J.Try.Resource;
     }
 
     @Value

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -463,4 +463,61 @@ class FinalizeLocalVariablesTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/359")
+    @Test
+    void initializedInTryWithResources() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileOutputStream;
+              class T {
+                  public void doSomething() {
+                      try (FileOutputStream out = new FileOutputStream("......")) {
+                          //...
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void initializedInTryCatchFinally() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileOutputStream;
+              class T {
+                  public void doSomething() {
+                      try {
+                          String someValue = "some value";
+                      } catch (Exception e) {
+                          String someExceptionValue = "some exception value";
+                      } finally {
+                          String someFinallyValue = "some finally value";
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.FileOutputStream;
+              class T {
+                  public void doSomething() {
+                      try {
+                          final String someValue = "some value";
+                      } catch (Exception e) {
+                          final String someExceptionValue = "some exception value";
+                      } finally {
+                          final String someFinallyValue = "some finally value";
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
- Added a check to the `FinalizeLocalVariables` recipe to ignore variables in the resources block of try-with-resources
- Added a test to validate variables inside try-catch-finally are still finalized

## What's your motivation?
Fixes:
- https://github.com/openrewrite/rewrite-static-analysis/issues/359
