### PR TITLE
UseCollectionInterfaces updates methodInvovations type info to enable import removal

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -43,7 +43,7 @@ public class UseCollectionInterfaces extends Recipe {
     @Override
     public String getDescription() {
         return "Use `Deque`, `List`, `Map`, `ConcurrentMap`, `Queue`, and `Set` instead of implemented collections. " +
-               "Replaces the return type of public method declarations and the variable type public variable declarations.";
+              "Replaces the return type of public method declarations and the variable type public variable declarations.";
     }
 
     @Override
@@ -114,12 +114,12 @@ public class UseCollectionInterfaces extends Recipe {
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
                 if ((m.hasModifier(J.Modifier.Type.Public) || m.hasModifier(J.Modifier.Type.Private) || m.getModifiers().isEmpty()) &&
-                    m.getReturnTypeExpression() != null) {
+                      m.getReturnTypeExpression() != null) {
                     JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(m.getReturnTypeExpression().getType());
                     if (originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
 
                         JavaType.FullyQualified newType = TypeUtils.asFullyQualified(
-                                JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
+                              JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
                         if (newType != null) {
                             maybeRemoveImport(originalType);
                             maybeAddImport(newType);
@@ -127,13 +127,13 @@ public class UseCollectionInterfaces extends Recipe {
                             TypeTree typeExpression;
                             if (m.getReturnTypeExpression() instanceof J.Identifier) {
                                 typeExpression = new J.Identifier(
-                                        randomId(),
-                                        m.getReturnTypeExpression().getPrefix(),
-                                        Markers.EMPTY,
-                                        emptyList(),
-                                        newType.getClassName(),
-                                        newType,
-                                        null
+                                      randomId(),
+                                      m.getReturnTypeExpression().getPrefix(),
+                                      Markers.EMPTY,
+                                      emptyList(),
+                                      newType.getClassName(),
+                                      newType,
+                                      null
                                 );
                             } else if (m.getReturnTypeExpression() instanceof J.AnnotatedType) {
                                 J.AnnotatedType annotatedType = (J.AnnotatedType) m.getReturnTypeExpression();
@@ -161,10 +161,8 @@ public class UseCollectionInterfaces extends Recipe {
                         if (rspecRulesReplaceTypeMap.containsKey(fullyQualifiedName)) {
                             JavaType.FullyQualified newType = TypeUtils.asFullyQualified(JavaType.buildType(rspecRulesReplaceTypeMap.get(fullyQualifiedName)));
                             if (newType != null) {
-                                if(originalType instanceof JavaType.Parameterized) {
-                                    JavaType.Parameterized originalParameterizedType = (JavaType.Parameterized) originalType;
-                                    JavaType.Parameterized newParameterizedType = new JavaType.Parameterized(null, newType, originalParameterizedType.getTypeParameters());
-                                    return updateMethodInvocation(mi, newParameterizedType);
+                                if (originalType instanceof JavaType.Parameterized) {
+                                    newType = new JavaType.Parameterized(null, newType, ((JavaType.Parameterized) originalType).getTypeParameters());
                                 }
                                 return updateMethodInvocation(mi, newType);
                             }
@@ -179,13 +177,13 @@ public class UseCollectionInterfaces extends Recipe {
                 J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
                 JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(mv.getType());
                 if ((mv.hasModifier(J.Modifier.Type.Public) || mv.hasModifier(J.Modifier.Type.Private) || mv.getModifiers().isEmpty()) &&
-                    originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
+                      originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
                     if (mv.getTypeExpression() instanceof J.Identifier && "var".equals(((J.Identifier) mv.getTypeExpression()).getSimpleName())) {
                         return mv;
                     }
 
                     JavaType.FullyQualified newType = TypeUtils.asFullyQualified(
-                            JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
+                          JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
                     if (newType != null) {
                         maybeRemoveImport(originalType);
                         maybeAddImport(newType);
@@ -195,13 +193,13 @@ public class UseCollectionInterfaces extends Recipe {
                             typeExpression = null;
                         } else if (mv.getTypeExpression() instanceof J.Identifier) {
                             typeExpression = new J.Identifier(
-                                    randomId(),
-                                    mv.getTypeExpression().getPrefix(),
-                                    Markers.EMPTY,
-                                    emptyList(),
-                                    newType.getClassName(),
-                                    newType,
-                                    null
+                                  randomId(),
+                                  mv.getTypeExpression().getPrefix(),
+                                  Markers.EMPTY,
+                                  emptyList(),
+                                  newType.getClassName(),
+                                  newType,
+                                  null
                             );
                         } else if (mv.getTypeExpression() instanceof J.AnnotatedType) {
                             J.AnnotatedType annotatedType = (J.AnnotatedType) mv.getTypeExpression();
@@ -229,7 +227,7 @@ public class UseCollectionInterfaces extends Recipe {
                 if (mi.getSelect() != null) {
                     mi = mi.withSelect(mi.getSelect().withType(newType));
                 }
-                if(mi.getMethodType() != null) {
+                if (mi.getMethodType() != null) {
                     mi = mi.withMethodType(mi.getMethodType().withDeclaringType(newType));
                 }
                 return mi;
@@ -238,18 +236,18 @@ public class UseCollectionInterfaces extends Recipe {
             private TypeTree removeFromParameterizedType(JavaType.FullyQualified newType,
                                                          J.ParameterizedType parameterizedType) {
                 J.Identifier returnType = new J.Identifier(
-                        randomId(),
-                        Space.EMPTY,
-                        Markers.EMPTY,
-                        emptyList(),
-                        newType.getClassName(),
-                        newType,
-                        null
+                      randomId(),
+                      Space.EMPTY,
+                      Markers.EMPTY,
+                      emptyList(),
+                      newType.getClassName(),
+                      newType,
+                      null
                 );
                 JavaType.Parameterized javaType = (JavaType.Parameterized) parameterizedType.getType();
                 return parameterizedType.withClazz(returnType)
-                        .withType(javaType != null ? javaType.withType(newType) :
-                                new JavaType.Parameterized(null, newType, null));
+                      .withType(javaType != null ? javaType.withType(newType) :
+                            new JavaType.Parameterized(null, newType, null));
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -151,6 +151,18 @@ public class UseCollectionInterfaces extends Recipe {
             }
 
             @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+                JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(mi.getSelect().getType());
+                if (originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
+                    JavaType.FullyQualified newType = TypeUtils.asFullyQualified(
+                          JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
+                    return mi.withSelect(mi.getSelect().withType(newType));
+                }
+                return mi;
+            }
+
+            @Override
             public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                 J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
                 JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(mv.getType());

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -43,7 +43,7 @@ public class UseCollectionInterfaces extends Recipe {
     @Override
     public String getDescription() {
         return "Use `Deque`, `List`, `Map`, `ConcurrentMap`, `Queue`, and `Set` instead of implemented collections. " +
-              "Replaces the return type of public method declarations and the variable type public variable declarations.";
+               "Replaces the return type of public method declarations and the variable type public variable declarations.";
     }
 
     @Override
@@ -114,12 +114,12 @@ public class UseCollectionInterfaces extends Recipe {
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
                 if ((m.hasModifier(J.Modifier.Type.Public) || m.hasModifier(J.Modifier.Type.Private) || m.getModifiers().isEmpty()) &&
-                      m.getReturnTypeExpression() != null) {
+                    m.getReturnTypeExpression() != null) {
                     JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(m.getReturnTypeExpression().getType());
                     if (originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
 
                         JavaType.FullyQualified newType = TypeUtils.asFullyQualified(
-                              JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
+                                JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
                         if (newType != null) {
                             maybeRemoveImport(originalType);
                             maybeAddImport(newType);
@@ -127,13 +127,13 @@ public class UseCollectionInterfaces extends Recipe {
                             TypeTree typeExpression;
                             if (m.getReturnTypeExpression() instanceof J.Identifier) {
                                 typeExpression = new J.Identifier(
-                                      randomId(),
-                                      m.getReturnTypeExpression().getPrefix(),
-                                      Markers.EMPTY,
-                                      emptyList(),
-                                      newType.getClassName(),
-                                      newType,
-                                      null
+                                        randomId(),
+                                        m.getReturnTypeExpression().getPrefix(),
+                                        Markers.EMPTY,
+                                        emptyList(),
+                                        newType.getClassName(),
+                                        newType,
+                                        null
                                 );
                             } else if (m.getReturnTypeExpression() instanceof J.AnnotatedType) {
                                 J.AnnotatedType annotatedType = (J.AnnotatedType) m.getReturnTypeExpression();
@@ -177,13 +177,13 @@ public class UseCollectionInterfaces extends Recipe {
                 J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
                 JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(mv.getType());
                 if ((mv.hasModifier(J.Modifier.Type.Public) || mv.hasModifier(J.Modifier.Type.Private) || mv.getModifiers().isEmpty()) &&
-                      originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
+                    originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
                     if (mv.getTypeExpression() instanceof J.Identifier && "var".equals(((J.Identifier) mv.getTypeExpression()).getSimpleName())) {
                         return mv;
                     }
 
                     JavaType.FullyQualified newType = TypeUtils.asFullyQualified(
-                          JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
+                            JavaType.buildType(rspecRulesReplaceTypeMap.get(originalType.getFullyQualifiedName())));
                     if (newType != null) {
                         maybeRemoveImport(originalType);
                         maybeAddImport(newType);
@@ -193,13 +193,13 @@ public class UseCollectionInterfaces extends Recipe {
                             typeExpression = null;
                         } else if (mv.getTypeExpression() instanceof J.Identifier) {
                             typeExpression = new J.Identifier(
-                                  randomId(),
-                                  mv.getTypeExpression().getPrefix(),
-                                  Markers.EMPTY,
-                                  emptyList(),
-                                  newType.getClassName(),
-                                  newType,
-                                  null
+                                    randomId(),
+                                    mv.getTypeExpression().getPrefix(),
+                                    Markers.EMPTY,
+                                    emptyList(),
+                                    newType.getClassName(),
+                                    newType,
+                                    null
                             );
                         } else if (mv.getTypeExpression() instanceof J.AnnotatedType) {
                             J.AnnotatedType annotatedType = (J.AnnotatedType) mv.getTypeExpression();
@@ -236,18 +236,18 @@ public class UseCollectionInterfaces extends Recipe {
             private TypeTree removeFromParameterizedType(JavaType.FullyQualified newType,
                                                          J.ParameterizedType parameterizedType) {
                 J.Identifier returnType = new J.Identifier(
-                      randomId(),
-                      Space.EMPTY,
-                      Markers.EMPTY,
-                      emptyList(),
-                      newType.getClassName(),
-                      newType,
-                      null
+                        randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        emptyList(),
+                        newType.getClassName(),
+                        newType,
+                        null
                 );
                 JavaType.Parameterized javaType = (JavaType.Parameterized) parameterizedType.getType();
                 return parameterizedType.withClazz(returnType)
-                      .withType(javaType != null ? javaType.withType(newType) :
-                            new JavaType.Parameterized(null, newType, null));
+                        .withType(javaType != null ? javaType.withType(newType) :
+                                new JavaType.Parameterized(null, newType, null));
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.groovy.tree.G;

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -151,8 +151,8 @@ public class UseCollectionInterfaces extends Recipe {
             }
 
             @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
-                J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
                 JavaType.FullyQualified originalType = TypeUtils.asFullyQualified(mi.getSelect().getType());
                 if (originalType != null && rspecRulesReplaceTypeMap.containsKey(originalType.getFullyQualifiedName())) {
                     JavaType.FullyQualified newType = TypeUtils.asFullyQualified(

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -174,16 +174,6 @@ public class UseCollectionInterfaces extends Recipe {
                 return mi;
             }
 
-            private J.MethodInvocation updateMethodInvocation(J.MethodInvocation mi, JavaType.FullyQualified newType) {
-                if (mi.getSelect() != null) {
-                    mi = mi.withSelect(mi.getSelect().withType(newType));
-                }
-                if(mi.getMethodType() != null) {
-                    mi = mi.withMethodType(mi.getMethodType().withDeclaringType(newType));
-                }
-                return mi;
-            }
-
             @Override
             public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                 J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
@@ -233,6 +223,16 @@ public class UseCollectionInterfaces extends Recipe {
                     }
                 }
                 return mv;
+            }
+
+            private J.MethodInvocation updateMethodInvocation(J.MethodInvocation mi, JavaType.FullyQualified newType) {
+                if (mi.getSelect() != null) {
+                    mi = mi.withSelect(mi.getSelect().withType(newType));
+                }
+                if(mi.getMethodType() != null) {
+                    mi = mi.withMethodType(mi.getMethodType().withDeclaringType(newType));
+                }
+                return mi;
             }
 
             private TypeTree removeFromParameterizedType(JavaType.FullyQualified newType,

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.groovy.tree.G;
@@ -164,18 +165,22 @@ public class UseCollectionInterfaces extends Recipe {
                                 if(originalType instanceof JavaType.Parameterized) {
                                     JavaType.Parameterized originalParameterizedType = (JavaType.Parameterized) originalType;
                                     JavaType.Parameterized newParameterizedType = new JavaType.Parameterized(null, newType, originalParameterizedType.getTypeParameters());
-                                    if(mi.getMethodType() != null) {
-                                        return mi
-                                              .withSelect(mi.getSelect().withType(newParameterizedType))
-                                              .withMethodType(mi.getMethodType().withDeclaringType(newParameterizedType));
-                                    }
-                                    return mi
-                                          .withSelect(mi.getSelect().withType(newParameterizedType));
+                                    return updateMethodInvocation(mi, newParameterizedType);
                                 }
-                                return mi.withSelect(mi.getSelect().withType(newType));
+                                return updateMethodInvocation(mi, newType);
                             }
                         }
                     }
+                }
+                return mi;
+            }
+
+            private J.MethodInvocation updateMethodInvocation(J.MethodInvocation mi, JavaType.FullyQualified newType) {
+                if (mi.getSelect() != null) {
+                    mi = mi.withSelect(mi.getSelect().withType(newType));
+                }
+                if(mi.getMethodType() != null) {
+                    mi = mi.withMethodType(mi.getMethodType().withDeclaringType(newType));
                 }
                 return mi;
             }

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -1001,4 +1001,34 @@ class UseCollectionInterfacesTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
+    @Test
+    void danglingReference() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            import java.util.concurrent.ConcurrentLinkedQueue;
+
+            class B {
+                private final ConcurrentLinkedQueue<String> widgetDataList;
+                public void foo() {
+                  widgetDataList.add("TEST");
+                }
+            }
+            """,
+            """
+            import java.util.Queue;
+
+            class B {
+                private final Queue<String> widgetDataList;
+                public void foo() {
+                  widgetDataList.add("TEST");
+                }
+            }
+            """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -1004,7 +1004,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
     @Test
-    void danglingReference() {
+    void danglingGenericReference() {
         rewriteRun(
           //language=java
           java(
@@ -1023,6 +1023,36 @@ class UseCollectionInterfacesTest implements RewriteTest {
 
             class B {
                 private final Queue<String> widgetDataList;
+                public void foo() {
+                  widgetDataList.add("TEST");
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
+    @Test
+    void danglingReference() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            import java.util.concurrent.ConcurrentLinkedQueue;
+
+            class B {
+                private final ConcurrentLinkedQueue widgetDataList;
+                public void foo() {
+                  widgetDataList.add("TEST");
+                }
+            }
+            """,
+            """
+            import java.util.Queue;
+
+            class B {
+                private final Queue widgetDataList;
                 public void foo() {
                   widgetDataList.add("TEST");
                 }


### PR DESCRIPTION
## What's changed?
UseCollectionInterfaces now also visits methodInvocation to change their type. This causes the imports to be removed correctly.

## What's your motivation?
Fixes:
- https://github.com/openrewrite/rewrite-static-analysis/issues/357
