### PR TITLE
Handling parentheses sometimes needed around instanceof

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
@@ -288,14 +288,14 @@ class ReplaceClassIsInstanceWithInstanceofTest implements RewriteTest {
           //language=java
           java(
             """
-              class A {
-                  boolean foo(Object one, Object two) {
-                      if (one == null || !String.class.isInstance(two)) {
-                          return false;
-                      }
-                      return true;
-                  }
-              }
+            class A {
+                boolean foo(Object one, Object two) {
+                    if (one == null || !String.class.isInstance(two)) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
             """,
             """
             class A {

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
@@ -282,4 +282,32 @@ class ReplaceClassIsInstanceWithInstanceofTest implements RewriteTest {
         );
     }
 
+    @Test
+    void parensAroundInstanceOf() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  boolean foo(Object one, Object two) {
+                      if (one == null || !String.class.isInstance(two)) {
+                          return false;
+                      }
+                      return true;
+                  }
+              }
+            """,
+            """
+            class A {
+                boolean foo(Object one, Object two) {
+                    if (one == null || !(two instanceof String)) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Fixing `ReplaceClassIsInstanceWithInstanceof` wrt to parenthesis being sometimes needed around the `instanceof`.

## What's your motivation?
Fix the errors observed in real-life, e.g.
[this code in spring-hateoas](https://github.com/spring-projects/spring-hateoas/blob/f8850d3d15db48bf0ddac3ce12e8197c004e9c5d/src/main/java/org/springframework/hateoas/mediatype/collectionjson/Jackson2CollectionJsonModule.java#L921) throws:
```
Message:

class org.openrewrite.java.tree.J$Parentheses cannot be cast to class org.openrewrite.java.tree.J$InstanceOf (org.openrewrite.java.tree.J$Parentheses and org.openrewrite.java.tree.J$InstanceOf are in unnamed module of loader 'app')
Detail:

java.lang.ClassCastException: class org.openrewrite.java.tree.J$Parentheses cannot be cast to class org.openrewrite.java.tree.J$InstanceOf (org.openrewrite.java.tree.J$Parentheses and org.openrewrite.java.tree.J$InstanceOf are in unnamed module of loader 'app')
  org.openrewrite.staticanalysis.ReplaceClassIsInstanceWithInstanceof$1.visitMethodInvocation(ReplaceClassIsInstanceWithInstanceof.java:73)
  org.openrewrite.staticanalysis.ReplaceClassIsInstanceWithInstanceof$1.visitMethodInvocation(ReplaceClassIsInstanceWithInstanceof.java:60)
```
