### PR TITLE
fix: use box for primitives when rewriting `instanceof` (#528)

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -259,8 +259,16 @@ public class InstanceOfPatternMatch extends Recipe {
                 return instanceOf;
             }
             String name = patternVariableName(instanceOf, cursor);
-            TypeTree typeCastTypeTree = computeTypeTreeFromTypeCasts(instanceOf);
-            J currentTypeTree = instanceOf.getClazz();
+            TypedTree typeCastTypeTree = computeTypeTreeFromTypeCasts(instanceOf);
+            TypedTree currentTypeTree = (TypedTree) instanceOf.getClazz();
+
+            // handle primitives, they must not appear in instanceof's
+            if (typeCastTypeTree.getType() instanceof JavaType.Primitive) {
+                // we have cheked for the correct assignability beforehand
+                // so we can just use type from the original instanceof
+                typeCastTypeTree = currentTypeTree;
+            }
+
             J.InstanceOf result = instanceOf.withPattern(new J.Identifier(
                     randomId(),
                     Space.build(" ", emptyList()),

--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -264,7 +264,7 @@ public class InstanceOfPatternMatch extends Recipe {
 
             // handle primitives, they must not appear in instanceof's
             if (typeCastTypeTree.getType() instanceof JavaType.Primitive) {
-                // we have cheked for the correct assignability beforehand
+                // we have checked for the correct assignability beforehand
                 // so we can just use type from the original instanceof
                 typeCastTypeTree = currentTypeTree;
             }

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -1421,6 +1421,36 @@ class InstanceOfPatternMatchTest implements RewriteTest {
               )
             );
         }
+        
+        @Test
+        void matchingPrimitiveVariableInBody() {
+            rewriteRun(
+              version(
+                //language=java
+                java(
+                  """
+                    public class A {
+                        void test(Object o, Integer integer) {
+                            if (o instanceof Integer) {
+                                for (int j = 0; j < (int) o; j++) {
+                                }
+                            }
+                        }
+                    }
+                    """,
+                  """
+                    public class A {
+                        void test(Object o, Integer integer) {
+                            if (o instanceof Integer integer1) {
+                                for (int j = 0; j < integer1; j++) {
+                                }
+                            }
+                        }
+                    }
+                    """
+                ), 17)
+            );
+        }
     }
 
     @Nested

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -1421,7 +1421,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
               )
             );
         }
-        
+
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/528")
         @Test
         void matchingPrimitiveVariableInBody() {
             rewriteRun(
@@ -1429,7 +1430,7 @@ class InstanceOfPatternMatchTest implements RewriteTest {
                 //language=java
                 java(
                   """
-                    public class A {
+                    class A {
                         void test(Object o, Integer integer) {
                             if (o instanceof Integer) {
                                 for (int j = 0; j < (int) o; j++) {
@@ -1439,7 +1440,7 @@ class InstanceOfPatternMatchTest implements RewriteTest {
                     }
                     """,
                   """
-                    public class A {
+                    class A {
                         void test(Object o, Integer integer) {
                             if (o instanceof Integer integer1) {
                                 for (int j = 0; j < integer1; j++) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
We now only use the boxed variants of primitives when rewriting `instanceof`.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- fix #528 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
