### PR TITLE
Fix clashing variable names generated by `InstanceOfPatternMatch`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -320,7 +320,14 @@ public class InstanceOfPatternMatch extends Recipe {
                 strategy = VariableNameStrategy.short_();
             }
             String baseName = strategy.variableName(type);
-            return VariableNameUtils.generateVariableName(baseName, cursor, INCREMENT_NUMBER);
+            if (root instanceof J.If) {
+                J.If enclosingIf = cursor.firstEnclosing(J.If.class);
+                String nameInIfScope = VariableNameUtils.generateVariableName(baseName, new Cursor(cursor, enclosingIf), INCREMENT_NUMBER);
+                String nameInCursorScope = VariableNameUtils.generateVariableName(baseName, cursor, INCREMENT_NUMBER);
+                return nameInIfScope.compareTo(nameInCursorScope) >= 0 ? nameInIfScope : nameInCursorScope;
+            } else {
+                return VariableNameUtils.generateVariableName(baseName, cursor, INCREMENT_NUMBER);
+            }
         }
 
         public @Nullable J processTypeCast(J.TypeCast typeCast, Cursor cursor) {

--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -325,9 +325,8 @@ public class InstanceOfPatternMatch extends Recipe {
                 String nameInIfScope = VariableNameUtils.generateVariableName(baseName, new Cursor(cursor, enclosingIf), INCREMENT_NUMBER);
                 String nameInCursorScope = VariableNameUtils.generateVariableName(baseName, cursor, INCREMENT_NUMBER);
                 return nameInIfScope.compareTo(nameInCursorScope) >= 0 ? nameInIfScope : nameInCursorScope;
-            } else {
-                return VariableNameUtils.generateVariableName(baseName, cursor, INCREMENT_NUMBER);
             }
+            return VariableNameUtils.generateVariableName(baseName, cursor, INCREMENT_NUMBER);
         }
 
         public @Nullable J processTypeCast(J.TypeCast typeCast, Cursor cursor) {

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -560,9 +560,9 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/334")
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/481")
         @Test
-        void clashingWithInstanceOfVariableName() {
+        void conflictingWithLocalVariable() {
             rewriteRun(
               //language=java
               java(
@@ -604,8 +604,9 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/334")
         @Test
-        void clashingInstanceOfVariableNames() {
+        void conflictingWithOtherInstanceOf() {
             rewriteRun(
               //language=java
               java(


### PR DESCRIPTION
In addition to the `cursor` scope, added the enclosing `J.If` scope for searching conflicting variable names.

- Fix https://github.com/openrewrite/rewrite-static-analysis/issues/334
- Fix https://github.com/openrewrite/rewrite-static-analysis/issues/481
- Fix https://github.com/openrewrite/rewrite/issues/2787
- It also can be a workaround for https://github.com/openrewrite/rewrite/issues/2776