### PR TITLE
Enable custom Serial Version UID

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializable.java
@@ -45,8 +45,6 @@ public class AddSerialVersionUidToSerializable extends Recipe {
     @Nullable
     String uid;
 
-    private static final String DEFAULT_NEW_UID = "1";
-
     @Override
     public String getDisplayName() {
         return "Add `serialVersionUID` to a `Serializable` class when missing";
@@ -67,11 +65,7 @@ public class AddSerialVersionUidToSerializable extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
-            final String newUid = uid != null ? uid : DEFAULT_NEW_UID;
-            final JavaTemplate template = JavaTemplate.builder(
-                            String.format("private static final long serialVersionUID = %s;", newUid)
-                    )
-                    .build();
+            final JavaTemplate template = JavaTemplate.builder(String.format("private static final long serialVersionUID = %s;", uid != null ? uid : "1")).build();
 
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUIDTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUIDTest.java
@@ -62,7 +62,7 @@ class AddSerialAnnotationToSerialVersionUIDTest implements RewriteTest {
     void shouldAddToNewFieldWhenChained() {
         rewriteRun(
           spec -> spec.recipes(
-            new AddSerialVersionUidToSerializable(),
+            new AddSerialVersionUidToSerializable(null),
             new AddSerialAnnotationToSerialVersionUID()),
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializableTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializableTest.java
@@ -57,7 +57,6 @@ class AddSerialVersionUidToSerializableTest implements RewriteTest {
         );
     }
 
-    @DocumentExample
     @Test
     void addCustomSerialVersionUID() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializableTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializableTest.java
@@ -27,7 +27,7 @@ class AddSerialVersionUidToSerializableTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AddSerialVersionUidToSerializable());
+        spec.recipe(new AddSerialVersionUidToSerializable(null));
     }
 
     @DocumentExample
@@ -49,6 +49,34 @@ class AddSerialVersionUidToSerializableTest implements RewriteTest {
 
               public class Example implements Serializable {
                   private static final long serialVersionUID = 1;
+                  private String fred;
+                  private int numberOfFreds;
+              }
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void addCustomSerialVersionUID() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSerialVersionUidToSerializable("1L")),
+          //language=java
+          java(
+            """
+              import java.io.Serializable;
+
+              public class Example implements Serializable {
+                  private String fred;
+                  private int numberOfFreds;
+              }
+              """,
+            """
+              import java.io.Serializable;
+
+              public class Example implements Serializable {
+                  private static final long serialVersionUID = 1L;
                   private String fred;
                   private int numberOfFreds;
               }
@@ -156,6 +184,25 @@ class AddSerialVersionUidToSerializableTest implements RewriteTest {
     @Test
     void uidAlreadyPresent() {
         rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.Serializable;
+
+              public class Example implements Serializable {
+                  private static final long serialVersionUID = 1;
+                  private String fred;
+                  private int numberOfFreds;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void customUidKeepsUidAlreadyPresent() {
+        rewriteRun(
+          spec -> spec.recipe(new AddSerialVersionUidToSerializable("1L")),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/staticanalysis/HiddenFieldTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/HiddenFieldTest.java
@@ -92,7 +92,7 @@ class HiddenFieldTest implements RewriteTest {
                       String localVariable = someField;
                   }
               }
-                """
+              """
           )
         );
     }
@@ -759,7 +759,7 @@ class HiddenFieldTest implements RewriteTest {
 
                   public abstract void method(int n);
               }
-                """
+              """
           )
         );
     }


### PR DESCRIPTION
## What's changed?

To be able to choose from `1`, `1L`, or any other value.

## What's your motivation?

Codebases often go for the `1L` value, so having an option to use that value is cool.

## Anything in particular you'd like reviewers to focus on?

Unit test coverage, maybe?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
