### PR TITLE
Reordering Annotations

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUID.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUID.java
@@ -50,8 +50,8 @@ public class AddSerialAnnotationToSerialVersionUID extends Recipe {
         return Duration.ofMinutes(1);
     }
 
-    @Override
     @NonNull
+    @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 Preconditions.and(

--- a/src/main/java/org/openrewrite/staticanalysis/BooleanChecksNotInverted.java
+++ b/src/main/java/org/openrewrite/staticanalysis/BooleanChecksNotInverted.java
@@ -51,8 +51,8 @@ public class BooleanChecksNotInverted extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
 
-            @SuppressWarnings("ConstantConditions")
             @Override
+            @SuppressWarnings("ConstantConditions")
             public J visitUnary(J.Unary unary, ExecutionContext ctx) {
                 if (unary.getOperator() == J.Unary.Type.Not && unary.getExpression() instanceof J.Parentheses) {
                     J.Parentheses<?> expr = (J.Parentheses<?>) unary.getExpression();

--- a/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
@@ -715,8 +715,8 @@ public class CombineSemanticallyEqualCatchBlocks extends Recipe {
                 return cu;
             }
 
-            @SuppressWarnings("unchecked")
             @Override
+            @SuppressWarnings("unchecked")
             public <T extends J> J.ControlParentheses<T> visitControlParentheses(J.ControlParentheses<T> controlParens, J j) {
                 if (isEqual.get()) {
                     if (!(j instanceof J.ControlParentheses)) {
@@ -1426,8 +1426,8 @@ public class CombineSemanticallyEqualCatchBlocks extends Recipe {
                 return type;
             }
 
-            @SuppressWarnings("unchecked")
             @Override
+            @SuppressWarnings("unchecked")
             public <T extends J> J.Parentheses<T> visitParentheses(J.Parentheses<T> parens, J j) {
                 if (isEqual.get()) {
                     if (!(j instanceof J.Parentheses)) {

--- a/src/main/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorVisitor.java
@@ -64,8 +64,8 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
         this.utilityClassMatcher = new UtilityClassMatcher(style.getIgnoreIfAnnotatedBy());
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
+    @SuppressWarnings("ConstantConditions")
     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, P p) {
         J.ClassDeclaration c = super.visitClassDeclaration(classDecl, p);
         if (!EXCLUDE_CLASS_TYPES.contains(c.getKind()) && !c.hasModifier(J.Modifier.Type.Abstract) && utilityClassMatcher.isRefactorableUtilityClass(getCursor())) {

--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -451,8 +451,8 @@ public class InstanceOfPatternMatch extends Recipe {
             return typeCast;
         }
 
-        @SuppressWarnings("NullableProblems")
         @Override
+        @SuppressWarnings("NullableProblems")
         public @Nullable J visitVariableDeclarations(J.VariableDeclarations multiVariable, Integer integer) {
             multiVariable = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, integer);
             return replacements.processVariableDeclarations(multiVariable);

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveExtraSemicolons.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveExtraSemicolons.java
@@ -53,8 +53,8 @@ public class RemoveExtraSemicolons extends Recipe {
         return Duration.ofMinutes(1);
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
+    @SuppressWarnings("ConstantConditions")
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
 

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -68,8 +68,8 @@ public class RemoveUnusedLocalVariables extends Recipe {
         this.withSideEffects = withSideEffects;
     }
 
-    @InlineMe(replacement = "new RemoveUnusedLocalVariables(ignoreVariablesNamed, null, withSideEffects)")
     @Deprecated
+    @InlineMe(replacement = "new RemoveUnusedLocalVariables(ignoreVariablesNamed, null, withSideEffects)")
     public RemoveUnusedLocalVariables(
             String @Nullable [] ignoreVariablesNamed,
             @Nullable Boolean withSideEffects) {

--- a/src/main/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCase.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCase.java
@@ -96,8 +96,8 @@ public class RenamePrivateFieldsToCamelCase extends Recipe {
                 return super.visitClassDeclaration(classDecl, ctx);
             }
 
-            @SuppressWarnings("all")
             @Override
+            @SuppressWarnings("all")
             public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext ctx) {
                 Cursor parentScope = getCursorToParentScope(getCursor());
 

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -48,44 +48,44 @@ public class ReorderAnnotations extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
-                if (!cd.getLeadingAnnotations().isEmpty()) {
-                    List<J.Annotation> sortedAnnotations = new ArrayList<>(cd.getLeadingAnnotations());
+                J.ClassDeclaration d = super.visitClassDeclaration(classDecl, ctx);
+                if (1 < d.getLeadingAnnotations().size()) {
+                    List<J.Annotation> sortedAnnotations = new ArrayList<>(d.getLeadingAnnotations());
                     sortedAnnotations.sort(comparator);
-                    if (!sortedAnnotations.equals(cd.getLeadingAnnotations())) {
-                        return cd.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
-                                (i, a) -> a.withPrefix(cd.getLeadingAnnotations().get(i).getPrefix())));
+                    if (!sortedAnnotations.equals(d.getLeadingAnnotations())) {
+                        return d.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
+                                (i, a) -> a.withPrefix(d.getLeadingAnnotations().get(i).getPrefix())));
                     }
                 }
-                return cd;
+                return d;
             }
 
             @Override
             public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
-                J.VariableDeclarations fd = super.visitVariableDeclarations(multiVariable, ctx);
-                if (!fd.getLeadingAnnotations().isEmpty()) {
-                    List<J.Annotation> sortedAnnotations = new ArrayList<>(fd.getLeadingAnnotations());
+                J.VariableDeclarations d = super.visitVariableDeclarations(multiVariable, ctx);
+                if (1 < d.getLeadingAnnotations().size()) {
+                    List<J.Annotation> sortedAnnotations = new ArrayList<>(d.getLeadingAnnotations());
                     sortedAnnotations.sort(comparator);
-                    if (!sortedAnnotations.equals(fd.getLeadingAnnotations())) {
-                        return fd.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
-                                (i, a) -> a.withPrefix(fd.getLeadingAnnotations().get(i).getPrefix())));
+                    if (!sortedAnnotations.equals(d.getLeadingAnnotations())) {
+                        return d.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
+                                (i, a) -> a.withPrefix(d.getLeadingAnnotations().get(i).getPrefix())));
                     }
                 }
-                return fd;
+                return d;
             }
 
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                J.MethodDeclaration md = super.visitMethodDeclaration(method, ctx);
-                if (!md.getLeadingAnnotations().isEmpty()) {
-                    List<J.Annotation> sortedAnnotations = new ArrayList<>(md.getLeadingAnnotations());
+                J.MethodDeclaration d = super.visitMethodDeclaration(method, ctx);
+                if (1 < d.getLeadingAnnotations().size()) {
+                    List<J.Annotation> sortedAnnotations = new ArrayList<>(d.getLeadingAnnotations());
                     sortedAnnotations.sort(comparator);
-                    if (!sortedAnnotations.equals(md.getLeadingAnnotations())) {
-                        return md.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
-                                (i, a) -> a.withPrefix(md.getLeadingAnnotations().get(i).getPrefix())));
+                    if (!sortedAnnotations.equals(d.getLeadingAnnotations())) {
+                        return d.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
+                                (i, a) -> a.withPrefix(d.getLeadingAnnotations().get(i).getPrefix())));
                     }
                 }
-                return md;
+                return d;
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -47,8 +47,8 @@ public class ReorderAnnotations extends Recipe {
     public JavaIsoVisitor<ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
-            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
-                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
                 if (!cd.getLeadingAnnotations().isEmpty()) {
                     List<J.Annotation> sortedAnnotations = new ArrayList<>(cd.getLeadingAnnotations());
                     sortedAnnotations.sort(comparator);
@@ -61,17 +61,31 @@ public class ReorderAnnotations extends Recipe {
             }
 
             @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                if (!m.getLeadingAnnotations().isEmpty()) {
-                    List<J.Annotation> sortedAnnotations = new ArrayList<>(m.getLeadingAnnotations());
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                J.VariableDeclarations fd = super.visitVariableDeclarations(multiVariable, ctx);
+                if (!fd.getLeadingAnnotations().isEmpty()) {
+                    List<J.Annotation> sortedAnnotations = new ArrayList<>(fd.getLeadingAnnotations());
                     sortedAnnotations.sort(comparator);
-                    if (!sortedAnnotations.equals(m.getLeadingAnnotations())) {
-                        return m.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
-                                (i, a) -> a.withPrefix(m.getLeadingAnnotations().get(i).getPrefix())));
+                    if (!sortedAnnotations.equals(fd.getLeadingAnnotations())) {
+                        return fd.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
+                                (i, a) -> a.withPrefix(fd.getLeadingAnnotations().get(i).getPrefix())));
                     }
                 }
-                return m;
+                return fd;
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration md = super.visitMethodDeclaration(method, ctx);
+                if (!md.getLeadingAnnotations().isEmpty()) {
+                    List<J.Annotation> sortedAnnotations = new ArrayList<>(md.getLeadingAnnotations());
+                    sortedAnnotations.sort(comparator);
+                    if (!sortedAnnotations.equals(md.getLeadingAnnotations())) {
+                        return md.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
+                                (i, a) -> a.withPrefix(md.getLeadingAnnotations().get(i).getPrefix())));
+                    }
+                }
+                return md;
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -1,0 +1,58 @@
+package org.openrewrite.staticanalysis;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ReorderAnnotations extends Recipe {
+    private static final Comparator<J.Annotation> defaultComparator = Comparator.comparing(J.Annotation::getSimpleName);
+    // TODO: Take in optional Comparator<J.Annotation>, defaulted to alphabetical
+    @Override
+    public String getDisplayName() {
+        return "Reorder annotations in a consistent order";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Reorder annotations based on a provided Comparator class.";
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    public static class ReorderAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
+        Comparator<J.Annotation> comparator;
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+            J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+            List<J.Annotation> annotations = m.getLeadingAnnotations();
+            if (annotations.isEmpty()) {
+                return m;
+            }
+            List<J.Annotation> sortedAnnotations = new ArrayList<>(annotations);
+            sortedAnnotations.sort(comparator);
+            if (sortedAnnotations.equals(annotations)) {
+                return m;
+            }
+            for (int i = 0; i < annotations.size(); i++) {
+                sortedAnnotations.set(i, sortedAnnotations.get(i).withPrefix(annotations.get(i).getPrefix()));
+            }
+
+            return m.withLeadingAnnotations(sortedAnnotations);
+        }
+    }
+
+    @Override
+    public JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new ReorderAnnotationVisitor(defaultComparator);
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -47,6 +47,20 @@ public class ReorderAnnotations extends Recipe {
     public JavaIsoVisitor<ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+                if (!cd.getLeadingAnnotations().isEmpty()) {
+                    List<J.Annotation> sortedAnnotations = new ArrayList<>(cd.getLeadingAnnotations());
+                    sortedAnnotations.sort(comparator);
+                    if (!sortedAnnotations.equals(cd.getLeadingAnnotations())) {
+                        return cd.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
+                                (i, a) -> a.withPrefix(cd.getLeadingAnnotations().get(i).getPrefix())));
+                    }
+                }
+                return cd;
+            }
+
+            @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
                 if (!m.getLeadingAnnotations().isEmpty()) {

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.staticanalysis;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 
@@ -52,7 +53,8 @@ public class ReorderAnnotations extends Recipe {
                     List<J.Annotation> sortedAnnotations = new ArrayList<>(m.getLeadingAnnotations());
                     sortedAnnotations.sort(comparator);
                     if (!sortedAnnotations.equals(m.getLeadingAnnotations())) {
-                        return autoFormat(m.withLeadingAnnotations(sortedAnnotations), m.getName(), ctx, getCursor().getParentOrThrow());
+                        return m.withLeadingAnnotations(ListUtils.map(sortedAnnotations,
+                                (i, a) -> a.withPrefix(m.getLeadingAnnotations().get(i).getPrefix())));
                     }
                 }
                 return m;

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
@@ -86,8 +86,8 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
                 return super.visit(tree, ctx);
             }
 
-            @SuppressWarnings("UnusedAssignment")
             @Override
+            @SuppressWarnings("UnusedAssignment")
             public J visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 if (classDecl.getType() == null) {
                     return classDecl;

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -2494,6 +2494,35 @@ examples:
     language: java
 ---
 type: specs.openrewrite.org/v1beta/example
+recipeName: org.openrewrite.staticanalysis.ReorderAnnotations
+examples:
+- description: ''
+  sources:
+  - before: |
+      import org.junit.jupiter.api.Test;
+      import org.junitpioneer.jupiter.ExpectedToFail;
+      import org.junitpioneer.jupiter.Issue;
+      class A {
+          @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+          @Test
+          @ExpectedToFail
+          void explicitImplementationClassInApi() {
+          }
+      }
+    after: |
+      import org.junit.jupiter.api.Test;
+      import org.junitpioneer.jupiter.ExpectedToFail;
+      import org.junitpioneer.jupiter.Issue;
+      class A {
+          @ExpectedToFail
+          @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+          @Test
+          void explicitImplementationClassInApi() {
+          }
+      }
+    language: java
+---
+type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.staticanalysis.ReplaceApacheCommonsLang3ValidateNotNullWithObjectsRequireNonNull
 examples:
 - description: ''

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableParametersTest.java
@@ -331,12 +331,12 @@ class AnnotateNullableParametersTest implements RewriteTest {
     @Nested
     class KnownNullCheckers {
 
-        @ParameterizedTest
         @CsvSource({
           "java.util.Objects, Objects.nonNull",
           "org.apache.commons.lang3.StringUtils, StringUtils.isNotBlank",
           "org.apache.commons.lang3.StringUtils, StringUtils.isNotEmpty",
         })
+        @ParameterizedTest
         void knownMethodsPositiveInvocation(String pkg, String methodCall) {
             rewriteRun(
               //language=java
@@ -375,12 +375,12 @@ class AnnotateNullableParametersTest implements RewriteTest {
             );
         }
 
-        @ParameterizedTest
         @CsvSource({
           "java.util.Objects, Objects.isNull",
           "org.apache.commons.lang3.StringUtils, StringUtils.isBlank",
           "org.apache.commons.lang3.StringUtils, StringUtils.isEmpty",
         })
+        @ParameterizedTest
         void knownMethodsNegatedUnary(String pkg, String methodCall) {
             rewriteRun(
               //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/BufferedWriterCreationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/BufferedWriterCreationTest.java
@@ -30,8 +30,8 @@ class BufferedWriterCreationTest implements RewriteTest {
         spec.recipe(new BufferedWriterCreationRecipes());
     }
 
-    @Test
     @DocumentExample
+    @Test
     void bufferedReaderCreation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
@@ -143,9 +143,9 @@ class CombineSemanticallyEqualCatchBlocksTest implements RewriteTest {
         );
     }
 
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/506")
     @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/506")
+    @Test
     void combineSameSemanticallyEquivalentMethodTypes() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CompareEnumsWithEqualityOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CompareEnumsWithEqualityOperatorTest.java
@@ -200,8 +200,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
           ));
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/143")
+    @Test
     void noSelect() {
         rewriteRun(
           //language=java
@@ -219,8 +219,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("StatementWithEmptyBody")
     @Issue("https://github.com/moderneinc/customer-requests/issues/190")
+    @SuppressWarnings("StatementWithEmptyBody")
     @Test
     void changeEnumInsideBooleanExpression() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/ControlFlowIndentationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ControlFlowIndentationTest.java
@@ -68,8 +68,8 @@ class ControlFlowIndentationTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("SuspiciousIndentAfterControlStatement")
     @Issue("https://github.com/openrewrite/rewrite/issues/2277")
+    @SuppressWarnings("SuspiciousIndentAfterControlStatement")
     @Test
     void removesIndentationFromStatementAroundIf() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -364,8 +364,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
             );
         }
 
-        @Test
         @Disabled("Not yet supported")
+        @Test
         void lambdaGenerics() {
             rewriteRun(
               //language=java
@@ -447,8 +447,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/434")
+        @Test
         void missingWhitespace() {
             rewriteRun(
               // language=java

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -31,8 +31,8 @@ class EqualsToContentEqualsTest implements RewriteTest {
           .recipe(new EqualsToContentEquals());
     }
 
-    @Test
     @DocumentExample
+    @Test
     void replaceStringBuilder() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -270,9 +270,9 @@ class FallThroughTest implements RewriteTest {
         );
     }
 
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/229")
     @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/229")
+    @Test
     void switchAsLastStatement() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
@@ -58,8 +58,8 @@ class FinalClassTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2954")
+    @Test
     void nestedClassWithSubclass() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -156,8 +156,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/549")
+    @Test
     void catchBlocksIgnored() {
         rewriteRun(
           //language=java
@@ -391,8 +391,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2956")
+    @Test
     void recordShouldNotIntroduceExtraClosingParenthesis() {
         rewriteRun(
           version(
@@ -442,8 +442,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/181")
+    @Test
     void shouldNotFinalizeVariablesWhichAreAssignedInAnonymousClasses() {
         this.rewriteRun(
           // language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
@@ -210,8 +210,8 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/176")
+    @Test
     void doNotReplaceIfAssignedThroughUnaryOrAccumulator() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
@@ -819,8 +819,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2865")
+    @Test
     void additionalConstructorIgnored() {
         rewriteRun(
           //language=java
@@ -841,8 +841,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/121")
+    @Test
     void mustNotChangeVolatileFields() {
         //language=java
         rewriteRun(
@@ -861,8 +861,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/177")
+    @Test
     void staticFieldAssignedInConstructorNotMadeFinal() {
         //language=java
         rewriteRun(
@@ -879,8 +879,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/177")
+    @Test
     void staticFieldAssignedInBlockNotMadeFinal() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
@@ -98,8 +98,8 @@ class FixStringFormatExpressionsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/260")
+    @Test
     void escapedNewline() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/HiddenFieldTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/HiddenFieldTest.java
@@ -304,8 +304,8 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("ConstantValue")
+    @Test
     void tryResources() {
         rewriteRun(
           //language=java
@@ -340,8 +340,8 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings({"EmptyTryBlock", "CatchMayIgnoreException", "TryWithIdenticalCatches"})
+    @Test
     void catchClause() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorTest.java
@@ -72,8 +72,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryModifier")
     @Issue("https://github.com/openrewrite/rewrite/issues/1780")
+    @SuppressWarnings("UnnecessaryModifier")
     @Test
     void doNotAddConstructorToInterface() {
         rewriteRun(
@@ -255,8 +255,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/538")
+    @Test
     void ignoreClassesWithMainMethod() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
@@ -167,9 +167,9 @@ class InlineVariableTest implements RewriteTest {
         );
     }
 
-    @Test
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Issue("https://github.com/openrewrite/rewrite/issues/3201")
+    @SuppressWarnings("UnnecessaryLocalVariable")
+    @Test
     void preserveComment() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -766,8 +766,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/174")
+        @Test
         void ifTwoDifferentInstanceOf() {
             rewriteRun(
               version(
@@ -798,8 +798,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/174")
+        @Test
         void ifTwoDifferentInstanceOfWithParentheses() {
             rewriteRun(
               version(
@@ -932,8 +932,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/265")
+        @Test
         void multipleCastsInDifferentOperands() {
             rewriteRun(
               //language=java
@@ -1006,8 +1006,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
+        @Test
         void castTypeIsSuperType() {
             rewriteRun(
               //language=java
@@ -1027,8 +1027,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
+        @Test
         void castTypeIsSubType() {
             rewriteRun(
               //language=java
@@ -1251,8 +1251,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/482")
+        @Test
         void castTooSpecific() {
             rewriteRun(
               version(
@@ -1307,8 +1307,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/308")
+        @Test
         void passBareTypeToParameterizedMethod() {
             rewriteRun(
               version(
@@ -1476,8 +1476,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/483")
+        @Test
         void classVariableShadowing() {
             rewriteRun(
               version(
@@ -1513,8 +1513,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/484")
+        @Test
         void enumPatternMatch() {
             rewriteRun(
               version(
@@ -1639,8 +1639,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Test
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/307")
+        @Test
         void throwsExceptionWithExtraParentheses() {
             rewriteRun(
               //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/JavaElementFactoryTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/JavaElementFactoryTest.java
@@ -41,8 +41,8 @@ class JavaElementFactoryTest implements RewriteTest {
         spec.parser(JavaParser.fromJavaVersion().typeCache(typeCache));
     }
 
-    @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
     void instanceMethodReference() {
         RecipeSpec spec = RecipeSpec.defaults();
         defaults(spec);
@@ -80,8 +80,8 @@ class JavaElementFactoryTest implements RewriteTest {
         assertThat(SemanticallyEqual.areEqual(reference, methodReference)).isTrue();
     }
 
-    @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
     void staticMethodReference() {
         RecipeSpec spec = RecipeSpec.defaults();
         defaults(spec);
@@ -119,8 +119,8 @@ class JavaElementFactoryTest implements RewriteTest {
         assertThat(SemanticallyEqual.areEqual(reference, methodReference)).isTrue();
     }
 
-    @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
     void qualifiedStaticMethodReference() {
         RecipeSpec spec = RecipeSpec.defaults();
         defaults(spec);

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -57,8 +57,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1")
+    @Test
     void simplifyLambdaBlockToExpressionWithComments() {
         rewriteRun(
           //language=java
@@ -145,8 +145,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/582")
+    @Test
     void simplifyAssertThrows() {
         rewriteRun(
           spec-> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),

--- a/src/test/java/org/openrewrite/staticanalysis/MethodNameCasingTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MethodNameCasingTest.java
@@ -390,8 +390,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnusedAssignment")
     @Issue("https://github.com/openrewrite/rewrite/issues/2103")
+    @SuppressWarnings("UnusedAssignment")
     @Test
     void snakeCaseToCamelCase() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -395,8 +395,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("StatementWithEmptyBody")
     @Issue("https://github.com/openrewrite/rewrite/issues/800")
+    @SuppressWarnings("StatementWithEmptyBody")
     @Test
     void noCases() {
         rewriteRun(
@@ -610,8 +610,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3076")
+    @Test
     void switchExpressions() {
         rewriteRun(
           //language=java
@@ -752,8 +752,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3076")
+    @Test
     void multipleSwitchExpressions() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
@@ -73,8 +73,8 @@ class ModifierOrderTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/187")
+    @Test
     void putDefaultModifierAtJLSRightPosition() {
         // default modifier must be placed between abstract and static modifiers
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/NoToStringOnStringTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoToStringOnStringTypeTest.java
@@ -30,8 +30,8 @@ class NoToStringOnStringTypeTest implements RewriteTest {
     }
 
     @DocumentExample
-    @Test
     @SuppressWarnings("StringOperationCanBeSimplified")
+    @Test
     void toStringOnString() {
         rewriteRun(
           //language=java
@@ -70,8 +70,8 @@ class NoToStringOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("StringOperationCanBeSimplified")
+    @Test
     void toStringOnStringVariable() {
         rewriteRun(
           //language=java
@@ -94,8 +94,8 @@ class NoToStringOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("StringOperationCanBeSimplified")
+    @Test
     void toStringOnMethodInvocation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoValueOfOnStringTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoValueOfOnStringTypeTest.java
@@ -31,12 +31,12 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
     }
 
     @DocumentExample
-    @Test
     @SuppressWarnings({
     "UnnecessaryCallToStringValueOf",
     "UnusedAssignment",
     "StringConcatenationMissingWhitespace",
     })
+    @Test
     void valueOfOnLiterals() {
         rewriteRun(
           //language=java
@@ -103,8 +103,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("UnnecessaryCallToStringValueOf")
+    @Test
     void valueOfOnNonStringPrimitiveWithinBinaryConcatenation() {
         rewriteRun(
           //language=java
@@ -143,8 +143,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/456")
+    @Test
     void valueOfOnNonStringPrimitiveWithBinaryArgument() {
         rewriteRun(
           //language=java
@@ -160,8 +160,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1200")
+    @Test
     void valueOfIsMethodInvocationPartOfBinary() {
         rewriteRun(
           //language=java
@@ -181,8 +181,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings({"UnnecessaryCallToStringValueOf", "StringConcatenationMissingWhitespace"})
+    @Test
     void valueOfOnStandaloneNonStringPrimitive() {
         rewriteRun(
           //language=java
@@ -221,9 +221,9 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1200")
     @SuppressWarnings({"IndexOfReplaceableByContains", "StatementWithEmptyBody"})
+    @Test
     void valueOfOnIntWithinBinaryComparison() {
         rewriteRun(
           //language=java
@@ -241,8 +241,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("UnnecessaryCallToStringValueOf")
+    @Test
     void valueOfOnMethodInvocation() {
         rewriteRun(
           //language=java
@@ -273,8 +273,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/441")
+    @Test
     void concatenationExpressionNeedsParentheses() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
@@ -167,8 +167,8 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/98")
+    @Test
     void removeTrailingEmptyLines() {
         rewriteRun(
           //language=java
@@ -635,8 +635,8 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
     }
 
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3078")
+    @Test
     void visitingQuarkMustNotFail() {
         rewriteRun(
           other(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
@@ -59,8 +59,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         );
     }
 
-    @Test
     @DocumentExample
+    @Test
     void repeatedSemicolon() {
         rewriteRun(
           //language=java
@@ -248,8 +248,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/5146")
+    @Test
     void noValuesJustSemicolon() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
@@ -30,9 +30,9 @@ class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
         spec.recipe(new RemoveHashCodeCallsFromArrayInstances());
     }
 
-    @Test
     @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/44")
+    @Test
     void replaceHashCodeCalls() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatchTest.java
@@ -519,8 +519,8 @@ class RemoveInstanceOfPatternMatchTest implements RewriteTest {
             14));
     }
 
-    @Test
     @Disabled("Not supported")
+    @Test
     void negationLocalVariable() {
         rewriteRun(
           version(
@@ -558,8 +558,8 @@ class RemoveInstanceOfPatternMatchTest implements RewriteTest {
             14));
     }
 
-    @Test
     @Disabled("Not supported")
+    @Test
     void negationWithoutElse() {
         rewriteRun(
           version(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTagTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTagTest.java
@@ -29,9 +29,9 @@ class RemoveJavaDocAuthorTagTest implements RewriteTest {
         spec.recipe(new RemoveJavaDocAuthorTag());
     }
 
+    @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite/issues/1640")
     @Test
-    @DocumentExample
     void preserveDocsBeforeTag() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
@@ -30,9 +30,9 @@ class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
         spec.recipe(new RemoveToStringCallsFromArrayInstances());
     }
 
-    @Test
     @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/44")
+    @Test
     void fixNonCompliantToString() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededBlockTest.java
@@ -415,8 +415,8 @@ class RemoveUnneededBlockTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3073")
+    @Test
     void preserveComments() {
         rewriteRun(
           //language=java
@@ -528,8 +528,8 @@ class RemoveUnneededBlockTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("EmptyFinallyBlock")
+    @Test
     void removeEmptyTryFinallyBlock() {
         rewriteRun(
           //language=java
@@ -575,8 +575,8 @@ class RemoveUnneededBlockTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("EmptyFinallyBlock")
+    @Test
     void keepNonEmptyTryFinallyBlock2() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -76,8 +76,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/841")
+    @Test
     void ignoreSuppressWarnings() {
         rewriteRun(
           //language=java
@@ -95,9 +95,9 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1332")
     @SuppressWarnings("MethodMayBeStatic")
+    @Test
     void ignoreVariablesNamed() {
         rewriteRun(
           spec -> spec.recipe(new RemoveUnusedLocalVariables(new String[]{"unused"}, null, null)),
@@ -122,9 +122,9 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1278")
     @SuppressWarnings("MethodMayBeStatic")
+    @Test
     void keepRightHandSideStatement() {
         rewriteRun(
           //language=java
@@ -364,8 +364,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/apache/dubbo/blob/747282cdf851c144af562d3f92e10349cc315e36/dubbo-metadata/dubbo-metadata-definition-protobuf/src/test/java/org/apache/dubbo/metadata/definition/protobuf/model/GooglePB.java#L938-L944")
+    @Test
     void keepLocalVariablesAssignmentOperationToOtherVariables() {
         rewriteRun(
           //language=java
@@ -387,8 +387,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
+    @Test
     void keepLocalVariableAssignmentOperation() {
         rewriteRun(
           //language=java
@@ -405,8 +405,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
+    @Test
     void removeUnusedLocalVariableBitwiseAssignmentOperation() {
         rewriteRun(
           //language=java
@@ -433,8 +433,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
+    @Test
     void keepLocalVariableBitwiseAssignmentOperationWithinExpression() {
         rewriteRun(
           //language=java
@@ -456,8 +456,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
+    @Test
     void handleInstanceOf() {
         rewriteRun(
           //language=java
@@ -586,8 +586,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/apache/dubbo/blob/747282cdf851c144af562d3f92e10349cc315e36/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java#L108-L118")
+    @Test
     void forLoopWithExternalIncrementLogic() {
         rewriteRun(
           //language=java
@@ -795,8 +795,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/txazo/spring-cloud-sourcecode/blob/5ffe615558e76f3bb37f19026ece5cbaff4d0404/eureka-client/src/main/java/com/netflix/discovery/converters/jackson/builder/StringInterningAmazonInfoBuilder.java#L114-L124")
+    @Test
     void recognizeUsedVariableWithinWhileLoop() {
         rewriteRun(
           //language=java
@@ -855,8 +855,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("This still causes SonarQube to warn, but there isn't much that can be done in these cases. Maybe change to a while loop?")
+    @Test
     void ignoreForLoopIncrementVariableNeverRead() {
         rewriteRun(
           //language=java
@@ -877,8 +877,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("This still causes SonarQube to warn, but there isn't much that can be done in these cases. Maybe change to a forEach?")
+    @Test
     void ignoreEnhancedForLoops() {
         rewriteRun(
           //language=java
@@ -1037,8 +1037,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/152")
+    @Test
     void retainUnusedInsideCase() {
         rewriteRun(
           //language=java
@@ -1072,8 +1072,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-feature-flags/pull/35")
+    @Test
     void removeDespiteSideEffects() {
         rewriteRun(
           spec -> spec.recipe(new RemoveUnusedLocalVariables(null, null, true)),
@@ -1234,8 +1234,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
             );
         }
 
-        @Test
         @ExpectedToFail("Not yet implemented")
+        @Test
         void retainUnusedLocalVariableConst() {
             rewriteRun(
               //language=kotlin

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateFieldsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateFieldsTest.java
@@ -224,8 +224,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3061")
+    @Test
     void findReferencesInOuterScope() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -204,8 +204,8 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4076")
+    @Test
     void doNotRemoveMethodsWithUnusedSuppressWarningsOnClass() {
         rewriteRun(
           //language=java
@@ -229,8 +229,8 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/4076")
+    @Test
     void doNotRemoveMethodsWithUnusedSuppressWarningsOnClassNestedClass() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
@@ -114,9 +114,9 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("JavadocDeclaration")
     @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/2437")
+    @SuppressWarnings("JavadocDeclaration")
     @Test
     void renameJavaDocParam() {
         rewriteRun(
@@ -375,8 +375,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/171")
+    @Test
     void renameMultipleOcurrencesDifferentScope() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCaseTest.java
@@ -587,8 +587,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
+    @Test
     void doNotChangeLombokAnnotatedClasses() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),
@@ -604,8 +604,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
+    @Test
     void doNotChangeLombokAnnotatedFields() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -59,6 +59,32 @@ class ReorderAnnotationsTest implements RewriteTest {
     }
 
     @Test
+    void reordersClassAnnotations() {
+        rewriteRun(
+          spec -> spec.recipe(new ReorderAnnotations()),
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Disabled;
+
+              @SuppressWarnings("all")
+              @Disabled
+              class A {
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Disabled;
+
+              @Disabled
+              @SuppressWarnings("all")
+              class A {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void withComments() {
         // Not entirely sure if we'd want to keep comments in the same place, but this at least documents what we do now
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -1,0 +1,74 @@
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class ReorderAnnotationsTest implements RewriteTest {
+    @Nested
+    class ParameterlessConstructor {
+        @Test
+        @DocumentExample
+        void doesNotReorderAnnotationsIfNotNeeded() {
+            rewriteRun(
+              spec -> spec.recipe(new ReorderAnnotations()),
+              //language=java
+              java(
+                """
+                    import org.junit.jupiter.api.Test;
+                    import org.junitpioneer.jupiter.ExpectedToFail;
+                    import org.junitpioneer.jupiter.Issue;
+
+                    class A {
+                        @ExpectedToFail
+                        @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                        @Test
+                        void explicitImplementationClassInApi() {
+                        }
+                    }
+                  """
+              )
+            );
+        }
+
+        @Test
+        @DocumentExample
+        void reordersMethodAnnotations() {
+            rewriteRun(
+              spec -> spec.recipe(new ReorderAnnotations()),
+              //language=java
+              java(
+                """
+                    import org.junit.jupiter.api.Test;
+                    import org.junitpioneer.jupiter.ExpectedToFail;
+                    import org.junitpioneer.jupiter.Issue;
+
+                    class A {
+                        @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                        @Test
+                        @ExpectedToFail
+                        void explicitImplementationClassInApi() {
+                        }
+                    }
+                  """,
+                """
+                    import org.junit.jupiter.api.Test;
+                    import org.junitpioneer.jupiter.ExpectedToFail;
+                    import org.junitpioneer.jupiter.Issue;
+
+                    class A {
+                        @ExpectedToFail
+                        @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                        @Test
+                        void explicitImplementationClassInApi() {
+                        }
+                    }
+                  """
+              )
+            );
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -85,6 +85,30 @@ class ReorderAnnotationsTest implements RewriteTest {
     }
 
     @Test
+    void reordersFieldAnnotations() {
+        rewriteRun(
+          spec -> spec.recipe(new ReorderAnnotations()),
+          //language=java
+          java(
+            """
+              class A {
+                  @SuppressWarnings("all")
+                  @Deprecated
+                  String field;
+              }
+              """,
+            """
+              class A {
+                  @Deprecated
+                  @SuppressWarnings("all")
+                  String field;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void withComments() {
         // Not entirely sure if we'd want to keep comments in the same place, but this at least documents what we do now
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Nested;
@@ -7,7 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class ReorderAnnotationsTest implements RewriteTest {
+class ReorderAnnotationsTest implements RewriteTest {
     @Nested
     class ParameterlessConstructor {
         @Test

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -33,17 +33,16 @@ class ReorderAnnotationsTest implements RewriteTest {
               //language=java
               java(
                 """
-                    import org.junit.jupiter.api.Test;
-                    import org.junitpioneer.jupiter.ExpectedToFail;
-                    import org.junitpioneer.jupiter.Issue;
-
-                    class A {
-                        @ExpectedToFail
-                        @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                        @Test
-                        void explicitImplementationClassInApi() {
-                        }
-                    }
+                  import org.junit.jupiter.api.Test;
+                  import org.junitpioneer.jupiter.ExpectedToFail;
+                  import org.junitpioneer.jupiter.Issue;
+                  class A {
+                      @ExpectedToFail
+                      @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                      @Test
+                      void explicitImplementationClassInApi() {
+                      }
+                  }
                   """
               )
             );
@@ -57,30 +56,28 @@ class ReorderAnnotationsTest implements RewriteTest {
               //language=java
               java(
                 """
-                    import org.junit.jupiter.api.Test;
-                    import org.junitpioneer.jupiter.ExpectedToFail;
-                    import org.junitpioneer.jupiter.Issue;
-
-                    class A {
-                        @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                        @Test
-                        @ExpectedToFail
-                        void explicitImplementationClassInApi() {
-                        }
-                    }
+                  import org.junit.jupiter.api.Test;
+                  import org.junitpioneer.jupiter.ExpectedToFail;
+                  import org.junitpioneer.jupiter.Issue;
+                  class A {
+                      @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                      @Test
+                      @ExpectedToFail
+                      void explicitImplementationClassInApi() {
+                      }
+                  }
                   """,
                 """
-                    import org.junit.jupiter.api.Test;
-                    import org.junitpioneer.jupiter.ExpectedToFail;
-                    import org.junitpioneer.jupiter.Issue;
-
-                    class A {
-                        @ExpectedToFail
-                        @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                        @Test
-                        void explicitImplementationClassInApi() {
-                        }
-                    }
+                  import org.junit.jupiter.api.Test;
+                  import org.junitpioneer.jupiter.ExpectedToFail;
+                  import org.junitpioneer.jupiter.Issue;
+                  class A {
+                      @ExpectedToFail
+                      @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                      @Test
+                      void explicitImplementationClassInApi() {
+                      }
+                  }
                   """
               )
             );

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -60,6 +60,7 @@ class ReorderAnnotationsTest implements RewriteTest {
 
     @Test
     void withComments() {
+        // Not entirely sure if we'd want to keep comments in the same place, but this at least documents what we do now
         rewriteRun(
           spec -> spec.recipe(new ReorderAnnotations()),
           //language=java
@@ -69,13 +70,13 @@ class ReorderAnnotationsTest implements RewriteTest {
               import org.junitpioneer.jupiter.ExpectedToFail;
               import org.junitpioneer.jupiter.Issue;
               class A {
-                  // Issue
+                  // Before first
                   @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                  // Test
+                  // Before second
                   @Test
-                  // ExpectedToFail
+                  // Before third
                   @ExpectedToFail
-                  // Method
+                  // Before method
                   void explicitImplementationClassInApi() {
                   }
               }
@@ -85,13 +86,13 @@ class ReorderAnnotationsTest implements RewriteTest {
               import org.junitpioneer.jupiter.ExpectedToFail;
               import org.junitpioneer.jupiter.Issue;
               class A {
-                  // ExpectedToFail
+                  // Before first
                   @ExpectedToFail
-                  // Issue
+                  // Before second
                   @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                  // Test
+                  // Before third
                   @Test
-                  // Method
+                  // Before method
                   void explicitImplementationClassInApi() {
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -23,50 +23,91 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 class ReorderAnnotationsTest implements RewriteTest {
-    @Nested
-    class ParameterlessConstructor {
-        @Test
-        @DocumentExample
-        void doesNotReorderAnnotationsIfNotNeeded() {
-            rewriteRun(
-              spec -> spec.recipe(new ReorderAnnotations()),
-              //language=java
-              java(
-                """
-                  import org.junit.jupiter.api.Test;
-                  import org.junitpioneer.jupiter.ExpectedToFail;
-                  import org.junitpioneer.jupiter.Issue;
-                  class A {
-                      @ExpectedToFail
-                      @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                      @Test
-                      void explicitImplementationClassInApi() {
-                      }
+    @DocumentExample
+    @Test
+    void reordersMethodAnnotations() {
+        rewriteRun(
+          spec -> spec.recipe(new ReorderAnnotations()),
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junitpioneer.jupiter.ExpectedToFail;
+              import org.junitpioneer.jupiter.Issue;
+              class A {
+                  @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                  @Test
+                  @ExpectedToFail
+                  void explicitImplementationClassInApi() {
                   }
-                  """
-              )
-            );
-        }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junitpioneer.jupiter.ExpectedToFail;
+              import org.junitpioneer.jupiter.Issue;
+              class A {
+                  @ExpectedToFail
+                  @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                  @Test
+                  void explicitImplementationClassInApi() {
+                  }
+              }
+              """
+          )
+        );
+    }
 
+    @Test
+    void withComments() {
+        rewriteRun(
+          spec -> spec.recipe(new ReorderAnnotations()),
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junitpioneer.jupiter.ExpectedToFail;
+              import org.junitpioneer.jupiter.Issue;
+              class A {
+                  // Issue
+                  @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                  // Test
+                  @Test
+                  // ExpectedToFail
+                  @ExpectedToFail
+                  // Method
+                  void explicitImplementationClassInApi() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junitpioneer.jupiter.ExpectedToFail;
+              import org.junitpioneer.jupiter.Issue;
+              class A {
+                  // ExpectedToFail
+                  @ExpectedToFail
+                  // Issue
+                  @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                  // Test
+                  @Test
+                  // Method
+                  void explicitImplementationClassInApi() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Nested
+    class NoChange {
         @Test
-        @DocumentExample
-        void reordersMethodAnnotations() {
+        void alreadySorted() {
             rewriteRun(
               spec -> spec.recipe(new ReorderAnnotations()),
               //language=java
               java(
-                """
-                  import org.junit.jupiter.api.Test;
-                  import org.junitpioneer.jupiter.ExpectedToFail;
-                  import org.junitpioneer.jupiter.Issue;
-                  class A {
-                      @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                      @Test
-                      @ExpectedToFail
-                      void explicitImplementationClassInApi() {
-                      }
-                  }
-                  """,
                 """
                   import org.junit.jupiter.api.Test;
                   import org.junitpioneer.jupiter.ExpectedToFail;

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -18,16 +18,21 @@ package org.openrewrite.staticanalysis;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
 class ReorderAnnotationsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReorderAnnotations());
+    }
+
     @DocumentExample
     @Test
     void reordersMethodAnnotations() {
         rewriteRun(
-          spec -> spec.recipe(new ReorderAnnotations()),
           //language=java
           java(
             """
@@ -61,7 +66,6 @@ class ReorderAnnotationsTest implements RewriteTest {
     @Test
     void reordersClassAnnotations() {
         rewriteRun(
-          spec -> spec.recipe(new ReorderAnnotations()),
           //language=java
           java(
             """
@@ -87,7 +91,6 @@ class ReorderAnnotationsTest implements RewriteTest {
     @Test
     void reordersFieldAnnotations() {
         rewriteRun(
-          spec -> spec.recipe(new ReorderAnnotations()),
           //language=java
           java(
             """
@@ -112,7 +115,6 @@ class ReorderAnnotationsTest implements RewriteTest {
     void withComments() {
         // Not entirely sure if we'd want to keep comments in the same place, but this at least documents what we do now
         rewriteRun(
-          spec -> spec.recipe(new ReorderAnnotations()),
           //language=java
           java(
             """
@@ -156,7 +158,6 @@ class ReorderAnnotationsTest implements RewriteTest {
         @Test
         void alreadySorted() {
             rewriteRun(
-              spec -> spec.recipe(new ReorderAnnotations()),
               //language=java
               java(
                 """
@@ -166,6 +167,23 @@ class ReorderAnnotationsTest implements RewriteTest {
                   class A {
                       @ExpectedToFail
                       @Issue("https://github.com/openrewrite/rewrite/issues/2973")
+                      @Test
+                      void explicitImplementationClassInApi() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void lessThanTwo() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.junit.jupiter.api.Test;
+                  class A {
                       @Test
                       void explicitImplementationClassInApi() {
                       }

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
@@ -31,8 +31,8 @@ class ReplaceClassIsInstanceWithInstanceofTest implements RewriteTest {
         spec.recipe(new ReplaceClassIsInstanceWithInstanceof());
     }
 
-    @Test
     @DocumentExample
+    @Test
     void changeInstanceOf() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
@@ -29,8 +29,8 @@ class ReplaceCollectionToArrayArgWithEmptyArrayTest implements RewriteTest {
         spec.recipe(new ReplaceCollectionToArrayArgWithEmptyArray());
     }
 
-    @Test
     @DocumentExample
+    @Test
     void replaceSizeArgumentWithZero() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -194,8 +194,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/201")
+    @Test
     void typeCastOnConstructorCall() {
         rewriteRun(
           //language=java
@@ -1099,8 +1099,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("StringOperationCanBeSimplified")
     @Issue("https://github.com/openrewrite/rewrite/issues/2949")
+    @SuppressWarnings("StringOperationCanBeSimplified")
     @Test
     void anotherSimplerMultipleConstructorsCase() {
         rewriteRun(
@@ -1195,9 +1195,9 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
     }
 
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3071")
     @SuppressWarnings("OptionalOfNullableMisuse")
     @Test
-    @Issue("https://github.com/openrewrite/rewrite/issues/3071")
     void missingImportForDeclaringType() {
         rewriteRun(
           //language=java
@@ -1235,9 +1235,9 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/200")
     @SuppressWarnings({"ConstantValue"})
     @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/200")
     void nestedType() {
         rewriteRun(
           //language=java
@@ -1275,8 +1275,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/132")
+    @Test
     void dontReplaceLambdaSupplierOfMethodReference() {
         rewriteRun(
           //language=java
@@ -1328,8 +1328,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/237")
+    @Test
     void groupingByGetClass() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceStringBuilderWithStringTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceStringBuilderWithStringTest.java
@@ -54,8 +54,8 @@ class ReplaceStringBuilderWithStringTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/88")
+    @Test
     void replaceWhileMaintainingSpaces() {
         rewriteRun(
           //language=java
@@ -230,8 +230,8 @@ class ReplaceStringBuilderWithStringTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/88")
+    @Test
     void retainComments() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceWeekYearWithYearTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceWeekYearWithYearTest.java
@@ -31,9 +31,9 @@ class ReplaceWeekYearWithYearTest implements RewriteTest {
           .recipe(new ReplaceWeekYearWithYear());
     }
 
-    @Test
     @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/58")
+    @Test
     void changeSimpleDateFormat() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -75,8 +75,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/286")
+    @Test
     void doNotChangeParenthesisOnly() {
         rewriteRun(
           //language=java
@@ -145,8 +145,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("DuplicateCondition")
+    @Test
     void simplifyConstantIfTrueOrTrue() {
         rewriteRun(
           //language=java
@@ -1355,8 +1355,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/89")
+    @Test
     void preserveComments() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyDurationCreationUnitsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyDurationCreationUnitsTest.java
@@ -313,8 +313,8 @@ class SimplifyDurationCreationUnitsTest implements RewriteTest {
      * <p>
      * This test just documents the current behavior.
      */
-    @Test
     @SuppressWarnings("IntegerMultiplicationImplicitCastToLong")
+    @Test
     void doesNotChangeNonConstantUnitCount() {
         rewriteRun(
           //language=java
@@ -331,8 +331,8 @@ class SimplifyDurationCreationUnitsTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/moderneinc/support-public/issues/30")
+    @Test
     void doesNotChangeZeroConstant() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/TernaryOperatorsShouldNotBeNestedTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/TernaryOperatorsShouldNotBeNestedTest.java
@@ -36,8 +36,8 @@ class TernaryOperatorsShouldNotBeNestedTest {
             spec.recipe(new TernaryOperatorsShouldNotBeNested()).allSources(s -> s.markers(javaVersion(11)));
         }
 
-        @Test
         @DocumentExample
+        @Test
         void doReplaceNestedOrTernaryWithIfFollowedByTernary() {
             rewriteRun(
               //language=java
@@ -302,8 +302,8 @@ class TernaryOperatorsShouldNotBeNestedTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/112")
         @ExpectedToFail("only directly returned ternaries are taken into account")
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/112")
         @Test
         void doReplaceNestedOrAssignmentTernaryWithIfElse() {
             rewriteRun(
@@ -600,8 +600,8 @@ class TernaryOperatorsShouldNotBeNestedTest {
 
         @Nested
         class ReplaceWithSwitchExpression {
-            @Test
             @DocumentExample
+            @Test
             void doReplaceNestedOrTernaryWithSwitchExpression() {
                 rewriteRun(
                   //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -71,8 +71,8 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
-    @Test
     @ExpectedToFail("Not implemented yet")
+    @Test
     void withinLambda() {
         rewriteRun(
           //language=java
@@ -167,8 +167,8 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
     }
 
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Issue("https://github.com/openrewrite/rewrite/issues/2818")
+    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
     void assignedToVar() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryParenthesesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryParenthesesTest.java
@@ -129,8 +129,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/798")
     @Disabled
+    @Issue("https://github.com/openrewrite/rewrite/issues/798")
     @Test
     void unwrapExpr() {
         //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -28,8 +28,8 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
         spec.recipe(new UnnecessaryReturnAsLastStatement());
     }
 
-    @Test
     @DocumentExample
+    @Test
     void simpleReturn() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
@@ -85,8 +85,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("EmptyTryBlock")
     @Issue("https://github.com/openrewrite/rewrite/issues/631")
+    @SuppressWarnings("EmptyTryBlock")
     @Test
     void necessaryThrowsFromCloseable() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -132,8 +132,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/223")
+    @Test
     void annotatedReturnType() {
         rewriteRun(
           spec -> spec
@@ -260,8 +260,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/223")
+    @Test
     void annotatedFieldType() {
         rewriteRun(
           spec -> spec
@@ -731,8 +731,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/179")
+    @Test
     void enumSetHasDifferentGenericTypeThanSet() {
         rewriteRun(
           //language=java
@@ -935,9 +935,9 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
+    @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite/issues/2973")
     @Test
-    @ExpectedToFail
     void explicitImplementationClassInApi() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -59,8 +59,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("removal")
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/10")
+    @SuppressWarnings("removal")
     @Test
     void castingAmbiguity() {
         rewriteRun(
@@ -105,8 +105,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/194")
+    @SuppressWarnings("ConstantConditions")
     @Test
     void gson() {
         rewriteRun(
@@ -355,8 +355,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Issue("https://github.com/openrewrite/rewrite/issues/1915")
+    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
     void dontUseLambdaWhenShadowsClassField() {
         rewriteRun(
@@ -381,8 +381,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Issue("https://github.com/openrewrite/rewrite/issues/1915")
+    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
     void dontUseLambdaWhenShadowsMethodDeclarationParam() {
         rewriteRun(
@@ -465,8 +465,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @SuppressWarnings("DataFlowIssue")
+    @Test
     void noReplaceOnReferenceToUninitializedFinalField() {
         rewriteRun(
           //language=java
@@ -664,8 +664,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/moderneinc/support-app/issues/17")
+    @Test
     void lambdaWithComplexTypeInference() {
         rewriteRun(
           //language=java
@@ -736,8 +736,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/309")
+    @Test
     void dontUseLambdaForMethodWithTypeParameter() {
         //language=java
         rewriteRun(
@@ -775,8 +775,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
+    @Test
     void dontUseLambdaWhenEnumAccessesStaticFieldFromConstructor() {
         rewriteRun(
           //language=java
@@ -803,8 +803,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
+    @Test
     void dontUseLambdaWhenEnumAccessesStaticFieldFromFromMethod() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseStandardCharsetTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseStandardCharsetTest.java
@@ -110,8 +110,8 @@ class UseStandardCharsetTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/moderneinc/support-public/issues/29")
+    @Test
     void nonConstantCharset() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
@@ -31,9 +31,9 @@ class UseStringReplaceTest implements RewriteTest {
         spec.recipe(new UseStringReplace());
     }
 
-    @Test
     @DisplayName("String#replaceAll replaced by String#replace, because first argument is not a regular expression")
     @DocumentExample
+    @Test
     void replaceAllReplacedByReplace() {
         rewriteRun(
           //language=java
@@ -58,8 +58,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("ReplaceOnLiteralHasNoEffect")
     @Issue("https://github.com/openrewrite/rewrite/issues/2222")
+    @SuppressWarnings("ReplaceOnLiteralHasNoEffect")
     @Test
     void literalValueSourceAccountsForEscapeCharacters() {
         rewriteRun(
@@ -103,8 +103,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @DisplayName("String#replaceAll replaced by String#replace, because first argument is not a regular expression and it contains special characters")
+    @Test
     void replaceAllReplacedByReplaceWithSpecialCharacters() {
         rewriteRun(
           //language=java
@@ -129,8 +129,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @DisplayName("String#replaceAll is not replaced by String#replace, because first argument is a real regular expression")
+    @Test
     void replaceAllUnchanged() {
         rewriteRun(
           //language=java
@@ -147,9 +147,9 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
     @DisplayName("String#replaceAll is not replaced by String#replace, because second argument has a backslash in it")
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
+    @Test
     void replaceAllUnchangedIfBackslashInReplacementString() {
         rewriteRun(
           //language=java
@@ -165,9 +165,9 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
     @DisplayName("String#replaceAll is not replaced by String#replace, because second argument has a dollar sign in it")
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
+    @Test
     void replaceAllUnchangedIfDollarInReplacementString() {
         rewriteRun(
           //language=java
@@ -188,8 +188,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/330")
+    @Test
     void equalsSignOnlyWhenSafeToReplace() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/groovy/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/groovy/MinimumSwitchCasesTest.java
@@ -62,8 +62,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("GrMethodMayBeStatic")
     @Issue("https://github.com/openrewrite/rewrite/issues/2566")
+    @SuppressWarnings("GrMethodMayBeStatic")
     @Test
     void nonIdentifierEnum() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
@@ -31,8 +31,8 @@ class MoveFieldAnnotationToTypeTest implements RewriteTest {
         spec.recipe(new MoveFieldAnnotationToType("org.openrewrite..*"));
     }
 
-    @Test
     @DocumentExample
+    @Test
     void fieldAnnotation() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
- Fixes #543 

Reordering annotations (alphabetically only for now on method declarations alone).

Looking to define boundaries for what should be included in the changes for annotation reordering. As per the linked issue, the starting point would be a default alphabetical ordering of annotations (the ability to pass in what `Comparator<J.Annotation>` to use will be upcoming). It's been suggested to start with just method declarations and move on from there after, but I'm open to thoughts and suggestions.

## What's changed?
- Added a `ReorderAnnotations` recipe for reordering annotations (default alphabetic) on `J.MethodDeclaration`
- Added simple tests for the reordering for method declarations (only using the default sorting)

## Related issue with additional fixes that should be implemented first
- https://github.com/openrewrite/rewrite/issues/5392

## Anyone you would like to review specifically?
@timtebeek 
@greg-at-moderne 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases for method declarations
- [x] I've implemented handling of class declarations
- [x] I've implemented handling of field declarations
- [ ] I've added unit tests to cover both positive and negative cases for class declarations
- [ ] I've added unit tests to cover both positive and negative cases for field declarations
- [ ] I've implemented the ability to provide what `Comparator<J.Annotation>` you would like to use to sort the annotations on a given LST entry point
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
