### PR TITLE
SimplifyConstantIfBranchExecution leaves unreachable code

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnneededBlock.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnneededBlock.java
@@ -80,8 +80,10 @@ public class RemoveUnneededBlock extends Recipe {
                     return stmt;
                 }
 
-                // blocks are relevant for scoping, so don't flatten them if they contain variable declarations
-                if (i < statements.size() - 1 && nested.getStatements().stream().anyMatch(J.VariableDeclarations.class::isInstance)) {
+                // blocks are relevant for scoping, so don't flatten them if they contain variable declarations unless they also have returns
+                if (i < statements.size() - 1 &&
+                    nested.getStatements().stream().anyMatch(J.VariableDeclarations.class::isInstance) &&
+                    nested.getStatements().stream().noneMatch(J.Return.class::isInstance)) {
                     return stmt;
                 }
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededBlockTest.java
@@ -469,6 +469,37 @@ class RemoveUnneededBlockTest implements RewriteTest {
     }
 
     @Test
+    void inlineNonLastBlockContainingVariableDeclarationsIfAlsoContainsReturn() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void SomeFunction() {
+                      {
+                          int i = 0;
+                          return;
+                      }
+                      {
+                          System.out.println("hello world!");
+                      }
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void SomeFunction() {
+                      int i = 0;
+                      return;
+                      System.out.println("hello world!");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void inlineLastBlockContainingVariableDeclarations() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -196,6 +196,34 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
     }
 
     @Test
+    void simplifyConstantIfTrueWithReturnImpliedFalseBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public boolean test() {
+                      if (true) {
+                          Object x;
+                          return true;
+                      }
+                      return false;
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public boolean test() {
+                      Object x;
+                      return true;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void simplifyConstantIfTrueElse() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -207,6 +207,40 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
                           Object x;
                           return true;
                       }
+                      Object x;
+                      return false;
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public boolean test() {
+                      Object x;
+                      return true;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyConstantIfTrueNestedWithReturnImpliedFalseBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public boolean test() {
+                      if (true) {
+                          Object x;
+                          if (true) {
+                              return true;
+                          }
+                          {
+                              Object y;
+                          }
+                      }
                       return false;
                   }
               }


### PR DESCRIPTION
- fixes #399 

Certain cases where there is an object assignment in an unneeded `if` block in the initial code can cause `SimplifyConstantIfBranchExecution` to leave scoping braces and unreachable lines in the code. The underlying cause is due to `RemoveUnneededBlock` deciding to not remove scoping braces if a block contains variable declarations, however, if the block also contains a return, then `SimplifyConstantIfBranchExecution` which also uses `RemoveUnreachableCodeVisitor` should be able to be unwrapped because there should be no conflicts after unreachable code is removed.

## What's changed?
- Test example from submitted issue has been added.
- Deeper nested if examples included for `SimplifyConstantIfBranchExecution` tests and test example provided for `RemoveUnneededBlock` specifically covering change in logic to allow unwrapping if return statement is nested.

### Checklist
- [X] I've added further unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
