### PR TITLE
Handle static method calls when removing unnecessary explicit type arguments.

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -48,7 +48,7 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
 
                 if (m.getMethodType() != null) {
                     Object enclosing = getCursor().getParentTreeCursor().getValue();
-                    JavaType inferedType = null;
+                    JavaType inferredType = null;
                     if (enclosing instanceof J.MethodInvocation) {
                         if (m.getMethodType().getFlags().contains(Flag.Static)) {
                             List<String> formalTypeNames = new ArrayList<>(m.getMethodType().getDeclaredFormalTypeNames());
@@ -77,9 +77,9 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                                 .count() > 1) {
                             return m;
                         }
-                        inferedType = m.getMethodType().getReturnType();
+                        inferredType = m.getMethodType().getReturnType();
                     } else if (enclosing instanceof Expression) {
-                        inferedType = ((Expression) enclosing).getType();
+                        inferredType = ((Expression) enclosing).getType();
                     } else if (enclosing instanceof NameTree) {
                         if (enclosing instanceof J.VariableDeclarations.NamedVariable) {
                             J.VariableDeclarations decl = getCursor().getParentTreeCursor().getParentTreeCursor().getValue();
@@ -87,20 +87,20 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                                 return m;
                             }
                         }
-                        inferedType = ((NameTree) enclosing).getType();
+                        inferredType = ((NameTree) enclosing).getType();
                     } else if (enclosing instanceof J.Return) {
                         Object e = getCursor().dropParentUntil(p -> p instanceof J.MethodDeclaration || p instanceof J.Lambda || p.equals(Cursor.ROOT_VALUE)).getValue();
                         if (e instanceof J.MethodDeclaration) {
                             J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) e;
                             if (methodDeclaration.getReturnTypeExpression() != null) {
-                                inferedType = methodDeclaration.getReturnTypeExpression().getType();
+                                inferredType = methodDeclaration.getReturnTypeExpression().getType();
                             }
                         } else if (e instanceof J.Lambda) {
-                            inferedType = ((J.Lambda) e).getType();
+                            inferredType = ((J.Lambda) e).getType();
                         }
                     }
 
-                    if (inferedType != null && TypeUtils.isOfType(inferedType, m.getMethodType().getReturnType())) {
+                    if (inferredType != null && TypeUtils.isOfType(inferredType, m.getMethodType().getReturnType())) {
                         m = m.withTypeParameters(null);
                     }
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -42,70 +42,74 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                if (m.getTypeParameters() == null || m.getTypeParameters().isEmpty()) {
+                JavaType.Method methodType = m.getMethodType();
+                if (methodType == null || m.getTypeParameters() == null || m.getTypeParameters().isEmpty()) {
                     return m;
                 }
 
-                if (m.getMethodType() != null) {
-                    Object enclosing = getCursor().getParentTreeCursor().getValue();
-                    JavaType inferredType = null;
-                    if (enclosing instanceof J.MethodInvocation) {
-                        if (m.getMethodType().getFlags().contains(Flag.Static)) {
-                            List<String> formalTypeNames = new ArrayList<>(m.getMethodType().getDeclaredFormalTypeNames());
-                            m.getMethodType().getParameterTypes().stream()
-                                    .filter(p -> p instanceof JavaType.Parameterized)
-                                    .flatMap(p -> ((JavaType.Parameterized) p).getTypeParameters().stream())
-                                    .filter(t -> t instanceof JavaType.GenericTypeVariable)
-                                    .forEach(it -> formalTypeNames.remove(((JavaType.GenericTypeVariable) it).getName()));
-                            if (!formalTypeNames.isEmpty()) {
-                                return m;
-                            }
-                        }
-                        // Cannot remove type parameters if it would introduce ambiguity about which method should be called
-                        J.MethodInvocation enclosingMethod = (J.MethodInvocation) enclosing;
-                        if (enclosingMethod.getMethodType() == null) {
+                Object enclosing = getCursor().getParentTreeCursor().getValue();
+                JavaType inferredType = null;
+                if (enclosing instanceof J.MethodInvocation) {
+                    if (shouldRetainOnStaticMethod(methodType)) {
+                        return m;
+                    }
+                    // Cannot remove type parameters if it would introduce ambiguity about which method should be called
+                    J.MethodInvocation enclosingMethod = (J.MethodInvocation) enclosing;
+                    if (enclosingMethod.getMethodType() == null) {
+                        return m;
+                    }
+                    if (!(enclosingMethod.getMethodType().getDeclaringType() instanceof JavaType.Class)) {
+                        return m;
+                    }
+                    JavaType.Class declaringClass = (JavaType.Class) enclosingMethod.getMethodType().getDeclaringType();
+                    // If there's another method on the class with the same name, skip removing type parameters
+                    // More nuanced detection of ambiguity introduction is possible
+                    if (declaringClass.getMethods().stream()
+                            .filter(it -> it.getName().equals(enclosingMethod.getSimpleName()))
+                            .count() > 1) {
+                        return m;
+                    }
+                    inferredType = methodType.getReturnType();
+                } else if (enclosing instanceof Expression) {
+                    inferredType = ((Expression) enclosing).getType();
+                } else if (enclosing instanceof NameTree) {
+                    if (enclosing instanceof J.VariableDeclarations.NamedVariable) {
+                        J.VariableDeclarations decl = getCursor().getParentTreeCursor().getParentTreeCursor().getValue();
+                        if (decl.getTypeExpression() instanceof J.Identifier && "var".equals(((J.Identifier) decl.getTypeExpression()).getSimpleName())) {
                             return m;
-                        }
-                        if (!(enclosingMethod.getMethodType().getDeclaringType() instanceof JavaType.Class)) {
-                            return m;
-                        }
-                        JavaType.Class declaringClass = (JavaType.Class) enclosingMethod.getMethodType().getDeclaringType();
-                        // If there's another method on the class with the same name, skip removing type parameters
-                        // More nuanced detection of ambiguity introduction is possible
-                        if (declaringClass.getMethods().stream()
-                                .filter(it -> it.getName().equals(enclosingMethod.getSimpleName()))
-                                .count() > 1) {
-                            return m;
-                        }
-                        inferredType = m.getMethodType().getReturnType();
-                    } else if (enclosing instanceof Expression) {
-                        inferredType = ((Expression) enclosing).getType();
-                    } else if (enclosing instanceof NameTree) {
-                        if (enclosing instanceof J.VariableDeclarations.NamedVariable) {
-                            J.VariableDeclarations decl = getCursor().getParentTreeCursor().getParentTreeCursor().getValue();
-                            if (decl.getTypeExpression() instanceof J.Identifier && "var".equals(((J.Identifier) decl.getTypeExpression()).getSimpleName())) {
-                                return m;
-                            }
-                        }
-                        inferredType = ((NameTree) enclosing).getType();
-                    } else if (enclosing instanceof J.Return) {
-                        Object e = getCursor().dropParentUntil(p -> p instanceof J.MethodDeclaration || p instanceof J.Lambda || p.equals(Cursor.ROOT_VALUE)).getValue();
-                        if (e instanceof J.MethodDeclaration) {
-                            J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) e;
-                            if (methodDeclaration.getReturnTypeExpression() != null) {
-                                inferredType = methodDeclaration.getReturnTypeExpression().getType();
-                            }
-                        } else if (e instanceof J.Lambda) {
-                            inferredType = ((J.Lambda) e).getType();
                         }
                     }
-
-                    if (inferredType != null && TypeUtils.isOfType(inferredType, m.getMethodType().getReturnType())) {
-                        m = m.withTypeParameters(null);
+                    inferredType = ((NameTree) enclosing).getType();
+                } else if (enclosing instanceof J.Return) {
+                    Object e = getCursor().dropParentUntil(p -> p instanceof J.MethodDeclaration || p instanceof J.Lambda || p.equals(Cursor.ROOT_VALUE)).getValue();
+                    if (e instanceof J.MethodDeclaration) {
+                        J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) e;
+                        if (methodDeclaration.getReturnTypeExpression() != null) {
+                            inferredType = methodDeclaration.getReturnTypeExpression().getType();
+                        }
+                    } else if (e instanceof J.Lambda) {
+                        inferredType = ((J.Lambda) e).getType();
                     }
                 }
 
+                if (inferredType != null && TypeUtils.isOfType(inferredType, methodType.getReturnType())) {
+                    m = m.withTypeParameters(null);
+                }
+
                 return m;
+            }
+
+            private boolean shouldRetainOnStaticMethod(JavaType.Method methodType) {
+                if (!methodType.hasFlags(Flag.Static)) {
+                    return false;
+                }
+                List<String> formalTypeNames = new ArrayList<>(methodType.getDeclaredFormalTypeNames());
+                methodType.getParameterTypes().stream()
+                        .filter(p -> p instanceof JavaType.Parameterized)
+                        .flatMap(p -> ((JavaType.Parameterized) p).getTypeParameters().stream())
+                        .filter(t -> t instanceof JavaType.GenericTypeVariable)
+                        .forEach(it -> formalTypeNames.remove(((JavaType.GenericTypeVariable) it).getName()));
+                return !formalTypeNames.isEmpty();
             }
         });
     }

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -225,8 +225,18 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
             package org.openrewrite.test;
 
             public class GenericClass<T> {
-                public static <T> GenericClass<T> typedBuilder() {
-                    return null;
+                public static <T> GenericClassBuilder<T> typedBuilder() {
+                    return new GenericClassBuilder<T>();
+                }
+
+                static class GenericClassBuilder<T> {
+                    GenericClassBuilder<T> type(String type) {
+                        return null;
+                    }
+
+                    GenericClass<T> build() {
+                        return null;
+                    }
                 }
             }
           """
@@ -237,7 +247,8 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
 
               public class Test {
                   <T> GenericClass<T> test(Class<T> clazz) {
-                      return GenericClass.<T>typedBuilder();
+                      final GenericClass<T> gc = GenericClass.<T>typedBuilder().type("thing").build();
+                      return gc;
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ExpectedToFail;
@@ -73,7 +72,7 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
     }
 
     @Test
-    @Disabled
+    @ExpectedToFail("Not implemented yet")
     void withinLambda() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -305,7 +305,7 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
             );
         }
 
-        @Disabled
+        @ExpectedToFail("Not matching yet")
         @Test
         void changeIfHasTypeInference() {
             rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -180,7 +180,7 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
               public class Test {
 
                   List<String> test() {
-                      var l = List.<String> of("x");
+                      var l = List.<String>of("x");
                       return l;
                   }
               }
@@ -218,7 +218,7 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
     }
 
     @Test
-    void typedBuilder() {
+    void staticMethodInvocation() {
         rewriteRun(
           java(
           """
@@ -226,6 +226,10 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
 
             public class GenericClass<T> {
                 public static <T> GenericClassBuilder<T> typedBuilder() {
+                    return new GenericClassBuilder<T>();
+                }
+
+                public static <T> GenericClassBuilder<T> typedBuilderWithClass(Class<T> clazz) {
                     return new GenericClassBuilder<T>();
                 }
 
@@ -246,9 +250,25 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
               package org.openrewrite.test;
 
               public class Test {
-                  <T> GenericClass<T> test(Class<T> clazz) {
-                      final GenericClass<T> gc = GenericClass.<T>typedBuilder().type("thing").build();
-                      return gc;
+                  <T> void test(Class<T> clazz) {
+                      final GenericClass<T> gc1 = GenericClass.<T>typedBuilderWithClass(clazz).build();
+                      final GenericClass<T> gc2 = GenericClass.<T>typedBuilder().type("thing").build();
+                      var gc3 = GenericClass.<T>typedBuilder().type("thing").build();
+                      final GenericClass.GenericClassBuilder<T> gcb1 = GenericClass.<T>typedBuilder();
+                      var gcb2 = GenericClass.<T>typedBuilder();
+                  }
+              }
+              """,
+            """
+              package org.openrewrite.test;
+
+              public class Test {
+                  <T> void test(Class<T> clazz) {
+                      final GenericClass<T> gc1 = GenericClass.typedBuilderWithClass(clazz).build();
+                      final GenericClass<T> gc2 = GenericClass.<T>typedBuilder().type("thing").build();
+                      var gc3 = GenericClass.<T>typedBuilder().type("thing").build();
+                      final GenericClass.GenericClassBuilder<T> gcb1 = GenericClass.typedBuilder();
+                      var gcb2 = GenericClass.<T>typedBuilder();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -217,6 +217,34 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void typedBuilder() {
+        rewriteRun(
+          java(
+          """
+            package org.openrewrite.test;
+
+            public class GenericClass<T> {
+                public static <T> GenericClass<T> typedBuilder() {
+                    return null;
+                }
+            }
+          """
+          ),
+          java(
+            """
+              package org.openrewrite.test;
+
+              public class Test {
+                  <T> GenericClass<T> test(Class<T> clazz) {
+                      return GenericClass.<T>typedBuilder();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class kotlinTest {
         @Test


### PR DESCRIPTION
## What's changed?
Adde rules to the removing unnecessary explicit type arguments recipe to deal with static method calls.

## What's your motivation?
The recipe currently removes explicit type arguments from method calls that need it.
