### PR TITLE
TestNG matching for RemoveUnneededAssertion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testImplementation("org.jetbrains:annotations:24.+")
     testImplementation("org.junit-pioneer:junit-pioneer:2.+")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.testng:testng:7.+")
 
     testImplementation("com.google.code.gson:gson:latest.release")
 

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnneededAssertion.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnneededAssertion.java
@@ -44,6 +44,10 @@ public class RemoveUnneededAssertion extends Recipe {
     private static final MethodMatcher JUNIT_ASSERT_MESSAGE_TRUE_MATCHER = new MethodMatcher("org.junit.Assert assertTrue(String, boolean)");
     private static final MethodMatcher JUNIT_ASSERT_MESSAGE_FALSE_MATCHER = new MethodMatcher("org.junit.Assert assertFalse(String, boolean)");
 
+    // TestNG
+    private static final MethodMatcher TEST_NG_ASSERT_TRUE_MATCHER = new MethodMatcher("org.testng.Assert assertTrue(..)");
+    private static final MethodMatcher TEST_NG_ASSERT_FALSE_MATCHER = new MethodMatcher("org.testng.Assert assertFalse(..)");
+
     @Override
     public String getDisplayName() {
         return "Remove unneeded assertions";
@@ -63,6 +67,8 @@ public class RemoveUnneededAssertion extends Recipe {
                 new UsesMethod<>(JUNIT_ASSERT_FALSE_MATCHER),
                 new UsesMethod<>(JUNIT_ASSERT_MESSAGE_TRUE_MATCHER),
                 new UsesMethod<>(JUNIT_ASSERT_MESSAGE_FALSE_MATCHER),
+                new UsesMethod<>(TEST_NG_ASSERT_TRUE_MATCHER),
+                new UsesMethod<>(TEST_NG_ASSERT_FALSE_MATCHER),
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.Assert visitAssert(J.Assert _assert, ExecutionContext ctx) {
@@ -84,6 +90,8 @@ public class RemoveUnneededAssertion extends Recipe {
         matchers.put(JUNIT_ASSERT_FALSE_MATCHER, isFalse);
         matchers.put(JUNIT_ASSERT_MESSAGE_TRUE_MATCHER, args -> J.Literal.isLiteralValue(args.get(1), true));
         matchers.put(JUNIT_ASSERT_MESSAGE_FALSE_MATCHER, args -> J.Literal.isLiteralValue(args.get(1), false));
+        matchers.put(TEST_NG_ASSERT_TRUE_MATCHER, isTrue);
+        matchers.put(TEST_NG_ASSERT_FALSE_MATCHER, isFalse);
 
         return Preconditions.check(constraints, new JavaIsoVisitor<ExecutionContext>() {
             @Override

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededAssertionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededAssertionTest.java
@@ -266,4 +266,100 @@ class RemoveUnneededAssertionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void testNgAssertTrue() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+          //language=java
+          java(
+            """
+              import static org.testng.Assert.assertTrue;
+              public class A {
+                  public void m() {
+                      assertTrue(true);
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void m() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void testNgAssertFalse() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+          //language=java
+          java(
+            """
+              import static org.testng.Assert.assertFalse;
+              public class A {
+                  public void m() {
+                      assertFalse(false);
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void m() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void testNgAssertTrueMessage() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+          //language=java
+          java(
+            """
+              import static org.testng.Assert.assertTrue;
+              public class A {
+                  public void m() {
+                      assertTrue(true, "message");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void m() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void testNgAssertFalseMessage() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+          //language=java
+          java(
+            """
+              import static org.testng.Assert.assertFalse;
+              public class A {
+                  public void m() {
+                      assertFalse(false, "message");
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void m() {
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededAssertionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededAssertionTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
@@ -75,291 +76,300 @@ class RemoveUnneededAssertionTest implements RewriteTest {
         );
     }
 
-    @Test
-    void junitJupiterAssertTrue() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
-          //language=java
-          java(
-            """
-              import static org.junit.jupiter.api.Assertions.assertTrue;
-              public class A {
-                  public void m() {
-                      assertTrue(true);
+    @Nested
+    class UsingJUnitJupiter {
+        @Test
+        void assertTrueWithTrueArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
+              //language=java
+              java(
+                """
+                  import static org.junit.jupiter.api.Assertions.assertTrue;
+                  public class A {
+                      public void m() {
+                          assertTrue(true);
+                      }
                   }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
                   }
-              }
-              """
-          )
-        );
+                  """
+              )
+            );
+        }
+
+        @Test
+        void assertFalseWithFalseArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
+              //language=java
+              java(
+                """
+                  import static org.junit.jupiter.api.Assertions.assertFalse;
+                  public class A {
+                      public void m() {
+                          assertFalse(false);
+                      }
+                  }
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void assertTrueWithTrueArgumentAndMessage() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
+              //language=java
+              java(
+                """
+                  import static org.junit.jupiter.api.Assertions.assertTrue;
+                  public class A {
+                      public void m() {
+                          assertTrue(true, "message");
+                      }
+                  }
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void assertFalseWithFalseArgumentAndMessage() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
+              //language=java
+              java(
+                """
+                  import static org.junit.jupiter.api.Assertions.assertFalse;
+                  public class A {
+                      public void m() {
+                          assertFalse(false, "message");
+                      }
+                  }
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 
-    @Test
-    void junitJupiterAssertFalse() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
-          //language=java
-          java(
-            """
-              import static org.junit.jupiter.api.Assertions.assertFalse;
-              public class A {
-                  public void m() {
-                      assertFalse(false);
+    @Nested
+    class UsingJUnit4 {
+        @Test
+        void assertTrueWithTrueArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
+              //language=java
+              java(
+                """
+                  import static org.junit.Assert.assertTrue;
+                  public class A {
+                      public void m() {
+                          assertTrue(true);
+                      }
                   }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
                   }
-              }
-              """
-          )
-        );
+                  """
+              )
+            );
+        }
+
+        @Test
+        void assertFalseWithFalseArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
+              //language=java
+              java(
+                """
+                  import static org.junit.Assert.assertFalse;
+                  public class A {
+                      public void m() {
+                          assertFalse(false);
+                      }
+                  }
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void assertTrueWithMessageAndTrueArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
+              //language=java
+              java(
+                """
+                  import static org.junit.Assert.assertTrue;
+                  public class A {
+                      public void m() {
+                          assertTrue("message", true);
+                      }
+                  }
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void assertTrueWithMessageAndFalseArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
+              //language=java
+              java(
+                """
+                  import static org.junit.Assert.assertFalse;
+                  public class A {
+                      public void m() {
+                          assertFalse("message", false);
+                      }
+                  }
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 
-    @Test
-    void junitJupiterAssertTrueMessage() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
-          //language=java
-          java(
-            """
-              import static org.junit.jupiter.api.Assertions.assertTrue;
-              public class A {
-                  public void m() {
-                      assertTrue(true, "message");
+    @Nested
+    class UsingTestNG {
+        @Test
+        void assertTrueWithTrueArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+              //language=java
+              java(
+                """
+                  import static org.testng.Assert.assertTrue;
+                  public class A {
+                      public void m() {
+                          assertTrue(true);
+                      }
                   }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
                   }
-              }
-              """
-          )
-        );
-    }
+                  """
+              )
+            );
+        }
 
-    @Test
-    void junitJupiterAssertFalseMessage() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api")),
-          //language=java
-          java(
-            """
-              import static org.junit.jupiter.api.Assertions.assertFalse;
-              public class A {
-                  public void m() {
-                      assertFalse(false, "message");
+        @Test
+        void assertFalseWithFalseArgument() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+              //language=java
+              java(
+                """
+                  import static org.testng.Assert.assertFalse;
+                  public class A {
+                      public void m() {
+                          assertFalse(false);
+                      }
                   }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
                   }
-              }
-              """
-          )
-        );
-    }
+                  """
+              )
+            );
+        }
 
-    @Test
-    void junit4AssertTrueWithTrueArgument() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
-          //language=java
-          java(
-            """
-              import static org.junit.Assert.assertTrue;
-              public class A {
-                  public void m() {
-                      assertTrue(true);
+        @Test
+        void assertTrueWithTrueArgumentAndMessage() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+              //language=java
+              java(
+                """
+                  import static org.testng.Assert.assertTrue;
+                  public class A {
+                      public void m() {
+                          assertTrue(true, "message");
+                      }
                   }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
                   }
-              }
-              """
-          )
-        );
-    }
+                  """
+              )
+            );
+        }
 
-    @Test
-    void junit4AssertFalseWithFalseArgument() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
-          //language=java
-          java(
-            """
-              import static org.junit.Assert.assertFalse;
-              public class A {
-                  public void m() {
-                      assertFalse(false);
+        @Test
+        void assertFalseWithFalseArgumentAndMessage() {
+            rewriteRun(
+              spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
+              //language=java
+              java(
+                """
+                  import static org.testng.Assert.assertFalse;
+                  public class A {
+                      public void m() {
+                          assertFalse(false, "message");
+                      }
                   }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
+                  """,
+                """
+                  public class A {
+                      public void m() {
+                      }
                   }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void junit4AssertTrueWithMessageAndTrueArgument() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
-          //language=java
-          java(
-            """
-              import static org.junit.Assert.assertTrue;
-              public class A {
-                  public void m() {
-                      assertTrue("message", true);
-                  }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void junit4AssertTrueWithMessageAndFalseArgument() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),
-          //language=java
-          java(
-            """
-              import static org.junit.Assert.assertFalse;
-              public class A {
-                  public void m() {
-                      assertFalse("message", false);
-                  }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void testNgAssertTrue() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
-          //language=java
-          java(
-            """
-              import static org.testng.Assert.assertTrue;
-              public class A {
-                  public void m() {
-                      assertTrue(true);
-                  }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void testNgAssertFalse() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
-          //language=java
-          java(
-            """
-              import static org.testng.Assert.assertFalse;
-              public class A {
-                  public void m() {
-                      assertFalse(false);
-                  }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void testNgAssertTrueMessage() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
-          //language=java
-          java(
-            """
-              import static org.testng.Assert.assertTrue;
-              public class A {
-                  public void m() {
-                      assertTrue(true, "message");
-                  }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void testNgAssertFalseMessage() {
-        rewriteRun(
-          spec -> spec.parser(JavaParser.fromJavaVersion().classpath("testng")),
-          //language=java
-          java(
-            """
-              import static org.testng.Assert.assertFalse;
-              public class A {
-                  public void m() {
-                      assertFalse(false, "message");
-                  }
-              }
-              """,
-            """
-              public class A {
-                  public void m() {
-                  }
-              }
-              """
-          )
-        );
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
- Finishes #166 

## What's changed?
- Matching added for TestNG's `assertTrue(..)` and `assertFalse(..)` assertions so they too can be cleaned up when unneded

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
