### PR TITLE
NoFinalizedLocalVariables - fix for J.Lambda.Parameters in LST

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NoFinalizedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoFinalizedLocalVariables.java
@@ -59,7 +59,7 @@ public class NoFinalizedLocalVariables extends Recipe {
                 }
 
                 Tree parent = getCursor().getParentTreeCursor().getValue();
-                if (parent instanceof J.MethodDeclaration || parent instanceof J.Lambda) {
+                if (parent instanceof J.MethodDeclaration || parent instanceof J.Lambda || parent instanceof J.Lambda.Parameters) {
                     // this variable is a method parameter or lambda parameter
                     if (Boolean.TRUE.equals(excludeMethodParameters)) {
                         return mv;


### PR DESCRIPTION
- Finishes #514 

Adding additional case for `J.Lambda.Parameters` being in LST between `J.VariableDeclaration` and `J.Lambda`, which seems to have cropped up recently.