### PR TITLE
RemoveUnusedParams

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedParamsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedParamsTest.java
@@ -1,0 +1,281 @@
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveUnusedParamsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveUnusedParams());
+    }
+
+    @Test
+    void removeUnusedMethodParameter() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  void method(String unused) {
+                      System.out.println("Hello");
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  void method() {
+                      System.out.println("Hello");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveUsedParameter() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  void method(String input) {
+                      System.out.println(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveOverriddenMethodParameter() {
+        rewriteRun(
+          java(
+            """
+              class Base {
+                  void method(String param) {}
+              }
+              class Derived extends Base {
+                  @Override
+                  void method(String param) {
+                      // not used but required
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveAnnotatedParameter() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  void method(@Deprecated String param) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeMultipleUnusedParams() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  void method(String a, int b, double c) {
+                      System.out.println("Only prints this");
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  void method() {
+                      System.out.println("Only prints this");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveJavadocAndComments() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  /**
+                   * Some doc
+                   * @param unused this param is never used
+                   */
+                  void method(String unused) {
+                      // comment
+                      System.out.println("used");
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  /**
+                   * Some doc
+                   * @param unused this param is never used
+                   */
+                  void method() {
+                      // comment
+                      System.out.println("used");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/559")
+    @Test
+    void shadowedParameterShouldStillBeRemoved() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  void method(String input) {
+                      String input = "shadowed";
+                      System.out.println(input);
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  void method() {
+                      String input = "shadowed";
+                      System.out.println(input);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeUnusedStaticMethodParam() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  static void helper(String unused) {
+                      // no use
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  static void helper() {
+                      // no use
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeUnusedConstructorParam() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  Test(String unused) {
+                      // ctor body
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  Test() {
+                      // ctor body
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeUnusedVarargs() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  void m(String... args) {
+                      System.out.println("no args used");
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  void m() {
+                      System.out.println("no args used");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveAnnotatedParamButRemoveOthers() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  void method(@Deprecated String keep, int removeMe) {
+                      System.out.println(keep);
+                  }
+              }
+              """,
+            """
+              public class Test {
+                  void method(@Deprecated String keep) {
+                      System.out.println(keep);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveNativeMethodParam() {
+        rewriteRun(
+          java(
+            """
+              public class Test {
+                  native void nativeCall(int mustStay);
+              }
+              """
+          )
+        );
+
+
+
+    }
+
+    @Test
+    void interfaceMethodUnchanged() {
+        rewriteRun(
+          java(
+            """
+              interface I {
+                  void foo(String param);
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What’s changed?
I’ve added a new recipe class, **RemoveUnusedParams**, that automatically removes parameters from Java methods when they’re declared but never referenced in the method body. It still respects:

- **@Override** methods (both explicit and those detected across the codebase)  
- **Native** methods  
- Parameters with their own annotations (e.g. `@Deprecated`)  
- Constructors, varargs, interfaces, and other edge cases

Alongside the main recipe, I’ve expanded the unit tests to cover:
- Basic removal of unused parameters  
- Preservation of used, overridden, and annotated parameters  
- Constructors with unused arguments  
- Varargs methods  
- Native declarations  
- Interface methods (no change expected)

## What’s your motivation?
Over time, code tends to accumulate unused parameters—leftovers from refactoring, changing requirements, or evolving APIs. They add noise, make signatures harder to read, and can confuse future maintainers. This recipe:

1. **Keeps signatures lean**, showing exactly what each method actually needs  
2. **Automates cleanup**, reducing manual PR churn  
3. **Helps enforce consistency** across a large codebase

## Anything in particular you'd like reviewers to focus on?
- **Override detection**: Does the scan/visitor logic reliably catch all overridden methods?  
- **Edge-case coverage**: Any real-world patterns (e.g. multi-parameter annotations, complex varargs, inner-class overrides) that might slip through?  
- **Performance**: The recipe now uses a single `JavaIsoVisitor` pass—does it still scale on large projects?

## Anyone you would like to review specifically?
- @Pankraz76 

## Have you considered any alternatives or workarounds?
- Keeping the original “shadow-stack” approach to detect name shadowing more precisely—but in practice it added complexity without significant benefit.  
- Using a dedicated `MethodMatcher` or type-based override detection; this felt like overkill for a simple annotation check.

## Any additional context
- This work is driven by feedback on [Issue #559](https://github.com/openrewrite/rewrite-static-analysis/issues/559).  
- All existing tests pass, and I’ve verified the new cases locally with `mvn test`.  
- I’ve also run the IntelliJ auto-formatter to keep the style consistent.

### Checklist
- [x] I’ve added unit tests to cover both positive and negative cases  
- [x] I’ve read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)  
- [x] I’ve used the IntelliJ IDEA auto-formatter on affected files  
