### PR TITLE
Enhance RemoveUnusedLocalVariables to support filtering by type

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -137,11 +137,7 @@ public class RemoveUnusedLocalVariables extends Recipe {
                 }
 
                 // skip matching ignored variable types right away
-                if (
-                    variable.getType() instanceof JavaType.FullyQualified &&
-                    withType != null &&
-                    !withType.equals(((JavaType.FullyQualified) variable.getType()).getFullyQualifiedName())
-                ) {
+                if (withType != null && !TypeUtils.isOfClassType(variable.getType(), withType)) {
                     return variable;
                 }
 

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -44,8 +44,8 @@ public class RemoveUnusedLocalVariables extends Recipe {
             example = "[unused, notUsed, IGNORE_ME]")
     String @Nullable [] ignoreVariablesNamed;
 
-    @Option(displayName = "Only remove variables of type",
-            description = "A fully qualified class names. Only unused local variables whose type matches one of these will be removed. " +
+    @Option(displayName = "Only remove variables of a given type",
+            description = "A fully qualified class name. Only unused local variables whose type matches this will be removed. " +
                     "If empty or not set, all unused local variables are considered for removal.",
             required = false,
             example = "java.lang.String")

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.errorprone.annotations.InlineMe;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
@@ -45,33 +46,33 @@ public class RemoveUnusedLocalVariables extends Recipe {
 
     @Option(displayName = "Only remove variables of type",
             description = "A fully qualified class names. Only unused local variables whose type matches one of these will be removed. " +
-                          "If empty or not set, all unused local variables are considered for removal.",
+                    "If empty or not set, all unused local variables are considered for removal.",
             required = false,
             example = "java.lang.String")
-    @Nullable String withType;
+    @Nullable
+    String withType;
 
-    @Option(displayName = "Ignore possible side effects",
-            description = "If true, variables with possible side effects in their initializer will be ignored and not removed. " +
-                          "This option was previously named 'withSideEffects'.",
-            required = false,
-            example = "true")
-    @Nullable Boolean withSideEffects;
+    @Option(displayName = "Remove unused local variables with side effects in initializer",
+            description = "Whether to remove unused local variables despite side effects in the initializer. Default false.",
+            required = false)
+    @Nullable
+    Boolean withSideEffects;
 
     @JsonCreator
     public RemoveUnusedLocalVariables(
             String @Nullable [] ignoreVariablesNamed,
             @Nullable String withType,
-            @Nullable Boolean withSideEffects
-    ) {
+            @Nullable Boolean withSideEffects) {
         this.ignoreVariablesNamed = ignoreVariablesNamed;
         this.withType = withType;
         this.withSideEffects = withSideEffects;
     }
 
+    @InlineMe(replacement = "new RemoveUnusedLocalVariables(ignoreVariablesNamed, null, withSideEffects)")
+    @Deprecated
     public RemoveUnusedLocalVariables(
             String @Nullable [] ignoreVariablesNamed,
-            @Nullable Boolean withSideEffects
-    ) {
+            @Nullable Boolean withSideEffects) {
         this(ignoreVariablesNamed, null, withSideEffects);
     }
 

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -2229,6 +2229,7 @@ examples:
   parameters:
   - 'null'
   - 'null'
+  - 'null'
   sources:
   - before: |
       class Test {

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -688,7 +688,7 @@ class MinimumSwitchCasesTest implements RewriteTest {
               import java.io.ObjectInputFilter;
 
               class Test {
-                  int test(java.io.ObjectInputFilter filter) {
+                  int test(ObjectInputFilter filter) {
                       if (filter.checkInput(null) == ObjectInputFilter.Status.ALLOWED) {
                           return 0;
                       } else {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -1098,6 +1098,122 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void removeOnlyUnusedLocalVariablesOfTypeString() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveUnusedLocalVariables(
+            null,
+            "java.lang.String",
+            null
+          )),
+          //language=java
+          java(
+            """
+              class Test {
+                  void method() {
+                      String unusedString = "abc";
+                      Integer unusedInteger = 123;
+                      String usedString = "def";
+                      System.out.println(usedString);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                      Integer unusedInteger = 123;
+                      String usedString = "def";
+                      System.out.println(usedString);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeOnlyUnusedLocalVariablesOfTypeInteger() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveUnusedLocalVariables(
+            null,
+            "java.lang.Integer",
+            null
+          )),
+          //language=java
+          java(
+            """
+              class Test {
+                  void method() {
+                      String unusedString = "abc";
+                      Integer unusedInteger = 123;
+                      Integer usedInteger = 456;
+                      System.out.println(usedInteger);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                      String unusedString = "abc";
+                      Integer usedInteger = 456;
+                      System.out.println(usedInteger);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeAllUnusedLocalVariablesWhenWithTypeNull() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveUnusedLocalVariables(
+            null,
+            null,
+            null
+          )),
+          //language=java
+          java(
+            """
+              class Test {
+                  void method() {
+                      String unusedString = "abc";
+                      Integer unusedInteger = 123;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveUnusedLocalVariablesWhenWithTypeDoesNotMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveUnusedLocalVariables(
+            null,
+            "java.lang.BigInteger",
+            null
+          )),
+          //language=java
+          java(
+            """
+              class Test {
+                  void method() {
+                      String unusedString = "abc";
+                      Integer unusedInteger = 123;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class Kotlin {
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -46,7 +46,7 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new RemoveUnusedLocalVariables(new String[0], null));
+        spec.recipe(new RemoveUnusedLocalVariables(new String[0], null, null));
     }
 
     @DocumentExample
@@ -100,7 +100,7 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
     @SuppressWarnings("MethodMayBeStatic")
     void ignoreVariablesNamed() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveUnusedLocalVariables(new String[]{"unused"}, null)),
+          spec -> spec.recipe(new RemoveUnusedLocalVariables(new String[]{"unused"}, null, null)),
           //language=java
           java(
             """
@@ -1076,7 +1076,7 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite-feature-flags/pull/35")
     void removeDespiteSideEffects() {
         rewriteRun(
-          spec -> spec.recipe(new RemoveUnusedLocalVariables(null, true)),
+          spec -> spec.recipe(new RemoveUnusedLocalVariables(null, null, true)),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -613,7 +613,7 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
               class Test {
                   List<Object> filter(List<Object> l) {
                       return l.stream()
-                          .filter(org.test.CheckType.class::isInstance)
+                          .filter(CheckType.class::isInstance)
                           .map(CheckType.class::cast)
                           .collect(Collectors.toList());
                   }


### PR DESCRIPTION
## What's changed?

This PR enhances the `RemoveUnusedLocalVariables` recipe in OpenRewrite by introducing a new configuration option: `onlyRemoveVariablesOfType`. This option allows users to specify a list of fully qualified class names; only unused local variables of those types will be considered for removal.

## What's your motivation?

This change addresses an important scalability concern in large codebases. Removing **all** unused local variables often results in extensive, unrelated changes across a project, making code reviews cumbersome.

### Checklist

* [x] I've added unit tests to cover both positive and negative cases
* [x] I've read and applied the [[recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
* [x] I've used the IntelliJ IDEA auto-formatter on affected files