### PR TITLE
Fallthrough should not add `break;` when statements contain a guaranteed return

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -291,7 +291,5 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                 return case_;
             }
         }
-
     }
-
 }

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -230,7 +230,7 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
          *
          * @param enclosingSwitch The enclosing {@link J.Switch} subtree to search.
          * @param scope           the {@link J.Case} to use as a target.
-         * @return A set representing guaranteed {@link J.Return} statements.
+         * @return A set representing whether the case contains any guaranteed {@link J.Return} statements.
          */
         private static Set<J> find(J.Switch enclosingSwitch, J.Case scope) {
             Set<J> references = new HashSet<>();

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -223,9 +223,8 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
 
     }
 
+    NoArgsConstructor(access = PRIVATE)
     private static class FindGuaranteedReturns {
-        private FindGuaranteedReturns() {
-        }
 
         /**
          * If no results are found, it means we should append a {@link J.Break} to the provided {@link J.Case}.

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -252,7 +252,6 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
             }
 
             private static boolean returns(Statement s) {
-                boolean guaranteedReturnFound = false;
                 if (s instanceof J.ForLoop) {
                     J.ForLoop forLoop = (J.ForLoop) s;
                     Expression condition = forLoop.getControl().getCondition();

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -240,14 +240,10 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
             return references;
         }
 
+        @RequiredArgsConstructor
         private static class FindGuaranteedReturnsVisitor extends JavaIsoVisitor<Set<J>> {
-            private Cursor cursor;
+            private final Cursor cursor;
             private final J.Case scope;
-
-            public FindGuaranteedReturnsVisitor(Cursor cursor, J.Case scope) {
-                this.cursor = cursor;
-                this.scope = scope;
-            }
 
 
             private boolean hasGuaranteedReturn(List<? extends Statement> trees) {

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -264,9 +264,8 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                         Statement body = forLoop.getBody();
                         if (body instanceof J.Block) {
                             return !hasBreak(body) && hasGuaranteedReturn(((J.Block) body).getStatements());
-                        } else {
-                            return hasGuaranteedReturn(Collections.singletonList(forLoop.getBody()));
                         }
+                        return hasGuaranteedReturn(Collections.singletonList(body));
                     }
                 } else if (s instanceof J.WhileLoop) {
                     J.WhileLoop whileLoop = (J.WhileLoop) s;

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -149,7 +149,7 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                     return !statements.isEmpty() && breaks(statements.get(statements.size() - 1));
                 } else if (s instanceof J.If) {
                     J.If iff = (J.If) s;
-                    return iff.getElsePart() != null && breaks(iff.getThenPart()) && breaks(iff.getThenPart());
+                    return iff.getElsePart() != null && breaks(iff.getThenPart());
                 } else if (s instanceof J.Label) {
                     return breaks(((J.Label) s).getStatement());
                 } else if (s instanceof J.Try) {
@@ -271,7 +271,7 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                         if (value.getValue() == Boolean.TRUE) {
                             Statement body = whileLoop.getBody();
                             if (body instanceof J.Block) {
-                                return hasGuaranteedReturn(((J.Block) body).getStatements());
+                                return !hasBreak(((J.Block) body).getStatements()) && hasGuaranteedReturn(((J.Block) body).getStatements());
                             } else {
                                 return hasGuaranteedReturn(Collections.singletonList(whileLoop.getBody()));
                             }
@@ -279,6 +279,15 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                     }
                 }
                 return s instanceof J.Return;
+            }
+
+            private static boolean hasBreak(List<Statement> statements) {
+                for(Statement s : statements) {
+                    if(s instanceof J.Break) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             @Override

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -24,7 +24,10 @@ import org.openrewrite.java.style.FallThroughStyle;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -296,6 +296,7 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                         } else if (value instanceof J.ClassDeclaration) {
                             List<Statement> statements = ((J.ClassDeclaration) value).getBody().getStatements();
                             declaration = finalVariableDeclaration(statements, id);
+                            break;
                         }
                         cursor = cursor.getParentTreeCursor();
                         if (cursor.isRoot()) {

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -282,8 +282,8 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
             }
 
             private static boolean hasBreak(List<Statement> statements) {
-                for(Statement s : statements) {
-                    if(s instanceof J.Break) {
+                for (Statement s : statements) {
+                    if (s instanceof J.Break) {
                         return true;
                     } else if (s instanceof J.If) {
                         J.If if_ = (J.If) s;
@@ -294,7 +294,7 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                         } else {
                             hasBreak = hasBreak(Collections.singletonList(body));
                         }
-                        if(!hasBreak && if_.getElsePart() != null) {
+                        if (!hasBreak && if_.getElsePart() != null) {
                             Statement else_ = if_.getElsePart().getBody();
                             if (else_ instanceof J.If) {
                                 hasBreak = hasBreak(Collections.singletonList(else_));

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -291,8 +291,11 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                             List<Statement> statements = ((J.Case) value).getStatements();
                             declaration = finalVariableDeclaration(statements, id);
                         } else if (value instanceof J.MethodDeclaration) {
-                            List<Statement> statements = ((J.MethodDeclaration) value).getBody().getStatements();
-                            declaration = finalVariableDeclaration(statements, id);
+                            J.Block body = ((J.MethodDeclaration) value).getBody();
+                            if(body != null) {
+                                List<Statement> statements = body.getStatements();
+                                declaration = finalVariableDeclaration(statements, id);
+                            }
                         } else if (value instanceof J.ClassDeclaration) {
                             List<Statement> statements = ((J.ClassDeclaration) value).getBody().getStatements();
                             declaration = finalVariableDeclaration(statements, id);

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -22,8 +22,6 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.search.FindFields;
-import org.openrewrite.java.search.FindFieldsOfType;
 import org.openrewrite.java.style.FallThroughStyle;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -274,9 +274,8 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                         Statement body = whileLoop.getBody();
                         if (body instanceof J.Block) {
                             return !hasBreak(body) && hasGuaranteedReturn(((J.Block) body).getStatements());
-                        } else {
-                            return hasGuaranteedReturn(Collections.singletonList(whileLoop.getBody()));
                         }
+                        return hasGuaranteedReturn(Collections.singletonList(body));
                     }
                 }
                 return s instanceof J.Return;

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -15,8 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
+import lombok.*;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
@@ -223,7 +222,7 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
 
     }
 
-    NoArgsConstructor(access = PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
     private static class FindGuaranteedReturns {
 
         /**

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -531,11 +531,12 @@ class FallThroughTest implements RewriteTest {
           java(
             """
               enum Enum {
-                  A, B, C, D, E, F, G
+                  A, B, C, D, E, F, G, H, I
               }
               public class Test {
                   void foo(Enum a) {
                       boolean b = true;
+                      final boolean finalB = true;
                       switch(a) {
                           case A:
                               for (; ; ) {
@@ -550,21 +551,29 @@ class FallThroughTest implements RewriteTest {
                                   return;
                               }
                           case D:
-                              for (int i = 0; i > 0; i++) {
+                              for (; finalB; ) {
                                   return;
                               }
                           case E:
-                              while (b) {
+                              while (finalB) {
                                   return;
                               }
                           case F:
+                              for (int i = 0; i > 0; i++) {
+                                  return;
+                              }
+                          case G:
+                              while (b) {
+                                  return;
+                              }
+                          case H:
                               for (; ; ) {
                                   if (false) {
                                       break;
                                   }
                                   return;
                               }
-                          case G:
+                          case I:
                               while (true) {
                                   if (false) {
                                       break;
@@ -578,11 +587,12 @@ class FallThroughTest implements RewriteTest {
               """,
             """
               enum Enum {
-                  A, B, C, D, E, F, G
+                  A, B, C, D, E, F, G, H, I
               }
               public class Test {
                   void foo(Enum a) {
                       boolean b = true;
+                      final boolean finalB = true;
                       switch(a) {
                           case A:
                               for (; ; ) {
@@ -597,16 +607,24 @@ class FallThroughTest implements RewriteTest {
                                   return;
                               }
                           case D:
+                              for (; finalB; ) {
+                                  return;
+                              }
+                          case E:
+                              while (finalB) {
+                                  return;
+                              }
+                          case F:
                               for (int i = 0; i > 0; i++) {
                                   return;
                               }
                               break;
-                          case E:
+                          case G:
                               while (b) {
                                   return;
                               }
                               break;
-                          case F:
+                          case H:
                               for (; ; ) {
                                   if (false) {
                                       break;
@@ -614,7 +632,7 @@ class FallThroughTest implements RewriteTest {
                                   return;
                               }
                               break;
-                          case G:
+                          case I:
                               while (true) {
                                   if (false) {
                                       break;

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -257,7 +257,7 @@ class FallThroughTest implements RewriteTest {
                       switch (i) {
                       }
                   }
-                  
+
                   public void oneCase(int i) {
                       switch (i) {
                           case 0:
@@ -516,6 +516,75 @@ class FallThroughTest implements RewriteTest {
                                   default:
                                       System.out.print("other");
                               }
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void returnNestedInAlwaysTrueLoop() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              enum Enum {
+                  A, B, C, D
+              }
+              public class Test {
+                  void foo(Enum a) {
+                      boolean b = true;
+                      switch(a) {
+                          case A:
+                              for (; ; ) {
+                                  return;
+                              }
+                          case B:
+                              while (true) {
+                                  return;
+                              }
+                          case C:
+                              for (int i = 0; i > 0; i++) {
+                                  return;
+                              }
+                          case D:
+                              while (b) {
+                                  return;
+                              }
+                          default:
+                      }
+                  }
+              }
+              """,
+            """
+              enum Enum {
+                  A, B, C, D
+              }
+              public class Test {
+                  void foo(Enum a) {
+                      boolean b = true;
+                      switch(a) {
+                          case A:
+                              for (; ; ) {
+                                  return;
+                              }
+                          case B:
+                              while (true) {
+                                  return;
+                              }
+                          case C:
+                              for (int i = 0; i > 0; i++) {
+                                  return;
+                              }
+                              break;
+                          case D:
+                              while (b) {
+                                  return;
+                              }
+                              break;
+                          default:
                       }
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -525,55 +525,33 @@ class FallThroughTest implements RewriteTest {
     }
 
     @Test
-    void returnNestedInAlwaysTrueLoop() {
+    void returnNestedInLiteralTrue() {
         rewriteRun(
           //language=java
           java(
             """
               enum Enum {
-                  A, B, C, D, E, F, G, H, I
+                  A, B, C, D
               }
               public class Test {
                   void foo(Enum a) {
-                      boolean b = true;
-                      final boolean finalB = true;
                       switch(a) {
                           case A:
-                              for (; ; ) {
-                                  return;
-                              }
-                          case B:
                               for (; true; ) {
                                   return;
                               }
-                          case C:
+                          case B:
                               while (true) {
                                   return;
                               }
-                          case D:
-                              for (; finalB; ) {
-                                  return;
-                              }
-                          case E:
-                              while (finalB) {
-                                  return;
-                              }
-                          case F:
-                              for (int i = 0; i > 0; i++) {
-                                  return;
-                              }
-                          case G:
-                              while (b) {
-                                  return;
-                              }
-                          case H:
-                              for (; ; ) {
+                          case C:
+                              for (; true; ) {
                                   if (false) {
                                       break;
                                   }
                                   return;
                               }
-                          case I:
+                          case D:
                               while (true) {
                                   if (false) {
                                       break;
@@ -587,44 +565,83 @@ class FallThroughTest implements RewriteTest {
               """,
             """
               enum Enum {
-                  A, B, C, D, E, F, G, H, I
+                  A, B, C, D
               }
               public class Test {
                   void foo(Enum a) {
-                      boolean b = true;
-                      final boolean finalB = true;
+                      switch(a) {
+                          case A:
+                              for (; true; ) {
+                                  return;
+                              }
+                          case B:
+                              while (true) {
+                                  return;
+                              }
+                          case C:
+                              for (; true; ) {
+                                  if (false) {
+                                      break;
+                                  }
+                                  return;
+                              }
+                              break;
+                          case D:
+                              while (true) {
+                                  if (false) {
+                                      break;
+                                  }
+                                  return;
+                              }
+                              break;
+                          default:
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+    @Test
+    void returnNestedInInfiniteForLoop() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              enum Enum {
+                  A, B
+              }
+              public class Test {
+                  void foo(Enum a) {
                       switch(a) {
                           case A:
                               for (; ; ) {
                                   return;
                               }
                           case B:
-                              for (; true; ) {
+                              for (; ; ) {
+                                  if (false) {
+                                      break;
+                                  }
                                   return;
                               }
-                          case C:
-                              while (true) {
+                          default:
+                      }
+                  }
+              }
+              """,
+            """
+              enum Enum {
+                  A, B
+              }
+              public class Test {
+                  void foo(Enum a) {
+                      switch(a) {
+                          case A:
+                              for (; ; ) {
                                   return;
                               }
-                          case D:
-                              for (; finalB; ) {
-                                  return;
-                              }
-                          case E:
-                              while (finalB) {
-                                  return;
-                              }
-                          case F:
-                              for (int i = 0; i > 0; i++) {
-                                  return;
-                              }
-                              break;
-                          case G:
-                              while (b) {
-                                  return;
-                              }
-                              break;
-                          case H:
+                          case B:
                               for (; ; ) {
                                   if (false) {
                                       break;
@@ -632,14 +649,88 @@ class FallThroughTest implements RewriteTest {
                                   return;
                               }
                               break;
-                          case I:
-                              while (true) {
-                                  if (false) {
-                                      break;
-                                  }
+                          default:
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void returnNestedInNonFinalBooleanInfiniteLoop() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              enum Enum {
+                  A
+              }
+              public class Test {
+                  void foo(Enum a) {
+                      boolean b = true;
+                      switch(a) {
+                          case A:
+                              while (b) {
+                                  return;
+                              }
+                          default:
+                      }
+                  }
+              }
+              """,
+            """
+              enum Enum {
+                  A
+              }
+              public class Test {
+                  void foo(Enum a) {
+                      boolean b = true;
+                      switch(a) {
+                          case A:
+                              while (b) {
                                   return;
                               }
                               break;
+                          default:
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void returnNestedInFinalBooleanInfiniteLoop() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              enum Enum {
+                  A, B, C
+              }
+              public class Test {
+
+                  final boolean classBoolean = true;
+
+                  void foo(Enum a) {
+                      final boolean methodBoolean = true;
+                      switch(a) {
+                          case A:
+                              while (classBoolean) {
+                                  return;
+                              }
+                          case B:
+                              while (methodBoolean) {
+                                  return;
+                              }
+                          case C:
+                              final boolean caseBoolean = true;
+                              while (caseBoolean) {
+                                  return;
+                              }
                           default:
                       }
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -531,7 +531,7 @@ class FallThroughTest implements RewriteTest {
           java(
             """
               enum Enum {
-                  A, B, C, D
+                  A, B, C, D, E, F
               }
               public class Test {
                   void foo(Enum a) {
@@ -553,6 +553,20 @@ class FallThroughTest implements RewriteTest {
                               while (b) {
                                   return;
                               }
+                          case E:
+                              for (; ; ) {
+                                  if(false) {
+                                      break;
+                                  }
+                                  return;
+                              }
+                          case F:
+                              while (true) {
+                                  if(false) {
+                                      break;
+                                  }
+                                  return;
+                              }
                           default:
                       }
                   }
@@ -560,7 +574,7 @@ class FallThroughTest implements RewriteTest {
               """,
             """
               enum Enum {
-                  A, B, C, D
+                  A, B, C, D, E, F
               }
               public class Test {
                   void foo(Enum a) {
@@ -581,6 +595,22 @@ class FallThroughTest implements RewriteTest {
                               break;
                           case D:
                               while (b) {
+                                  return;
+                              }
+                              break;
+                          case E:
+                              for (; ; ) {
+                                  if(false) {
+                                      break;
+                                  }
+                                  return;
+                              }
+                              break;
+                          case F:
+                              while (true) {
+                                  if(false) {
+                                      break;
+                                  }
                                   return;
                               }
                               break;

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -531,7 +531,7 @@ class FallThroughTest implements RewriteTest {
           java(
             """
               enum Enum {
-                  A, B, C, D, E, F
+                  A, B, C, D, E, F, G
               }
               public class Test {
                   void foo(Enum a) {
@@ -542,27 +542,31 @@ class FallThroughTest implements RewriteTest {
                                   return;
                               }
                           case B:
-                              while (true) {
+                              for (; true; ) {
                                   return;
                               }
                           case C:
-                              for (int i = 0; i > 0; i++) {
+                              while (true) {
                                   return;
                               }
                           case D:
-                              while (b) {
+                              for (int i = 0; i > 0; i++) {
                                   return;
                               }
                           case E:
+                              while (b) {
+                                  return;
+                              }
+                          case F:
                               for (; ; ) {
-                                  if(false) {
+                                  if (false) {
                                       break;
                                   }
                                   return;
                               }
-                          case F:
+                          case G:
                               while (true) {
-                                  if(false) {
+                                  if (false) {
                                       break;
                                   }
                                   return;
@@ -574,7 +578,7 @@ class FallThroughTest implements RewriteTest {
               """,
             """
               enum Enum {
-                  A, B, C, D, E, F
+                  A, B, C, D, E, F, G
               }
               public class Test {
                   void foo(Enum a) {
@@ -585,30 +589,34 @@ class FallThroughTest implements RewriteTest {
                                   return;
                               }
                           case B:
-                              while (true) {
+                              for (; true; ) {
                                   return;
                               }
                           case C:
+                              while (true) {
+                                  return;
+                              }
+                          case D:
                               for (int i = 0; i > 0; i++) {
                                   return;
                               }
                               break;
-                          case D:
+                          case E:
                               while (b) {
                                   return;
                               }
                               break;
-                          case E:
+                          case F:
                               for (; ; ) {
-                                  if(false) {
+                                  if (false) {
                                       break;
                                   }
                                   return;
                               }
                               break;
-                          case F:
+                          case G:
                               while (true) {
-                                  if(false) {
+                                  if (false) {
                                       break;
                                   }
                                   return;


### PR DESCRIPTION
## What's changed?
- Added test
- Added check to find guaranteed returns

## What's your motivation?
When there is a guaranteed return in a switch case, adding a `break;` will result in unreachable code.
