### PR TITLE
`MinimumSwitchCases` ignores switches with cases with more than 1 break.

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -213,7 +213,7 @@ public class MinimumSwitchCases extends Recipe {
                             }
                         }
 
-                        return autoFormat(generatedIf, ctx);
+                        return autoFormat(super.visit(generatedIf, ctx), ctx);
                     } catch (RecipeRunException e) {
                         // JavaTemplate has problems on some Groovy files, don't currently have a way to adapt it appropriately
                         return switch_;
@@ -295,8 +295,10 @@ public class MinimumSwitchCases extends Recipe {
 
         @Override
         public @Nullable J visit(@Nullable Tree tree, List<Statement> statements) {
-            if(tree instanceof J.Break) {
+            if (tree instanceof J.Break) {
                 statements.add((J.Break) tree);
+            } else if (tree instanceof J.Switch) {
+                return (J) tree;
             }
             return super.visit(tree, statements);
         }

--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -31,7 +31,6 @@ import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.csharp.CSharpFileChecker;
 
-import javax.swing.plaf.nimbus.State;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -130,7 +129,7 @@ public class MinimumSwitchCases extends Recipe {
                                 List<Statement> breaks = new ArrayList<>();
                                 new BreakFinderVisitor().visit(aCase, breaks);
                                 Statement lastStatement = aCase.getStatements().isEmpty() ? null : aCase.getStatements().get(aCase.getStatements().size() - 1);
-                                if(breaks.size() > 1) {
+                                if (breaks.size() > 1) {
                                     return super.visitSwitch(switch_, ctx);
                                 }
                                 if (j != statements.size() - 1 && !(lastStatement instanceof J.Break || lastStatement instanceof J.Return)) {

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -776,7 +776,7 @@ class MinimumSwitchCasesTest implements RewriteTest {
     }
 
     @Test
-    void mutlipleBreaks() {
+    void multipleBreaks() {
         rewriteRun(
           //language=java
           java(
@@ -785,18 +785,61 @@ class MinimumSwitchCasesTest implements RewriteTest {
                   int variable;
                   void test() {
                       Object returnValue;
-                       switch (variable) {
-                           case 0:
-                               if(someCondition()) {
-                                   break;
-                               }
-                               returnValue = new Object();
-                               break;
-                           default:
-                               throw new RuntimeException();
+                      switch (variable) {
+                          case 0:
+                              if(someCondition()) {
+                                  break;
+                              }
+                              returnValue = new Object();
+                              break;
+                          default:
+                              throw new RuntimeException();
                        }
                   }
                   boolean someCondition() { return false; }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedSwitch() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  int variableA;
+                  int variableB;
+                  void test() {
+                      Object returnValue;
+                      switch(variableA) {
+                          case 0:
+                              switch (variableB) {
+                                  case 0: break;
+                                  default: break;
+                              }
+                              break;
+                          default:
+                              break;
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  int variableA;
+                  int variableB;
+                  void test() {
+                      Object returnValue;
+                      if (variableA == 0) {
+                          if (variableB == 0) {
+                          } else {
+                          }
+                      } else {
+                      }
+                  }
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -774,4 +774,32 @@ class MinimumSwitchCasesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void mutlipleBreaks() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  int variable;
+                  void test() {
+                      Object returnValue;
+                       switch (variable) {
+                           case 0:
+                               if(someCondition()) {
+                                   break;
+                               }
+                               returnValue = new Object();
+                               break;
+                           default:
+                               throw new RuntimeException();
+                       }
+                  }
+                  boolean someCondition() { return false; }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
`MinimumSwitchCases` ignores switches with cases with more than 1 break.

## What's your motivation?
When a case contains several breaks rewriting it to an if-statement results in an if-statement with a break.
