### PR TITLE
DEV Add nullable annotation for methods with ternary null returns

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -175,6 +175,10 @@ public class AnnotateNullableMethods extends Recipe {
             if (returnExpression instanceof J.MethodInvocation) {
                 return isKnowNullableMethod((J.MethodInvocation) returnExpression);
             }
+            if (returnExpression instanceof J.Ternary) {
+                J.Ternary ternary = (J.Ternary) returnExpression;
+                return maybeIsNull(ternary.getTruePart()) || maybeIsNull(ternary.getFalsePart());
+            }
             return false;
         }
 

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -283,4 +283,56 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           )
         );
     }
+
+    @DocumentExample
+    @Test
+    void methodReturnsNullInTernary() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Random;
+
+              public class Test {
+
+                  public String getString() {
+                      return new Random().nextBoolean() ? "Not null" : null;
+                  }
+              }
+              """,
+            """
+              import org.jspecify.annotations.Nullable;
+
+              import java.util.Random;
+
+              public class Test {
+
+                  public @Nullable String getString() {
+                      return new Random().nextBoolean() ? "Not null" : null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void methodWithTernaryNullButNeverReturnsNull() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Random;
+
+              public class Test {
+
+                  public String getString() {
+                      var value = new Random().nextBoolean() ? "Not null" : null;
+                      return value != null ? value : "Unknown";
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

This PR updates the `AnnotateNullableMethods` recipe in order to annotate methods with ternary null returns.

#### Example

**Before:**

```java
import java.util.Random;

public class Test {

    public String getString() {
        //...
        return new Random().nextBoolean() ? "Not null" : null;
    }
}
```

**After:**

```java
import java.util.Random;

public class Test {

    public @Nullable String getString() {
        //...
        return new Random().nextBoolean() ? "Not null" : null;
    }
}
```


## What's your motivation?
Support one more use case.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [] I've used the IntelliJ IDEA auto-formatter on affected files
