### PR TITLE
Remove default style choice from `CustomImportOrder`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/CustomImportOrder.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CustomImportOrder.java
@@ -51,8 +51,10 @@ public class CustomImportOrder extends Recipe {
         public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
             if (tree instanceof JavaSourceFile) {
                 JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-                CustomImportOrderStyle style = Style.from(CustomImportOrderStyle.class, cu, Checkstyle::customImportOrderStyle);
-                return new CustomImportOrderVisitor<>(style).visitNonNull(cu, ctx);
+                CustomImportOrderStyle style = Style.from(CustomImportOrderStyle.class, cu);
+                if (style != null) {
+                    return new CustomImportOrderVisitor<>(style).visitNonNull(cu, ctx);
+                }
             }
             return (J) tree;
         }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Removed the default selection of `Checkstyle::customImportOrderStyle`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
This recipe is currently changing imports even on projects that do not use Checkstyle

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
