### PR TITLE
fix: remove unnecessary continue in empty while loops

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
@@ -48,9 +48,12 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
     public J.WhileLoop visitWhileLoop(J.WhileLoop whileLoop, P p) {
         J.WhileLoop w = super.visitWhileLoop(whileLoop, p);
 
-        if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralWhile()) && isEmptyBlock(w.getBody())) {
+        if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralWhile()) && w.getBody() instanceof J.Block) {
             J.Block body = (J.Block) w.getBody();
-            w = continueStatement.apply(updateCursor(w), body.getCoordinates().lastStatement());
+            List<Statement> statements = body.getStatements();
+            if (statements.size() == 1 && statements.get(0) instanceof J.Continue) {
+                w = w.withBody(body.withStatements(new ArrayList<>()));
+            }
         }
 
         return w;
@@ -60,9 +63,12 @@ public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
     public J.DoWhileLoop visitDoWhileLoop(J.DoWhileLoop doWhileLoop, P p) {
         J.DoWhileLoop w = super.visitDoWhileLoop(doWhileLoop, p);
 
-        if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralWhile()) && isEmptyBlock(w.getBody())) {
+        if (Boolean.TRUE.equals(emptyBlockStyle.getLiteralWhile()) && w.getBody() instanceof J.Block) {
             J.Block body = (J.Block) w.getBody();
-            w = continueStatement.apply(updateCursor(w), body.getCoordinates().lastStatement());
+            List<Statement> statements = body.getStatements();
+            if (statements.size() == 1 && statements.get(0) instanceof J.Continue) {
+                w = w.withBody(body.withStatements(new ArrayList<>()));
+            }
         }
 
         return w;

--- a/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
@@ -223,8 +223,10 @@ class EmptyBlockTest implements RewriteTest {
               public class A {
                   public void foo() {
                       while(true) {
+                          continue;
                       }
                       do {
+                          continue;
                       } while(true);
                   }
               }
@@ -233,10 +235,8 @@ class EmptyBlockTest implements RewriteTest {
               public class A {
                   public void foo() {
                       while(true) {
-                          continue;
                       }
                       do {
-                          continue;
                       } while(true);
                   }
               }


### PR DESCRIPTION
## What's changed?
Changed EmptyBlockVisitor "visitWhileLoop" and "visitDoWhileLoop" methods so that they do not add any "continue" statement. Instead, If there is a continue statement, it should remove them.

## What's your motivation?
Closes #570 

## Anything in particular you'd like reviewers to focus on?
I would like to check if it's okay to put the logic of removing the continue statement on the same class. Or if not, where should it be?

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
