### PR TITLE
Do not pull Supertype-Cast to instanceof

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -1005,6 +1005,48 @@ class InstanceOfPatternMatchTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
+        void castTypeIsSuperType() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Main {
+                      void test(Object o) {
+                          if (o instanceof Car) {
+                              ((Vehicle) o).start();
+                          }
+                      }
+                      private static abstract class Vehicle { abstract void start(); }
+                      private static class Car extends Vehicle { void start() {} }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
+        void castTypeIsSubType() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  public class Main {
+                      void test(Object o) {
+                          if (o instanceof Car) {
+                              ((Vehicle) o).start();
+                          }
+                      }
+                      private static abstract class Vehicle { abstract void start(); }
+                      private static class Car extends Vehicle { void start() {} }
+                  }
+                  """
+              )
+            );
+        }
     }
 
     @Nested


### PR DESCRIPTION
When the cast type expression is a supertype of the instanceof type, the recipe should back off. The code semantics could change otherwise, because more instances can potentially pass the check. Fixes GH-572.


## What's changed?

Type casts after `instanceof` checks which use a different type than the one used in the `instanceof` check itself will now be ignored since changing the `instanceof` type might alter the code semantics.

## What's your motivation?

Issue #572

## Anything in particular you'd like reviewers to focus on?

The `isCheckedCastCompatible` might be extended even further to take generic type variables into account. Cases like these could also be migrated, since the type variables are the same:

```java
// java 11
class A<T> {
   void test(List<T> o) {
       if (o instanceof ArrayList<?>) {
           ((ArrayList<T>) o).trimToSize();
       }
   }
}

// java 16+ where the reifiable type-restriction was lifted
class A<T> {
   void test(List<T> o) {
       if (o instanceof ArrayList<T> list) {
           list.trimToSize();
       }
   }
}
```

The `isCheckedCastCompatible` might be a duplicate of existing code, but I didn't find any publicly accessible methods which perform such checks ☹️ 

## Have you considered any alternatives or workarounds?

In the first try I just flipped the type `TypeUtils#isAssignableTo` parameters in the `registerTypeCast` method, but then subtype casts were pulled up to the `instanceof` check, resulting in the same problem of changed semantics.

### Checklist
- [✅] I've added unit tests to cover both positive and negative cases
- [✅] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [❌] I've used the IntelliJ IDEA auto-formatter on affected files, since the formatting differs a bit from the existing code when using the IntelliJ formatter