### PR TITLE
Add regression test to verify that no default import order style is applied

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/CustomImportOrder.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CustomImportOrder.java
@@ -26,8 +26,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.style.Style;
 
-import static java.util.Objects.requireNonNull;
-
 public class CustomImportOrder extends Recipe {
 
     @Override
@@ -42,20 +40,17 @@ public class CustomImportOrder extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new CustomImportOrderCompilationUnitStyle();
-    }
-
-    private static class CustomImportOrderCompilationUnitStyle extends JavaIsoVisitor<ExecutionContext> {
-        @Override
-        public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
-            if (tree instanceof JavaSourceFile) {
-                JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-                CustomImportOrderStyle style = Style.from(CustomImportOrderStyle.class, cu);
-                if (style != null) {
-                    return new CustomImportOrderVisitor<>(style).visitNonNull(cu, ctx);
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof JavaSourceFile) {
+                    CustomImportOrderStyle style = Style.from(CustomImportOrderStyle.class, (JavaSourceFile) tree);
+                    if (style != null) {
+                        return new CustomImportOrderVisitor<>(style).visitNonNull(tree, ctx);
+                    }
                 }
+                return (J) tree;
             }
-            return (J) tree;
-        }
+        };
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/CustomImportOrderRecipeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CustomImportOrderRecipeTest.java
@@ -47,24 +47,24 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import org.apache.commons.lang3.StringUtils;
-                    import java.util.Collections;
-                    import static java.util.Collections.*;
+              import org.apache.commons.lang3.StringUtils;
+              import java.util.Collections;
+              import static java.util.Collections.*;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
+              import static java.util.Collections.*;
 
-                    import java.util.Collections;
-                    import org.apache.commons.lang3.StringUtils;
+              import java.util.Collections;
+              import org.apache.commons.lang3.StringUtils;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -87,31 +87,31 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
+              import static java.util.Collections.*;
 
-                    import java.time.*;
-                    import javax.net.*;
-                    import static java.io.File.separator;
+              import java.time.*;
+              import javax.net.*;
+              import static java.io.File.separator;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -122,31 +122,31 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
+              import java.time.*;
 
-                    import javax.net.*;
-                    import org.apache.commons.io.FileUtils;
+              import javax.net.*;
+              import org.apache.commons.io.FileUtils;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -158,36 +158,36 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import org.apache.commons.io.FileUtils;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -199,34 +199,34 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import org.apache.commons.lang3.StringUtils;
+              import org.apache.commons.lang3.StringUtils;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import org.apache.commons.lang3.StringUtils;
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.lang3.StringUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -238,35 +238,35 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
-                    import org.apache.commons.io.FileUtils;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import java.time.*;
+              import javax.net.*;
+              import org.apache.commons.io.FileUtils;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -279,33 +279,33 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
-                    import org.apache.commons.io.FileUtils;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import java.time.*;
+              import javax.net.*;
+              import org.apache.commons.io.FileUtils;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.io.File.separator;
-                    import static java.util.Collections.*;
+              import static java.io.File.separator;
+              import static java.util.Collections.*;
 
-                    import java.time.*;
-                    import javax.net.*;
-                    import org.apache.commons.io.FileUtils;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import java.time.*;
+              import javax.net.*;
+              import org.apache.commons.io.FileUtils;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -318,37 +318,37 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import javax.net.*;
-                    import java.time.*;
+              import javax.net.*;
+              import java.time.*;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.io.File.separator;
-                    import static java.util.Collections.*;
+              import static java.io.File.separator;
+              import static java.util.Collections.*;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -360,36 +360,36 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.util.Collections.*;
-                    import static java.io.File.separator;
+              import static java.util.Collections.*;
+              import static java.io.File.separator;
 
-                    import java.time.*;
-                    import javax.net.*;
-                    import org.apache.commons.io.FileUtils;
+              import java.time.*;
+              import javax.net.*;
+              import org.apache.commons.io.FileUtils;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.io.File.separator;
-                    import static java.util.Collections.*;
+              import static java.io.File.separator;
+              import static java.util.Collections.*;
 
-                    import java.time.*;
-                    import javax.net.*;
+              import java.time.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -400,25 +400,25 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import java.awt.Dialog;
-                    import java.awt.Window;
-                    import java.awt.color.ColorSpace;
-                    import java.awt.Frame;
+              import java.awt.Dialog;
+              import java.awt.Window;
+              import java.awt.color.ColorSpace;
+              import java.awt.Frame;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import java.awt.Dialog;
-                    import java.awt.Frame;
-                    import java.awt.Window;
-                    import java.awt.color.ColorSpace;
+              import java.awt.Dialog;
+              import java.awt.Frame;
+              import java.awt.Window;
+              import java.awt.color.ColorSpace;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -432,36 +432,36 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import static java.io.File.separator;
-                    import static java.util.Collections.*;
+              import static java.io.File.separator;
+              import static java.util.Collections.*;
 
-                    import java.time.*;
+              import java.time.*;
 
-                    import javax.net.*;
+              import javax.net.*;
 
-                    import org.apache.commons.io.FileUtils;
+              import org.apache.commons.io.FileUtils;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
-                    import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
-                    import org.apache.commons.io.FileUtils;
-                    import javax.net.*;
-                    import java.time.*;
+              import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+              import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+              import org.apache.commons.io.FileUtils;
+              import javax.net.*;
+              import java.time.*;
 
-                    import static java.io.File.separator;
-                    import static java.util.Collections.*;
+              import static java.io.File.separator;
+              import static java.util.Collections.*;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -472,21 +472,21 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-            package com.example;
+              package com.example;
 
-            import static java.util.Collections.emptyList;
-            import static java.lang.Math.max;
+              import static java.util.Collections.emptyList;
+              import static java.lang.Math.max;
 
-            class Test {}
-            """,
+              class Test {}
+              """,
             """
-            package com.example;
+              package com.example;
 
-            import static java.lang.Math.max;
-            import static java.util.Collections.emptyList;
+              import static java.lang.Math.max;
+              import static java.util.Collections.emptyList;
 
-            class Test {}
-            """
+              class Test {}
+              """
           )
         );
     }
@@ -498,21 +498,21 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-            package com.example;
+              package com.example;
 
-            import org.apache.commons.io.FileUtils;
-            import com.google.common.collect.Lists;
+              import org.apache.commons.io.FileUtils;
+              import com.google.common.collect.Lists;
 
-            class Test {}
-            """,
+              class Test {}
+              """,
             """
-            package com.example;
+              package com.example;
 
-            import com.google.common.collect.Lists;
-            import org.apache.commons.io.FileUtils;
+              import com.google.common.collect.Lists;
+              import org.apache.commons.io.FileUtils;
 
-            class Test {}
-            """
+              class Test {}
+              """
           )
         );
     }
@@ -526,34 +526,34 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-                    package com.example;
+              package com.example;
 
-                    import com.google.common.annotations.Beta;
-                    import com.google.common.annotations.VisibleForTesting;
-                    import org.apache.commons.io.FileUtils;
+              import com.google.common.annotations.Beta;
+              import com.google.common.annotations.VisibleForTesting;
+              import org.apache.commons.io.FileUtils;
 
-                    import static java.util.Collections.emptyList;
+              import static java.util.Collections.emptyList;
 
-                    import com.google.common.annotations.GwtCompatible;
+              import com.google.common.annotations.GwtCompatible;
 
-                    import java.lang.String;
+              import java.lang.String;
 
-                    class Test {}
-                    """,
+              class Test {}
+              """,
             """
-                    package com.example;
+              package com.example;
 
-                    import com.google.common.annotations.Beta;
-                    import com.google.common.annotations.VisibleForTesting;
-                    import org.apache.commons.io.FileUtils;
-                    import com.google.common.annotations.GwtCompatible;
+              import com.google.common.annotations.Beta;
+              import com.google.common.annotations.VisibleForTesting;
+              import org.apache.commons.io.FileUtils;
+              import com.google.common.annotations.GwtCompatible;
 
-                    import static java.util.Collections.emptyList;
+              import static java.util.Collections.emptyList;
 
-                    import java.lang.String;
+              import java.lang.String;
 
-                    class Test {}
-                    """
+              class Test {}
+              """
           ));
     }
 
@@ -564,31 +564,31 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           // language=java
           java(
             """
-            package com.mycompany.library.util;
+              package com.mycompany.library.util;
 
-            import com.mycompany.other.Helper;
-            import static java.util.Collections.emptyList;
-            import org.junit.Assert;
-            import com.mycompany.library.util.Bar;
-            import com.mycompany.library.Foo;
-            import com.mycompany.library.util.baz.Baz;
+              import com.mycompany.other.Helper;
+              import static java.util.Collections.emptyList;
+              import org.junit.Assert;
+              import com.mycompany.library.util.Bar;
+              import com.mycompany.library.Foo;
+              import com.mycompany.library.util.baz.Baz;
 
-            class Example {}
-            """,
+              class Example {}
+              """,
             """
-            package com.mycompany.library.util;
+              package com.mycompany.library.util;
 
-            import com.mycompany.library.util.Bar;
-            import com.mycompany.library.Foo;
-            import com.mycompany.library.util.baz.Baz;
+              import com.mycompany.library.util.Bar;
+              import com.mycompany.library.Foo;
+              import com.mycompany.library.util.baz.Baz;
 
-            import com.mycompany.other.Helper;
-            import org.junit.Assert;
+              import com.mycompany.other.Helper;
+              import org.junit.Assert;
 
-            import static java.util.Collections.emptyList;
+              import static java.util.Collections.emptyList;
 
-            class Example {}
-            """
+              class Example {}
+              """
           )
         );
     }
@@ -600,10 +600,10 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           // language=java
           java(
             """
-            package com.example;
+              package com.example;
 
-            class Example {}
-            """
+              class Example {}
+              """
           )
         );
     }
@@ -619,13 +619,13 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           // language=java
           java(
             """
-            package com.example;
+              package com.example;
 
-            import foo.A;
-            import bar.B;
+              import foo.A;
+              import bar.B;
 
-            class Example {}
-            """
+              class Example {}
+              """
           )
         );
     }
@@ -637,15 +637,15 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-            package com.example;
+              package com.example;
 
-            import static java.util.Collections.*;
+              import static java.util.Collections.*;
 
-            import java.util.Collections;
-            import org.apache.commons.lang3.StringUtils;
+              import java.util.Collections;
+              import org.apache.commons.lang3.StringUtils;
 
-            class Test {}
-            """
+              class Test {}
+              """
           ));
     }
 
@@ -655,14 +655,14 @@ class CustomImportOrderRecipeTest implements RewriteTest {
           //language=java
           java(
             """
-            package com.example;
+              package com.example;
 
-            import org.apache.commons.lang3.StringUtils;
-            import java.util.Collections;
-            import static java.util.Collections.*;
+              import org.apache.commons.lang3.StringUtils;
+              import static java.util.Collections.*;
+              import java.util.Collections;
 
-            class Test {}
-            """
+              class Test {}
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/staticanalysis/CustomImportOrderRecipeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CustomImportOrderRecipeTest.java
@@ -648,4 +648,22 @@ class CustomImportOrderRecipeTest implements RewriteTest {
             """
           ));
     }
+
+    @Test
+    void doNothingIfNoStyleConfigured() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            package com.example;
+
+            import org.apache.commons.lang3.StringUtils;
+            import java.util.Collections;
+            import static java.util.Collections.*;
+
+            class Test {}
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added regression test to verify that no default import order style is applied as a part of this issue:
- Closes https://github.com/openrewrite/rewrite-static-analysis/issues/574 

## Anyone you would like to review specifically?
@timtebeek 

## Additional Context
With this PR, we test the case where if no style is applied, the import order should not change.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
