### PR TITLE
(RSPEC-S2221) SpecifyGenericExceptionCatches recipe

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SpecifyGenericExceptionCatches.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SpecifyGenericExceptionCatches.java
@@ -1,0 +1,184 @@
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.JavaType.FullyQualified;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+public class SpecifyGenericExceptionCatches extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Replace `catch(Exception)` with specific exceptions thrown in the try block";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces `catch(Exception e)` blocks with a multi-catch block " +
+                "(`catch (SpecificException1 | SpecificException2 e)`) containing only the checked exceptions " +
+                "explicitly thrown by method or constructor invocations within the `try` block that are not " +
+                "already caught by more specific `catch` clauses. If no checked exceptions are found that " +
+                "require catching, the generic `catch` block is removed.";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.unmodifiableSet(new HashSet<>(Arrays.asList("CWE-396", "RSPEC-S2221")));
+    }
+
+    @Override
+    public JavaVisitor<ExecutionContext> getVisitor() {
+        return new GenericExceptionCatchVisitor();
+    }
+
+    private static class GenericExceptionCatchVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private static final String JAVA_LANG_EXCEPTION = "java.lang.Exception";
+        private static final String MULTI_CATCH_SEPARATOR = "|";
+        private static final String TRY_CATCH_TEMPLATE = "try {} catch (%s %s) {}";
+
+        @Override
+        public J.Try visitTry(J.Try aTry, ExecutionContext ctx) {
+            J.Try t = super.visitTry(aTry, ctx);
+
+            if (hasGenericCatch(t)) {
+                Set<JavaType> caughtExceptions = getCaughtExceptions(t);
+                Set<JavaType> thrownExceptions = getThrownExceptions(t);
+                thrownExceptions.removeAll(caughtExceptions); // Remove exceptions that are already specifically caught
+
+                if (!thrownExceptions.isEmpty()) {
+                    List<J.Try.Catch> updatedCatches = t.getCatches().stream()
+                            .map(c -> updateCatchIfGeneric(c, thrownExceptions))
+                            .collect(Collectors.toList());
+
+                    return t.withCatches(updatedCatches);
+                }
+            }
+
+            return t;
+        }
+
+        private static boolean isGenericCatch(J.Try.Catch aCatch) {
+            FullyQualified fq = TypeUtils.asFullyQualified(aCatch.getParameter().getType());
+            if (fq != null) {
+                String fqn = fq.getFullyQualifiedName();
+                return TypeUtils.fullyQualifiedNamesAreEqual(JAVA_LANG_EXCEPTION, fqn);
+            }
+            return false;
+        }
+
+        private boolean hasGenericCatch(J.Try aTry) {
+            for (J.Try.Catch c : aTry.getCatches()) {
+                if (isGenericCatch(c)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private Set<JavaType> getCaughtExceptions(J.Try aTry) {
+            Set<JavaType> caughtExceptions = new HashSet<>();
+
+            for (J.Try.Catch c : aTry.getCatches()) {
+                if (c.getParameter().getType() != null) {
+                    caughtExceptions.add(c.getParameter().getType());
+                }
+            }
+
+            return caughtExceptions;
+        }
+
+        /**
+         * Collects all checked exceptions that are explicitly thrown by method invocations
+         * and constructor calls within the try block.
+         *
+         * @param aTry the try block to analyze
+         * @return a set of exception types that may be thrown by code in the try block
+         */
+        private Set<JavaType> getThrownExceptions(J.Try aTry) {
+            Set<JavaType> thrownExceptions = new HashSet<>();
+            new JavaIsoVisitor<Set<JavaType>>() {
+                @Override
+                public J.NewClass visitNewClass(J.NewClass nc, Set<JavaType> set) {
+                    if (nc.getConstructorType() != null) {
+                        set.addAll(nc.getConstructorType().getThrownExceptions());
+                    }
+                    return super.visitNewClass(nc, set);
+                }
+
+                @Override
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, Set<JavaType> set) {
+                    if (mi.getMethodType() != null) {
+                        set.addAll(mi.getMethodType().getThrownExceptions());
+                    }
+                    return super.visitMethodInvocation(mi, set);
+                }
+            }.visit(aTry.getBody(), thrownExceptions);
+            return thrownExceptions;
+        }
+
+        /**
+         * Updates a generic catch block (catching java.lang.Exception) to catch only the specific
+         * exception types that are actually thrown within the try block.
+         *
+         * <p>This method transforms generic catch blocks like:
+         * <pre>{@code
+         * catch (Exception e) { ... }
+         * }</pre>
+         *
+         * into specific single or multi-catch blocks like:
+         * <pre>{@code
+         * catch (IOException e) { ... }
+         * // or
+         * catch (IOException | SQLException e) { ... }
+         * }</pre>
+         *
+         * @param aCatch the catch block to potentially update
+         * @param thrownExceptions the set of specific exception types thrown in the try block
+         *                        that are not already caught by other catch clauses
+         * @return the original catch block if it doesn't catch java.lang.Exception,
+         *         otherwise a new catch block with specific exception types
+         */
+        private J.Try.Catch updateCatchIfGeneric(J.Try.Catch aCatch, Set<JavaType> thrownExceptions) {
+            if (!isGenericCatch(aCatch)) {
+                return aCatch;
+            }
+
+            // Preserve the existing variable name from the original generic catch block
+            String variableName = aCatch.getParameter().getTree().getVariables().get(0).getSimpleName();
+
+            String throwableTypes = thrownExceptions.stream()
+                    .map(TypeUtils::asFullyQualified)
+                    .filter(Objects::nonNull)
+                    .sorted(Comparator.comparing(FullyQualified::getClassName))
+                    .map(FullyQualified::getFullyQualifiedName)
+                    .collect(Collectors.joining(MULTI_CATCH_SEPARATOR));
+
+            J.Try aTry = getCursor().firstEnclosing(J.Try.class);
+            assert aTry != null;
+
+            J.Try tempTry = JavaTemplate.builder(String.format(TRY_CATCH_TEMPLATE, throwableTypes, variableName))
+                    .contextSensitive()
+                    .build()
+                    .apply(
+                            new Cursor(getCursor(), aTry),
+                            aTry.getCoordinates().replace()
+                    );
+
+            J.ControlParentheses<J.VariableDeclarations> cp = tempTry.getCatches().get(0).getParameter();
+            doAfterVisit(ShortenFullyQualifiedTypeReferences.modifyOnly(cp.getTree()));
+            return aCatch.withParameter(cp);
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/SpecifyGenericExceptionCatchesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SpecifyGenericExceptionCatchesTest.java
@@ -1,0 +1,335 @@
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpecs;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SpecifyGenericExceptionCatchesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new SpecifyGenericExceptionCatches());
+    }
+
+    // Helper SourceSpecs for mock classes that throw checked exceptions
+    private static final SourceSpecs MOCK_THROWING_CLASS = java("""
+      package com.example;
+
+      public class MockThrowingClass {
+
+          public MockThrowingClass() {
+          }
+
+           public MockThrowingClass(boolean throwSQLException) throws java.sql.SQLException {
+              if (throwSQLException) {
+                  throw new java.sql.SQLException("Test Constructor SQL Exception");
+              }
+           }
+
+          public void throwsIOException() throws java.io.IOException {
+              throw new java.io.IOException("Test IO Exception");
+          }
+
+          public void throwsSQLException() throws java.sql.SQLException {
+              throw new java.sql.SQLException("Test SQL Exception");
+          }
+
+          public void throwsBothIOAndSQL() throws java.io.IOException, java.sql.SQLException {
+              throw new java.io.IOException("Test IO or SQL Exception");
+          }
+
+          public void throwsNothing() {
+              // This method throws no checked exceptions
+          }
+
+          public void throwsRuntimeException() throws RuntimeException {
+              throw new RuntimeException("Test Runtime Exception");
+          }
+      }
+      """);
+
+    @DocumentExample
+    @Test
+    void shouldReplaceExceptionWithSingleCheckedException() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsIOException();
+                  } catch (Exception e) {
+                      System.out.println("Caught exception: " + e.getMessage());
+                  }
+              }
+          }
+          """, """
+          package com.example;
+
+          import java.io.IOException;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsIOException();
+                  } catch (IOException e) {
+                      System.out.println("Caught exception: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldReplaceExceptionWithMultipleCheckedExceptions() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsIOException();
+                      new MockThrowingClass().throwsSQLException();
+                  } catch (Exception e) {
+                      System.out.println("Caught exception: " + e.getMessage());
+                  }
+              }
+          }
+          """, """
+          package com.example;
+
+          import java.io.IOException;
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsIOException();
+                      new MockThrowingClass().throwsSQLException();
+                  } catch (IOException | SQLException e) {
+                      System.out.println("Caught exception: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldReplaceExceptionWithMultipleCheckedExceptionsFromSingleCall() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsBothIOAndSQL();
+                  } catch (Exception e) {
+                      System.out.println("Caught exception: " + e.getMessage());
+                  }
+              }
+          }
+          """, """
+          package com.example;
+
+          import java.io.IOException;
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsBothIOAndSQL();
+                  } catch (IOException | SQLException e) {
+                      System.out.println("Caught exception: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldKeepSpecificCatchAndRemoveGenericWhenCovered() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          import java.io.IOException;
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsBothIOAndSQL();
+                  } catch (IOException e) {
+                      System.out.println("Caught IO: " + e.getMessage());
+                  } catch (Exception e) {
+                      System.out.println("Caught generic: " + e.getMessage());
+                  }
+              }
+          }
+          """, """
+          package com.example;
+
+          import java.io.IOException;
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsBothIOAndSQL();
+                  } catch (IOException e) {
+                      System.out.println("Caught IO: " + e.getMessage());
+                  } catch (SQLException e) {
+                      System.out.println("Caught generic: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldNotModifyWhenOnlySpecificCatchesExist() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          import java.io.IOException;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass().throwsIOException();
+                  } catch (IOException e) {
+                      System.out.println("Caught IO: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldNotModifyWhenNoCheckedExceptionIsThrown() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          public class MyService {
+              public void doSomething() {
+                  try {
+                      new MockThrowingClass(); // Nothing thrown
+                  } catch (Exception e) {
+                      System.out.println("Caught something unusual: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldHandleConstructorThrowingException() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          public class MyService {
+              public void createObject() {
+                  try {
+                      new MockThrowingClass(true); // Throws SQLException
+                  } catch (Exception e) {
+                      System.out.println("Caught constructor exception: " + e.getMessage());
+                  }
+              }
+          }
+          """, """
+          package com.example;
+
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void createObject() {
+                  try {
+                      new MockThrowingClass(true); // Throws SQLException
+                  } catch (SQLException e) {
+                      System.out.println("Caught constructor exception: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldHandleConstructorThrowingSpecificExceptionAndAnotherGenericCatch() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          import java.io.IOException;
+
+          public class MyService {
+              public void createAndHandle() {
+                  try {
+                      new MockThrowingClass(true); // Throws SQLException
+                      new MockThrowingClass().throwsIOException();
+                  } catch (Exception e) {
+                      System.out.println("Caught constructor exception: " + e.getMessage());
+                  }
+              }
+          }
+          """, """
+          package com.example;
+
+          import java.io.IOException;
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void createAndHandle() {
+                  try {
+                      new MockThrowingClass(true); // Throws SQLException
+                      new MockThrowingClass().throwsIOException();
+                  } catch (IOException | SQLException e) {
+                      System.out.println("Caught constructor exception: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+
+    @Test
+    void shouldHandleConstructorThrowingExceptionWithExistingSpecificCatch() {
+        rewriteRun(MOCK_THROWING_CLASS, java("""
+          package com.example;
+
+          import java.io.IOException;
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void createAndHandle() {
+                  try {
+                      new MockThrowingClass(true); // Throws SQLException
+                      new MockThrowingClass().throwsIOException();
+                  } catch (SQLException e) {
+                      System.out.println("Caught sql exception: " + e.getMessage());
+                  } catch (Exception e) {
+                      System.out.println("Caught generic: " + e.getMessage());
+                  }
+              }
+          }
+          """, """
+          package com.example;
+
+          import java.io.IOException;
+          import java.sql.SQLException;
+
+          public class MyService {
+              public void createAndHandle() {
+                  try {
+                      new MockThrowingClass(true); // Throws SQLException
+                      new MockThrowingClass().throwsIOException();
+                  } catch (SQLException e) {
+                      System.out.println("Caught sql exception: " + e.getMessage());
+                  } catch (IOException e) {
+                      System.out.println("Caught generic: " + e.getMessage());
+                  }
+              }
+          }
+          """));
+    }
+}


### PR DESCRIPTION
## Overview
Replaces generic `catch(Exception)` blocks with specific exception types that are actually thrown within the try block. This improves exception handling precision and code maintainability by catching only the exceptions that can actually occur.

## What's your motivation?
Generic exception catching with `catch(Exception e)` is considered a code smell (SonarQube rule [S2221](https://sonarsource.atlassian.net/browse/RSPEC-2221), [CWE-396](https://cwe.mitre.org/data/definitions/396.html)) because it masks specific error conditions and makes debugging harder. When developers write code that throws specific exceptions like `IOException` or `SQLException`, the catch blocks should reflect that specificity rather than using the overly broad `Exception` type.

## What it detects

* Generic `catch(Exception e)` blocks in try-catch statements
* Analyzes method calls and constructor invocations within try blocks to identify thrown exception types
* Generates appropriate single-catch or multi-catch syntax for those thrown exception types if not already caught by more specific catch clauses

**Before**:

```java
try {
    Files.readAllLines(path);
    connection.createStatement().executeQuery(sql);
} catch (Exception e) {
    log.error("Operation failed", e);
}
```

**After:**

```java
try {
    Files.readAllLines(path);
    connection.createStatement().executeQuery(sql);
} catch (IOException | SQLException e) {
    log.error("Operation failed", e);
}
```

## Anything in particular you'd like reviewers to focus on?

### Implementation approach
- **Exact matching**: The recipe specifically targets `java.lang.Exception` catches (not subclasses like `RuntimeException`) to be conservative about what constitutes "generic" exception handling
- **Multi-catch generation**: Uses JavaTemplate with complete try-catch syntax to properly parse multi-catch expressions with `|` separators
- Recipe name: feel free to suggest more suitable names

### Limitations
- **Static analysis only**: Relies on method/constructor signatures for thrown exceptions; doesn't perform data flow analysis for dynamically thrown exceptions
- **Checked exceptions focus**: Primarily improves handling of checked exceptions since those must be declared in method signatures

## Anyone you would like to review specifically?
@timtebeek

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [[recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files