### PR TITLE
Adding the nestedVariables test case

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -1670,4 +1670,39 @@ class InstanceOfPatternMatchTest implements RewriteTest {
         }
 
     }
+    @Test
+    void nestedVariables() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                public class A {
+                    Throwable wrap(Throwable cause) {
+                        if (cause instanceof Error) {
+                            if (cause instanceof OutOfMemoryError) {
+                                throw ((OutOfMemoryError) cause);
+                            }
+                            return (Error) cause;
+                        }
+                        return cause;
+                    }
+                }
+                """,
+              """
+                public class A {
+                    Throwable wrap(Throwable cause) {
+                        if (cause instanceof Error error1) {
+                            if (cause instanceof OutOfMemoryError error) {
+                                throw error;
+                            }
+                            return error1;
+                        }
+                        return cause;
+                    }
+                }
+                """
+            ), 17)
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Adding a new test case to `InstanceOfPatternMatchTest`.

## What's your motivation?

To show #531 is solved. After the recipe, the code is no longer invalid.
I suppose this has been fixed in #538.
