### PR TITLE
Place `Test` annotations first when reordering

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUID.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUID.java
@@ -50,8 +50,8 @@ public class AddSerialAnnotationToSerialVersionUID extends Recipe {
         return Duration.ofMinutes(1);
     }
 
-    @NonNull
     @Override
+    @NonNull
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 Preconditions.and(

--- a/src/main/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializable.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializable.java
@@ -34,8 +34,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class AddSerialVersionUidToSerializable extends Recipe {
 
     @Option(displayName = "New serial version UID",

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableMethods.java
@@ -31,8 +31,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class AnnotateNullableMethods extends Recipe {
 
     @Option(displayName = "`@Nullable` annotation class",

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableParameters.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableParameters.java
@@ -32,8 +32,8 @@ import org.openrewrite.staticanalysis.java.MoveFieldAnnotationToType;
 
 import java.util.*;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class AnnotateNullableParameters extends Recipe {
 
     private static final String DEFAULT_NULLABLE_ANN_CLASS = "org.jspecify.annotations.Nullable";

--- a/src/main/java/org/openrewrite/staticanalysis/CustomImportOrderVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CustomImportOrderVisitor.java
@@ -19,7 +19,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.CustomImportOrderStyle;
-import org.openrewrite.java.style.CustomImportOrderStyle.GroupWithDepth;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
@@ -29,8 +28,8 @@ import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.compile;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class CustomImportOrderVisitor<P> extends JavaIsoVisitor<P> {
     CustomImportOrderStyle style;
 

--- a/src/main/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVariance.java
+++ b/src/main/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVariance.java
@@ -32,8 +32,8 @@ import java.util.stream.Collectors;
 import static org.openrewrite.java.tree.J.Wildcard.Bound.Extends;
 import static org.openrewrite.java.tree.J.Wildcard.Bound.Super;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class DeclarationSiteTypeVariance extends Recipe {
 
     @Option(displayName = "Variant types",

--- a/src/main/java/org/openrewrite/staticanalysis/DefaultComesLastVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/DefaultComesLastVisitor.java
@@ -33,8 +33,8 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class DefaultComesLastVisitor<P> extends JavaIsoVisitor<P> {
     DefaultComesLastStyle style;
 

--- a/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EmptyBlockVisitor.java
@@ -38,8 +38,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class EmptyBlockVisitor<P> extends JavaIsoVisitor<P> {
     EmptyBlockStyle emptyBlockStyle;
     JavaTemplate continueStatement = JavaTemplate.builder("continue;").build();

--- a/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsAvoidsNull.java
@@ -33,8 +33,8 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class EqualsAvoidsNull extends Recipe {
 
     private static final String JAVA_LANG_STRING = "java.lang.String";

--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitCharsetOnStringGetBytes.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitCharsetOnStringGetBytes.java
@@ -25,8 +25,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class ExplicitCharsetOnStringGetBytes extends Recipe {
     private static final MethodMatcher GET_BYTES = new MethodMatcher("java.lang.String getBytes()");
 

--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitInitializationVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitInitializationVisitor.java
@@ -30,8 +30,8 @@ import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Iterator;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class ExplicitInitializationVisitor<P> extends JavaIsoVisitor<P> {
     private static final AnnotationMatcher LOMBOK_VALUE = new AnnotationMatcher("@lombok.Value");
     private static final AnnotationMatcher LOMBOK_BUILDER_DEFAULT = new AnnotationMatcher("@lombok.Builder.Default");

--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypes.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypes.java
@@ -164,13 +164,13 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
                 while (elemType instanceof JavaType.Array) {
                     elemType = ((JavaType.Array) elemType).getElemType();
                 }
-                
+
                 // Build the base type expression
                 TypeTree result = buildTypeTree(elemType, space);
                 if (result == null) {
                     return null;
                 }
-                
+
                 // Count dimensions and build array type
                 JavaType currentType = type;
                 while (currentType instanceof JavaType.Array) {

--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -35,8 +35,8 @@ import java.util.regex.Pattern;
 
 import static org.openrewrite.java.tree.J.Literal.isLiteralValue;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
     /**
      * Ignores any fall-through commented with a text matching the regex pattern.

--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeLocalVariables.java
@@ -95,8 +95,8 @@ public class FinalizeLocalVariables extends Recipe {
         };
     }
 
-    @Value
     @EqualsAndHashCode(callSuper = false)
+    @Value
     private static class FindAssignmentReferencesToVariable extends JavaIsoVisitor<AtomicBoolean> {
 
         J.VariableDeclarations.NamedVariable variable;

--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeMethodArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeMethodArguments.java
@@ -23,7 +23,10 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.marker.Markers;
 
 import java.util.List;
@@ -102,8 +105,8 @@ public class FinalizeMethodArguments extends Recipe {
         return method.getModifiers().stream().anyMatch(modifier -> modifier.getType() == J.Modifier.Type.Abstract);
     }
 
-    @Value
     @EqualsAndHashCode(callSuper = false)
+    @Value
     private static class FindAssignmentReferencesToVariable extends JavaIsoVisitor<AtomicBoolean> {
 
         J.VariableDeclarations.NamedVariable variable;

--- a/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
@@ -309,8 +309,8 @@ public class FinalizePrivateFields extends Recipe {
         }
     }
 
-    @Value
     @EqualsAndHashCode(callSuper = false)
+    @Value
     private static class FindLastIdentifier extends JavaIsoVisitor<List<J.Identifier>> {
 
         /**

--- a/src/main/java/org/openrewrite/staticanalysis/HiddenFieldVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/HiddenFieldVisitor.java
@@ -37,9 +37,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
 @Incubating(since = "7.6.0")
+@Value
 public class HiddenFieldVisitor<P> extends JavaIsoVisitor<P> {
     private static final Pattern NEXT_NAME_PATTERN = Pattern.compile("(.+)(\\d+)");
     HiddenFieldStyle style;

--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -40,9 +40,9 @@ import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER;
 
+@EqualsAndHashCode(callSuper = false)
 @Incubating(since = "7.36.0")
 @Value
-@EqualsAndHashCode(callSuper = false)
 public class InstanceOfPatternMatch extends Recipe {
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/MaskCreditCardNumbers.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MaskCreditCardNumbers.java
@@ -26,8 +26,8 @@ import org.openrewrite.java.tree.J;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class MaskCreditCardNumbers extends Recipe {
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/MethodNameCasing.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MethodNameCasing.java
@@ -34,8 +34,8 @@ import org.openrewrite.java.tree.TypeUtils;
 import java.time.Duration;
 import java.util.*;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class MethodNameCasing extends ScanningRecipe<List<MethodNameCasing.MethodNameChange>> {
 
     @Option(displayName = "Apply recipe to test source set",

--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -280,9 +280,9 @@ public class MinimumSwitchCases extends Recipe {
         return generatedIf;
     }
 
+    @AllArgsConstructor
     @Value
     @With
-    @AllArgsConstructor
     private static class DefaultOnly implements Marker {
         UUID id;
 

--- a/src/main/java/org/openrewrite/staticanalysis/MissingOverrideAnnotation.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MissingOverrideAnnotation.java
@@ -32,8 +32,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Set;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class MissingOverrideAnnotation extends Recipe {
     @Option(displayName = "Ignore methods in anonymous classes",
             description = "When enabled, ignore missing annotations on methods which override methods when the class definition is within an anonymous class.",

--- a/src/main/java/org/openrewrite/staticanalysis/NoFinalizedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoFinalizedLocalVariables.java
@@ -25,9 +25,9 @@ import org.openrewrite.java.tree.J;
 
 import java.util.Iterator;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
 @Incubating(since = "7.0.0")
+@Value
 public class NoFinalizedLocalVariables extends Recipe {
 
     @Option(displayName = "Exclude method parameters",

--- a/src/main/java/org/openrewrite/staticanalysis/OperatorWrap.java
+++ b/src/main/java/org/openrewrite/staticanalysis/OperatorWrap.java
@@ -30,8 +30,8 @@ import org.openrewrite.java.tree.TypeTree;
 
 import static java.util.Objects.requireNonNull;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class OperatorWrap extends Recipe {
 
     @Option(displayName = "Operator wrapping style",

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -33,9 +33,9 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
 @SuppressWarnings("ConstantConditions")
+@Value
 public class RemoveUnusedLocalVariables extends Recipe {
     @Incubating(since = "7.17.2")
     @Option(displayName = "Ignore matching variable names",
@@ -242,8 +242,8 @@ public class RemoveUnusedLocalVariables extends Recipe {
      * Take an assignment in a context other than a variable declaration, such as the arguments of a function invocation or if condition,
      * and remove the assignment, leaving behind the value being assigned.
      */
-    @Value
     @EqualsAndHashCode(callSuper = false)
+    @Value
     private static class PruneAssignmentExpression extends JavaIsoVisitor<ExecutionContext> {
         J.Assignment assignment;
 
@@ -263,8 +263,8 @@ public class RemoveUnusedLocalVariables extends Recipe {
         }
     }
 
-    @Value
     @EqualsAndHashCode(callSuper = false)
+    @Value
     private static class AssignmentToLiteral extends JavaVisitor<ExecutionContext> {
         J.Assignment assignment;
 

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateFields.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateFields.java
@@ -33,8 +33,8 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class RemoveUnusedPrivateFields extends Recipe {
     private static final AnnotationMatcher LOMBOK_ANNOTATION = new AnnotationMatcher("@lombok.*");
 

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -29,8 +29,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class ReorderAnnotations extends Recipe {
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -68,6 +68,7 @@ public class ReorderAnnotations extends Recipe {
                 }
                 return 0;
             })
+            .thenComparing(a -> a.getSimpleName().endsWith("Test")? -1 : 0) // Ensure test annotations are ordered first
             .thenComparing(J.Annotation::getSimpleName);
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiterals.java
@@ -35,8 +35,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class ReplaceDuplicateStringLiterals extends Recipe {
 
     @Option(displayName = "Apply recipe to test source set",
@@ -288,8 +288,8 @@ public class ReplaceDuplicateStringLiterals extends Recipe {
     /**
      * ReplaceStringLiterals in a class with a reference to a `private static final String` with the provided variable name.
      */
-    @Value
     @EqualsAndHashCode(callSuper = false)
+    @Value
     private static class ReplaceStringLiterals extends JavaVisitor<ExecutionContext> {
         J.ClassDeclaration isClass;
         Map<J.Literal, String> replacements;

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceOptionalIsPresentWithIfPresent.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceOptionalIsPresentWithIfPresent.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class ReplaceOptionalIsPresentWithIfPresent extends Recipe {
     private static final MethodMatcher OPTIONAL_IS_PRESENT = new MethodMatcher("java.util.Optional isPresent()");
     private static final MethodMatcher OPTIONAL_GET = new MethodMatcher("java.util.Optional get()");
@@ -231,8 +231,8 @@ public class ReplaceOptionalIsPresentWithIfPresent extends Recipe {
         }
     }
 
-    @Value
     @EqualsAndHashCode(callSuper = false)
+    @Value
     public static class ReplaceMethodCallWithVariableVisitor extends JavaVisitor<ExecutionContext> {
         J.Identifier lambdaParameterIdentifier;
         J.Identifier methodSelector;

--- a/src/main/java/org/openrewrite/staticanalysis/SortedSetStreamToLinkedHashSet.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SortedSetStreamToLinkedHashSet.java
@@ -27,8 +27,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class SortedSetStreamToLinkedHashSet extends Recipe {
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/URLEqualsHashCode.java
+++ b/src/main/java/org/openrewrite/staticanalysis/URLEqualsHashCode.java
@@ -22,13 +22,13 @@ import org.openrewrite.java.template.RecipeDescriptor;
 import java.net.URI;
 import java.net.URL;
 
-@SuppressWarnings("UrlHashCode")
 @RecipeDescriptor(
         name = "URL Equals and Hash Code",
         description = "Uses of `equals()` and `hashCode()` cause `java.net.URL` to make blocking internet connections. " +
                       "Instead, use `java.net.URI`.",
         tags = {"RSPEC-2112"}
 )
+@SuppressWarnings("UrlHashCode")
 public class URLEqualsHashCode {
 
     @RecipeDescriptor(

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
@@ -32,8 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class UnnecessaryCatch extends Recipe {
 
     @Option(displayName = "Include `java.lang.Exception`",

--- a/src/main/java/org/openrewrite/staticanalysis/UseAsBuilder.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseAsBuilder.java
@@ -30,8 +30,8 @@ import java.util.*;
 import static org.openrewrite.Validated.notBlank;
 import static org.openrewrite.java.format.TabsAndIndents.formatTabsAndIndents;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class UseAsBuilder extends Recipe {
     @Option(
             displayName = "Builder Type",

--- a/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
@@ -29,8 +29,8 @@ import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
-@Value
 @EqualsAndHashCode(callSuper = false)
+@Value
 public class MoveFieldAnnotationToType extends Recipe {
 
     @Option(displayName = "Annotation type",

--- a/src/test/java/org/openrewrite/staticanalysis/AbstractClassPublicConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AbstractClassPublicConstructorTest.java
@@ -31,8 +31,8 @@ class AbstractClassPublicConstructorTest implements RewriteTest {
         spec.recipe(new AbstractClassPublicConstructor());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replacePublicByProtected() {
         rewriteRun(
           //language=java
@@ -83,8 +83,8 @@ class AbstractClassPublicConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/449")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/449")
     void noReplaceOnNestedClasses() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUIDTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AddSerialAnnotationToSerialVersionUIDTest.java
@@ -32,8 +32,8 @@ class AddSerialAnnotationToSerialVersionUIDTest implements RewriteTest {
           .allSources(sourceSpec -> sourceSpec.markers(javaVersion(17)));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void addSerialAnnotation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializableTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AddSerialVersionUidToSerializableTest.java
@@ -30,8 +30,8 @@ class AddSerialVersionUidToSerializableTest implements RewriteTest {
         spec.recipe(new AddSerialVersionUidToSerializable(null));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void addSerialVersionUID() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableMethodsTest.java
@@ -32,8 +32,8 @@ class AnnotateNullableMethodsTest implements RewriteTest {
           .recipe(new AnnotateNullableMethods(null));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void methodReturnsNullLiteral() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableParametersTest.java
@@ -37,8 +37,8 @@ class AnnotateNullableParametersTest implements RewriteTest {
 
     @Nested
     class SimpleNullComparison {
-        @DocumentExample
         @Test
+        @DocumentExample
         void singleEqualsNullCase() {
             rewriteRun(
               //language=java
@@ -331,12 +331,12 @@ class AnnotateNullableParametersTest implements RewriteTest {
     @Nested
     class KnownNullCheckers {
 
+        @ParameterizedTest
         @CsvSource({
           "java.util.Objects, Objects.nonNull",
           "org.apache.commons.lang3.StringUtils, StringUtils.isNotBlank",
           "org.apache.commons.lang3.StringUtils, StringUtils.isNotEmpty",
         })
-        @ParameterizedTest
         void knownMethodsPositiveInvocation(String pkg, String methodCall) {
             rewriteRun(
               //language=java
@@ -375,12 +375,12 @@ class AnnotateNullableParametersTest implements RewriteTest {
             );
         }
 
+        @ParameterizedTest
         @CsvSource({
           "java.util.Objects, Objects.isNull",
           "org.apache.commons.lang3.StringUtils, StringUtils.isBlank",
           "org.apache.commons.lang3.StringUtils, StringUtils.isEmpty",
         })
-        @ParameterizedTest
         void knownMethodsNegatedUnary(String pkg, String methodCall) {
             rewriteRun(
               //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/AtomicPrimitiveEqualsUsesGetTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AtomicPrimitiveEqualsUsesGetTest.java
@@ -29,8 +29,8 @@ class AtomicPrimitiveEqualsUsesGetTest implements RewriteTest {
         spec.recipe(new AtomicPrimitiveEqualsUsesGet());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void usesEquals() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/AvoidBoxedBooleanExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AvoidBoxedBooleanExpressionsTest.java
@@ -29,8 +29,8 @@ class AvoidBoxedBooleanExpressionsTest implements RewriteTest {
         spec.recipe(new AvoidBoxedBooleanExpressions());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void guardAgainstNpe() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/BigDecimalDoubleConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/BigDecimalDoubleConstructorTest.java
@@ -30,8 +30,8 @@ class BigDecimalDoubleConstructorTest implements RewriteTest {
         spec.recipe(new BigDecimalDoubleConstructorRecipe());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void bigDecimalDoubleConstructor() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/BigDecimalRoundingConstantsToEnumsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/BigDecimalRoundingConstantsToEnumsTest.java
@@ -29,9 +29,9 @@ class BigDecimalRoundingConstantsToEnumsTest implements RewriteTest {
         spec.recipe(new BigDecimalRoundingConstantsToEnums());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings({"deprecation", "ResultOfMethodCallIgnored"})
-    @Test
     void bigDecimalRoundingChangeRoundingMode() {
         rewriteRun(
           //language=java
@@ -71,8 +71,8 @@ class BigDecimalRoundingConstantsToEnumsTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     void bigDecimalRoundingNoChange() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/BooleanChecksNotInvertedTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/BooleanChecksNotInvertedTest.java
@@ -24,9 +24,9 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings("DoubleNegation")
 class BooleanChecksNotInvertedTest implements RewriteTest {
 
+    @Test
     @DocumentExample
     @SuppressWarnings("StatementWithEmptyBody")
-    @Test
     void rspec1940() {
         rewriteRun(
           spec -> spec.recipe(new BooleanChecksNotInverted()),

--- a/src/test/java/org/openrewrite/staticanalysis/BufferedWriterCreationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/BufferedWriterCreationTest.java
@@ -30,8 +30,8 @@ class BufferedWriterCreationTest implements RewriteTest {
         spec.recipe(new BufferedWriterCreationRecipes());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void bufferedReaderCreation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CaseInsensitiveComparisonsDoNotChangeCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CaseInsensitiveComparisonsDoNotChangeCaseTest.java
@@ -29,8 +29,8 @@ class CaseInsensitiveComparisonsDoNotChangeCaseTest implements RewriteTest {
         spec.recipe(new CaseInsensitiveComparisonsDoNotChangeCase());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void argIsToLowerCase() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CatchClauseOnlyRethrowsTest.java
@@ -30,8 +30,8 @@ class CatchClauseOnlyRethrowsTest implements RewriteTest {
         spec.recipe(new CatchClauseOnlyRethrows());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void tryCanBeRemoved() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ChainStringBuilderAppendCallsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ChainStringBuilderAppendCallsTest.java
@@ -29,8 +29,8 @@ class ChainStringBuilderAppendCallsTest implements RewriteTest {
         spec.recipe(new ChainStringBuilderAppendCalls());
     }
 
-    @DocumentExample(value = "Chain `StringBuilder.append()` calls instead of the '+' operator to efficiently concatenate strings and numbers.")
     @Test
+    @DocumentExample(value = "Chain `StringBuilder.append()` calls instead of the '+' operator to efficiently concatenate strings and numbers.")
     void objectsConcatenation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
@@ -143,9 +143,9 @@ class CombineSemanticallyEqualCatchBlocksTest implements RewriteTest {
         );
     }
 
+    @Test
     @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/506")
-    @Test
     void combineSameSemanticallyEquivalentMethodTypes() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CommonStaticAnalysisIssuesPerformanceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CommonStaticAnalysisIssuesPerformanceTest.java
@@ -34,8 +34,8 @@ class CommonStaticAnalysisIssuesPerformanceTest implements RewriteTest {
 //          });
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void indexOfOnList() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CompareEnumsWithEqualityOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CompareEnumsWithEqualityOperatorTest.java
@@ -39,8 +39,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         """
     );
 
-    @SuppressWarnings("StatementWithEmptyBody")
     @Test
+    @SuppressWarnings("StatementWithEmptyBody")
     void changeEnumEquals() {
         rewriteRun(
           enumA,
@@ -72,8 +72,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("StatementWithEmptyBody")
     @Test
+    @SuppressWarnings("StatementWithEmptyBody")
     void changeEnumNotEquals() {
         rewriteRun(
           enumA,
@@ -105,8 +105,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("StatementWithEmptyBody")
     @Test
+    @SuppressWarnings("StatementWithEmptyBody")
     void changeEnumNotEqualsWithParentheses() {
         rewriteRun(
           enumA,
@@ -134,8 +134,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/support-public/issues/28")
     @Test
+    @Issue("https://github.com/moderneinc/support-public/issues/28")
     void equals() {
         rewriteRun(
           //language=java
@@ -167,8 +167,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
           ));
     }
 
-    @Issue("https://github.com/moderneinc/support-public/issues/28")
     @Test
+    @Issue("https://github.com/moderneinc/support-public/issues/28")
     void notEquals() {
         rewriteRun(
           //language=java
@@ -200,8 +200,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
           ));
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/143")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/143")
     void noSelect() {
         rewriteRun(
           //language=java
@@ -219,9 +219,9 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/moderneinc/customer-requests/issues/190")
     @SuppressWarnings("StatementWithEmptyBody")
-    @Test
     void changeEnumInsideBooleanExpression() {
         rewriteRun(
           enumA,
@@ -249,8 +249,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     void lambda() {
         rewriteRun(
           enumA,
@@ -292,8 +292,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     void notLambda() {
         rewriteRun(
           enumA,
@@ -335,8 +335,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     void ternaryExpression() {
         rewriteRun(
           enumA,
@@ -368,8 +368,8 @@ class CompareEnumsWithEqualityOperatorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/513")
     void notTernaryExpression() {
         rewriteRun(
           enumA,

--- a/src/test/java/org/openrewrite/staticanalysis/ControlFlowIndentationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ControlFlowIndentationTest.java
@@ -31,9 +31,9 @@ class ControlFlowIndentationTest implements RewriteTest {
         spec.recipe(new ControlFlowIndentation());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings({"SuspiciousIndentAfterControlStatement", "IfStatementWithIdenticalBranches"})
-    @Test
     void removesIndentationFromStatementAfterIfElse() {
         rewriteRun(
           //language=java
@@ -68,9 +68,9 @@ class ControlFlowIndentationTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2277")
     @SuppressWarnings("SuspiciousIndentAfterControlStatement")
-    @Test
     void removesIndentationFromStatementAroundIf() {
         rewriteRun(
           //language=java
@@ -109,8 +109,8 @@ class ControlFlowIndentationTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("DuplicateCondition")
     @Test
+    @SuppressWarnings("DuplicateCondition")
     void leavesIndentationAloneWhenBlocksAreExplicit() {
         rewriteRun(
           //language=java
@@ -172,8 +172,8 @@ class ControlFlowIndentationTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("SuspiciousIndentAfterControlStatement")
     @Test
+    @SuppressWarnings("SuspiciousIndentAfterControlStatement")
     void removesIndentationFromStatementAfterLoop() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CovariantEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CovariantEqualsTest.java
@@ -30,8 +30,8 @@ class CovariantEqualsTest implements RewriteTest {
         spec.recipe(new CovariantEquals());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceWithNonCovariantEquals() {
         rewriteRun(
           //language=java
@@ -62,8 +62,8 @@ class CovariantEqualsTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
+    @SuppressWarnings("UnnecessaryLocalVariable")
     void replaceMultiStatementReturnBody() {
         rewriteRun(
           //language=java
@@ -155,8 +155,8 @@ class CovariantEqualsTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
+    @SuppressWarnings("UnnecessaryLocalVariable")
     void replaceEqualsMaintainsExistingAnnotations() {
         rewriteRun(
           //language=java
@@ -189,8 +189,8 @@ class CovariantEqualsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/653")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/653")
     void replaceWithNonCovariantEqualsWhenNested() {
         rewriteRun(
           //language=java
@@ -298,8 +298,8 @@ class CovariantEqualsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2775")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2775")
     void equalsInInterface() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/CustomImportOrderRecipeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CustomImportOrderRecipeTest.java
@@ -39,8 +39,8 @@ class CustomImportOrderRecipeTest implements RewriteTest {
         spec.recipe(new CustomImportOrder());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void ordersStaticThenStandardThenThirdPartyWithNoGroupBlankLine() {
         rewriteRun(
           customImportOrder(style -> style.withSeparateLineBetweenGroups(false)),

--- a/src/test/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVarianceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVarianceTest.java
@@ -38,8 +38,8 @@ class DeclarationSiteTypeVarianceTest implements RewriteTest {
         ));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void inOutVariance() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
@@ -40,8 +40,8 @@ class DefaultComesLastTest implements RewriteTest {
         spec.recipe(new DefaultComesLast());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void moveDefaultToLastAlongWithItsStatementsAndAddBreakIfNecessary() {
         rewriteRun(
           //language=java
@@ -332,9 +332,9 @@ class DefaultComesLastTest implements RewriteTest {
         );
     }
 
+    @Test
     @EnabledForJreRange(min = JRE.JAVA_21)
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/461")
-    @Test
     void exhaustiveSwitch() {
         //language=java
         rewriteRun(
@@ -354,8 +354,8 @@ class DefaultComesLastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     void moveDefaultToLastWithFallThrough() {
         rewriteRun(
           //language=java
@@ -396,8 +396,8 @@ class DefaultComesLastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     void dontMoveDefaultToLastWithFallThroughAndStatements() {
         rewriteRun(
           //language=java
@@ -425,8 +425,8 @@ class DefaultComesLastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     void dontMoveDefaultToLastFromMiddleWithFallThroughAndStatements() {
         rewriteRun(
           //language=java
@@ -454,8 +454,8 @@ class DefaultComesLastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     void moveFallThroughBlockWithDefaultWithStatements() {
         rewriteRun(
           //language=java
@@ -503,8 +503,8 @@ class DefaultComesLastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/4")
     void moveFallThroughBlockWithDefaultWithoutStatements() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EmptyBlockTest.java
@@ -35,9 +35,9 @@ class EmptyBlockTest implements RewriteTest {
         spec.recipe(new EmptyBlock());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("ClassInitializerMayBeStatic")
-    @Test
     void emptySwitch() {
         rewriteRun(
           //language=java
@@ -78,8 +78,8 @@ class EmptyBlockTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("EmptySynchronizedStatement")
     @Test
+    @SuppressWarnings("EmptySynchronizedStatement")
     void emptySynchronized() {
         rewriteRun(
           //language=java
@@ -175,8 +175,8 @@ class EmptyBlockTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("RedundantFileCreation")
     @Test
+    @SuppressWarnings("RedundantFileCreation")
     void emptyCatchBlockWithExceptionAndEmptyFinally() {
         rewriteRun(
           //language=java
@@ -264,8 +264,8 @@ class EmptyBlockTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnusedAssignment")
     @Test
+    @SuppressWarnings("UnusedAssignment")
     void extractSideEffectsFromEmptyIfsWithNoElse() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsAvoidsNullTest.java
@@ -33,8 +33,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
         spec.recipe(new EqualsAvoidsNull());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void invertConditional() {
         rewriteRun(
           //language=java
@@ -158,12 +158,12 @@ class EqualsAvoidsNullTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Nested
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     class ReplaceConstantMethodArg {
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/398")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/398")
         void one() {
             rewriteRun(
               // language=java
@@ -364,8 +364,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
             );
         }
 
-        @Disabled("Not yet supported")
         @Test
+        @Disabled("Not yet supported")
         void lambdaGenerics() {
             rewriteRun(
               //language=java
@@ -447,8 +447,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/434")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/434")
         void missingWhitespace() {
             rewriteRun(
               // language=java
@@ -476,8 +476,8 @@ class EqualsAvoidsNullTest implements RewriteTest {
         }
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/442")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/442")
     void retainCompareToAsToNotChangeOrder() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/EqualsToContentEqualsTest.java
@@ -31,8 +31,8 @@ class EqualsToContentEqualsTest implements RewriteTest {
           .recipe(new EqualsToContentEquals());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceStringBuilder() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitCharsetOnStringGetBytesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitCharsetOnStringGetBytesTest.java
@@ -23,9 +23,9 @@ import static org.openrewrite.java.Assertions.java;
 
 class ExplicitCharsetOnStringGetBytesTest implements RewriteTest {
 
+    @Test
     @DocumentExample
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Test
     void addUtf8() {
         rewriteRun(
           spec -> spec.recipe(new ExplicitCharsetOnStringGetBytes(null)),

--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
@@ -31,8 +31,8 @@ class ExplicitInitializationTest implements RewriteTest {
         spec.recipe(new ExplicitInitialization());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeExplicitInitialization() {
         rewriteRun(
           //language=java
@@ -116,8 +116,8 @@ class ExplicitInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/101")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/101")
     void ignoreLombokValueField() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),
@@ -196,8 +196,8 @@ class ExplicitInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/109")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/109")
     void removeExplicitInitializationInAnonymousSubClasses() {
         rewriteRun(
           //language=java
@@ -254,8 +254,8 @@ class ExplicitInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/109")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/109")
     void ignoreInAnonymousSubClasses() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypesTest.java
@@ -36,8 +36,8 @@ class ExplicitLambdaArgumentTypesTest implements RewriteTest {
         spec.recipe(new ExplicitLambdaArgumentTypes());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void twoArgumentsWithBlock() {
         rewriteRun(
           //language=java
@@ -74,8 +74,8 @@ class ExplicitLambdaArgumentTypesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1459")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1459")
     void unknownArgumentType() {
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.builder().identifiers(false).methodDeclarations(false).build()),
@@ -615,8 +615,8 @@ class ExplicitLambdaArgumentTypesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2177")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2177")
     void extendsConstraint() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ExternalizableHasNoArgConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExternalizableHasNoArgConstructorTest.java
@@ -30,9 +30,9 @@ class ExternalizableHasNoArgConstructorTest implements RewriteTest {
         spec.recipe(new ExternalizableHasNoArgsConstructor());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("ExternalizableWithoutPublicNoArgConstructor")
-    @Test
     void needsNoArgsConstructor() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -37,8 +37,8 @@ class FallThroughTest implements RewriteTest {
         spec.recipe(new FallThrough());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void addBreakWhenPreviousCaseHasCodeButLacksBreak() {
         rewriteRun(
           //language=java
@@ -74,8 +74,8 @@ class FallThroughTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/173")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/173")
     void switchInSwitch() {
         //language=java
         rewriteRun(
@@ -270,9 +270,9 @@ class FallThroughTest implements RewriteTest {
         );
     }
 
+    @Test
     @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/229")
-    @Test
     void switchAsLastStatement() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
@@ -30,8 +30,8 @@ class FinalClassTest implements RewriteTest {
         spec.recipe(new FinalClass());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void finalizeClass() {
         rewriteRun(
           //language=java
@@ -58,8 +58,8 @@ class FinalClassTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2954")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2954")
     void nestedClassWithSubclass() {
         rewriteRun(
           //language=java
@@ -143,8 +143,8 @@ class FinalClassTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1061")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1061")
     void abstractClass() {
         rewriteRun(
           //language=java
@@ -162,8 +162,8 @@ class FinalClassTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2339")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2339")
     void classWithAnnotation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeLocalVariablesTest.java
@@ -32,8 +32,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         spec.recipe(new FinalizeLocalVariables());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void localVariablesAreMadeFinal() {
         rewriteRun(
           //language=java
@@ -60,8 +60,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1478")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1478")
     void initializedInWhileLoop() {
         rewriteRun(
           //language=java
@@ -156,8 +156,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/549")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/549")
     void catchBlocksIgnored() {
         rewriteRun(
           //language=java
@@ -274,8 +274,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1357")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1357")
     void forLoopVariablesIgnored() {
         rewriteRun(
           //language=java
@@ -391,8 +391,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2956")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2956")
     void recordShouldNotIntroduceExtraClosingParenthesis() {
         rewriteRun(
           version(
@@ -442,8 +442,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/181")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/181")
     void shouldNotFinalizeVariablesWhichAreAssignedInAnonymousClasses() {
         this.rewriteRun(
           // language=java
@@ -464,8 +464,8 @@ class FinalizeLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/359")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/359")
     void initializedInTryWithResources() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
@@ -31,8 +31,8 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
         spec.recipe(new FinalizeMethodArguments());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceWithFinalModifier() {
         rewriteRun(
           //language=java
@@ -53,8 +53,8 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/3133")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3133")
     void twoParameters() {
         rewriteRun(
           //language=java
@@ -77,8 +77,8 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/3135")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3135")
     void ignoreAbstractMethod() {
         rewriteRun(
           //language=java
@@ -210,8 +210,8 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/176")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/176")
     void doNotReplaceIfAssignedThroughUnaryOrAccumulator() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
@@ -34,8 +34,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         spec.recipe(new FinalizePrivateFields());
     }
 
-    @DocumentExample("Finalize private field.")
     @Test
+    @DocumentExample("Finalize private field.")
     void fieldWithInitializerMadeFinal() {
         rewriteRun(
           //language=java
@@ -138,8 +138,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2807")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2807")
     void fieldAssignedInConstructorMightHaveBeenNotInitializedIgnored() {
         rewriteRun(
           //language=java
@@ -398,8 +398,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Disabled("Doesn't support multiple constructors, to be enhanced")
     @Test
+    @Disabled("Doesn't support multiple constructors, to be enhanced")
     void fieldAssignedInAllAlternateConstructors() {
         rewriteRun(
           //language=java
@@ -434,8 +434,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Disabled("Doesn't support if-else conditions analysis, to be enhanced.")
     @Test
+    @Disabled("Doesn't support if-else conditions analysis, to be enhanced.")
     void fieldAssignedInIfElseStatementsInConstructor() {
         rewriteRun(
           //language=java
@@ -470,9 +470,9 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
+    @Test
     @Disabled("Multi constructors ignored")
     @Issue("https://github.com/openrewrite/rewrite/issues/2865")
-    @Test
     void fieldAssignedIndirectlyInAllAlternateConstructors() {
         rewriteRun(
           //language=java
@@ -819,8 +819,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2865")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2865")
     void additionalConstructorIgnored() {
         rewriteRun(
           //language=java
@@ -841,8 +841,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/121")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/121")
     void mustNotChangeVolatileFields() {
         //language=java
         rewriteRun(
@@ -861,8 +861,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/177")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/177")
     void staticFieldAssignedInConstructorNotMadeFinal() {
         //language=java
         rewriteRun(
@@ -879,8 +879,8 @@ class FinalizePrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/177")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/177")
     void staticFieldAssignedInBlockNotMadeFinal() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
@@ -30,8 +30,8 @@ class FixStringFormatExpressionsTest implements RewriteTest {
         spec.recipe(new FixStringFormatExpressions());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void newLineFormat() {
         rewriteRun(
           //language=java
@@ -98,8 +98,8 @@ class FixStringFormatExpressionsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/260")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/260")
     void escapedNewline() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ForLoopControlVariablePostfixOperatorsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ForLoopControlVariablePostfixOperatorsTest.java
@@ -29,8 +29,8 @@ class ForLoopControlVariablePostfixOperatorsTest implements RewriteTest {
         spec.recipe(new ForLoopControlVariablePostfixOperators());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void forLoopPostfixInductionVariableCounter() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdateTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdateTest.java
@@ -28,9 +28,9 @@ class ForLoopIncrementInUpdateTest implements RewriteTest {
         spec.recipe(new ForLoopIncrementInUpdate());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("StatementWithEmptyBody")
-    @Test
     void moveIncrementToUpdate() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/HiddenFieldTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/HiddenFieldTest.java
@@ -40,8 +40,8 @@ class HiddenFieldTest implements RewriteTest {
         spec.recipe(new HiddenField());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void constructorParameter() {
         rewriteRun(
           hiddenFieldStyle(style -> style.withIgnoreConstructorParameter(false)),
@@ -304,8 +304,8 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("ConstantValue")
     @Test
+    @SuppressWarnings("ConstantValue")
     void tryResources() {
         rewriteRun(
           //language=java
@@ -340,8 +340,8 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings({"EmptyTryBlock", "CatchMayIgnoreException", "TryWithIdenticalCatches"})
     @Test
+    @SuppressWarnings({"EmptyTryBlock", "CatchMayIgnoreException", "TryWithIdenticalCatches"})
     void catchClause() {
         rewriteRun(
           //language=java
@@ -376,8 +376,8 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings({"Convert2MethodRef", "ResultOfMethodCallIgnored"})
     @Test
+    @SuppressWarnings({"Convert2MethodRef", "ResultOfMethodCallIgnored"})
     void lambdaWithTypedParameterHides() {
         rewriteRun(
           //language=java
@@ -549,8 +549,8 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnusedAssignment")
     @Test
+    @SuppressWarnings("UnusedAssignment")
     void ignoreStaticMethodsAndInitializers() {
         rewriteRun(
           //language=java
@@ -695,8 +695,8 @@ class HiddenFieldTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1129")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1129")
     void ignoreVoidSettersAndSettersThatReturnItsClass() {
         rewriteRun(
           hiddenFieldStyle(style -> style.withIgnoreSetter(true).withSetterCanReturnItsClass(true)),

--- a/src/test/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorTest.java
@@ -44,8 +44,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
     /**
      * Should be a utility class since all methods are static, but class has public constructor
      */
-    @DocumentExample
     @Test
+    @DocumentExample
     void changePublicConstructorToPrivate() {
         rewriteRun(
           //language=java
@@ -72,9 +72,9 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1780")
     @SuppressWarnings("UnnecessaryModifier")
-    @Test
     void doNotAddConstructorToInterface() {
         rewriteRun(
           //language=java
@@ -255,8 +255,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/538")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/538")
     void ignoreClassesWithMainMethod() {
         rewriteRun(
           //language=java
@@ -489,8 +489,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1060")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1060")
     void identifyAbstractClass() {
         rewriteRun(
           //language=java
@@ -611,8 +611,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1058")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1058")
     void doesNotChangePackagePrivateEnumConstructorToPrivate() {
         rewriteRun(
           //language=java
@@ -632,8 +632,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1058")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1058")
     void enumClass() {
         rewriteRun(
           //language=java
@@ -650,8 +650,8 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1058")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1058")
     void emptyRecord() {
         rewriteRun(
           version(java(

--- a/src/test/java/org/openrewrite/staticanalysis/IndexOfChecksShouldUseAStartPositionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/IndexOfChecksShouldUseAStartPositionTest.java
@@ -29,8 +29,8 @@ class IndexOfChecksShouldUseAStartPositionTest implements RewriteTest {
         spec.recipe(new IndexOfChecksShouldUseAStartPosition());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void changeLhsWithLiteral() {
         rewriteRun(
           //language=java
@@ -69,8 +69,8 @@ class IndexOfChecksShouldUseAStartPositionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1225")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1225")
     void intentIsStringDoesNotStartWithSearchString() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/IndexOfReplaceableByContainsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/IndexOfReplaceableByContainsTest.java
@@ -28,8 +28,8 @@ class IndexOfReplaceableByContainsTest implements RewriteTest {
         spec.recipe(new IndexOfReplaceableByContains());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void stringIndexOfReplaceableByContains() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/IndexOfShouldNotCompareGreaterThanZeroTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/IndexOfShouldNotCompareGreaterThanZeroTest.java
@@ -29,8 +29,8 @@ class IndexOfShouldNotCompareGreaterThanZeroTest implements RewriteTest {
         spec.recipe(new IndexOfShouldNotCompareGreaterThanZero());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void indexOfOnList() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
@@ -29,9 +29,9 @@ class InlineVariableTest implements RewriteTest {
         spec.recipe(new InlineVariable());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings({"UnnecessaryLocalVariable", "CodeBlock2Expr", "Convert2MethodRef"})
-    @Test
     void inlineVariable() {
         rewriteRun(
           //language=java
@@ -103,8 +103,8 @@ class InlineVariableTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
+    @SuppressWarnings("UnnecessaryLocalVariable")
     void preserveComments() {
         rewriteRun(
           //language=java
@@ -167,9 +167,9 @@ class InlineVariableTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3201")
     @SuppressWarnings("UnnecessaryLocalVariable")
-    @Test
     void preserveComment() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -526,8 +526,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite/issues/2787")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite/issues/2787")
         void nestedPotentiallyConflictingIfs() {
             rewriteRun(
               //language=java
@@ -560,8 +560,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/481")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/481")
         void conflictingWithLocalVariable() {
             rewriteRun(
               //language=java
@@ -604,8 +604,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/334")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/334")
         void conflictingWithOtherInstanceOf() {
             rewriteRun(
               //language=java
@@ -766,8 +766,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/174")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/174")
         void ifTwoDifferentInstanceOf() {
             rewriteRun(
               version(
@@ -798,8 +798,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/174")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/174")
         void ifTwoDifferentInstanceOfWithParentheses() {
             rewriteRun(
               version(
@@ -831,8 +831,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
         }
     }
 
-    @SuppressWarnings({"CastCanBeRemovedNarrowingVariableType", "ClassInitializerMayBeStatic"})
     @Nested
+    @SuppressWarnings({"CastCanBeRemovedNarrowingVariableType", "ClassInitializerMayBeStatic"})
     class Ternary {
 
         @Test
@@ -932,8 +932,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/265")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/265")
         void multipleCastsInDifferentOperands() {
             rewriteRun(
               //language=java
@@ -1006,8 +1006,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
         void castTypeIsSuperType() {
             rewriteRun(
               //language=java
@@ -1027,8 +1027,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/572")
         void castTypeIsSubType() {
             rewriteRun(
               //language=java
@@ -1138,8 +1138,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Nested
+    @SuppressWarnings("unchecked")
     class Generics {
         @Test
         void wildcardInstanceOf() {
@@ -1251,8 +1251,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/482")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/482")
         void castTooSpecific() {
             rewriteRun(
               version(
@@ -1307,8 +1307,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/308")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/308")
         void passBareTypeToParameterizedMethod() {
             rewriteRun(
               version(
@@ -1376,8 +1376,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
         }
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Nested
+    @SuppressWarnings({"unchecked", "rawtypes"})
     class Various {
         @Test
         void unaryWithoutSideEffects() {
@@ -1476,8 +1476,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/483")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/483")
         void classVariableShadowing() {
             rewriteRun(
               version(
@@ -1513,8 +1513,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/484")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/484")
         void enumPatternMatch() {
             rewriteRun(
               version(
@@ -1548,8 +1548,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/528")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/528")
         void matchingPrimitiveVariableInBody() {
             rewriteRun(
               version(
@@ -1579,8 +1579,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/532")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/532")
         void varVariableDeclaration() {
             rewriteRun(
               version(
@@ -1639,8 +1639,8 @@ class InstanceOfPatternMatchTest implements RewriteTest {
             );
         }
 
-        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/307")
         @Test
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/307")
         void throwsExceptionWithExtraParentheses() {
             rewriteRun(
               //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/IsEmptyCallOnCollectionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/IsEmptyCallOnCollectionsTest.java
@@ -40,8 +40,8 @@ class IsEmptyCallOnCollectionsTest implements RewriteTest {
         spec.recipe(new IsEmptyCallOnCollections());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void sizeOnClassImplementationCollection() {
         rewriteRun(
           //language=java
@@ -160,8 +160,8 @@ class IsEmptyCallOnCollectionsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1112")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1112")
     void formatting() {
         rewriteRun(
           //language=java
@@ -182,8 +182,8 @@ class IsEmptyCallOnCollectionsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1120")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1120")
     void lambda() {
         rewriteRun(
           //language=java
@@ -202,8 +202,8 @@ class IsEmptyCallOnCollectionsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2813")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2813")
     void forLoop() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/JavaElementFactoryTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/JavaElementFactoryTest.java
@@ -41,8 +41,8 @@ class JavaElementFactoryTest implements RewriteTest {
         spec.parser(JavaParser.fromJavaVersion().typeCache(typeCache));
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     void instanceMethodReference() {
         RecipeSpec spec = RecipeSpec.defaults();
         defaults(spec);
@@ -80,8 +80,8 @@ class JavaElementFactoryTest implements RewriteTest {
         assertThat(SemanticallyEqual.areEqual(reference, methodReference)).isTrue();
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     void staticMethodReference() {
         RecipeSpec spec = RecipeSpec.defaults();
         defaults(spec);
@@ -119,8 +119,8 @@ class JavaElementFactoryTest implements RewriteTest {
         assertThat(SemanticallyEqual.areEqual(reference, methodReference)).isTrue();
     }
 
-    @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
     void qualifiedStaticMethodReference() {
         RecipeSpec spec = RecipeSpec.defaults();
         defaults(spec);

--- a/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LambdaBlockToExpressionTest.java
@@ -32,9 +32,9 @@ class LambdaBlockToExpressionTest implements RewriteTest {
             .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true));
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("CodeBlock2Expr")
-    @Test
     void simplifyLambdaBlockToExpression() {
         rewriteRun(
           //language=java
@@ -57,8 +57,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1")
     void simplifyLambdaBlockToExpressionWithComments() {
         rewriteRun(
           //language=java
@@ -84,8 +84,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/162")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/162")
     void noChangeIfLambdaBlockWithAmbiguousMethod() {
         //language=java
         rewriteRun(
@@ -114,8 +114,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/236")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/236")
     void simplifyLambdaBlockReturningVoidAsWell2() {
         //language=java
         rewriteRun(
@@ -145,8 +145,8 @@ class LambdaBlockToExpressionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/582")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/582")
     void simplifyAssertThrows() {
         rewriteRun(
           spec-> spec.parser(JavaParser.fromJavaVersion().classpath("junit")),

--- a/src/test/java/org/openrewrite/staticanalysis/LowercasePackageTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/LowercasePackageTest.java
@@ -33,8 +33,8 @@ class LowercasePackageTest implements RewriteTest {
         spec.recipe(new LowercasePackage());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void lowerCasePackage() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/MaskCreditCardNumbersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MaskCreditCardNumbersTest.java
@@ -30,8 +30,8 @@ class MaskCreditCardNumbersTest implements RewriteTest {
         spec.recipe(new MaskCreditCardNumbers());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void noSpaces() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/MethodNameCasingTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MethodNameCasingTest.java
@@ -35,8 +35,8 @@ class MethodNameCasingTest implements RewriteTest {
         spec.recipe(new MethodNameCasing(false, false));
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2571")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2571")
     void noChangesOnMethodsBeginningWithUnderscore() {
         rewriteRun(
           //language=java
@@ -51,8 +51,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2557")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2557")
     void interfaceMethods() {
         rewriteRun(
           //language=java
@@ -66,8 +66,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2557")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2557")
     void annotationMethods() {
         rewriteRun(
           //language=java
@@ -81,8 +81,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     void correctMethodNameCasing() {
         rewriteRun(
           srcMainJava(
@@ -107,8 +107,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     void doNotRenamePublicMethods() {
         rewriteRun(
           //language=java
@@ -122,8 +122,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     void doNotRenamePublicMethodsNullOptions() {
         rewriteRun(
           spec -> spec.recipe(new MethodNameCasing(null, null)),
@@ -138,8 +138,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2424")
     void okToRenamePublicMethods() {
         rewriteRun(
           spec -> spec.recipe(new MethodNameCasing(true, true)),
@@ -161,8 +161,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1741")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1741")
     void doNotApplyToTest() {
         rewriteRun(
           srcTestJava(
@@ -179,8 +179,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1741")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1741")
     void applyChangeToTest() {
         rewriteRun(
           spec -> spec.recipe(new MethodNameCasing(true, false)),
@@ -390,9 +390,9 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2103")
     @SuppressWarnings("UnusedAssignment")
-    @Test
     void snakeCaseToCamelCase() {
         rewriteRun(
           srcMainJava(
@@ -441,8 +441,8 @@ class MethodNameCasingTest implements RewriteTest {
 
     // This test uses a recipe remove ClassDeclaration types information prior to running the MethodNameCasing recipe.
     // This results in a change with an empty diff, thus before and after sources are identical
-    @Issue("https://github.com/openrewrite/rewrite/issues/2103")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2103")
     void doesNotRenameMethodInvocationsWhenTheMethodDeclarationsClassTypeIsNull() {
         rewriteRun(
           spec -> spec
@@ -554,8 +554,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings({"UnnecessaryLocalVariable", "unchecked", "rawtypes"})
     @Test
+    @SuppressWarnings({"UnnecessaryLocalVariable", "unchecked", "rawtypes"})
     void changeNameOfMethodWithArrayArgument() {
         rewriteRun(
           srcMainJava(
@@ -586,8 +586,8 @@ class MethodNameCasingTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2261")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2261")
     void unknownParameterTypes() {
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.none()),

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -31,8 +31,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         spec.recipe(new MinimumSwitchCases());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void caseWithReturnInsteadOfBreak() {
         rewriteRun(
           //language=java
@@ -72,8 +72,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     void primitiveAndDefault() {
         rewriteRun(
           //language=java
@@ -200,8 +200,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     void twoPrimitives() {
         rewriteRun(
           //language=java
@@ -241,8 +241,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     void stringAndDefault() {
         rewriteRun(
           //language=java
@@ -282,8 +282,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     void twoStrings() {
         rewriteRun(
           //language=java
@@ -323,8 +323,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     void onePrimitive() {
         rewriteRun(
           //language=java
@@ -359,8 +359,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/800")
     void oneString() {
         rewriteRun(
           //language=java
@@ -395,9 +395,9 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/800")
     @SuppressWarnings("StatementWithEmptyBody")
-    @Test
     void noCases() {
         rewriteRun(
           //language=java
@@ -415,8 +415,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1212")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1212")
     void importsOnEnum() {
         //noinspection EnhancedSwitchMigration
         rewriteRun(
@@ -532,8 +532,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1701")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1701")
     void removeBreaksFromCaseBody() {
         rewriteRun(
           //language=java
@@ -569,8 +569,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2258")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2258")
     void defaultOnly() {
         rewriteRun(
           //language=java
@@ -610,8 +610,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/3076")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3076")
     void switchExpressions() {
         rewriteRun(
           //language=java
@@ -701,8 +701,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings({"ConstantValue", "DataFlowIssue"})
     @Test
+    @SuppressWarnings({"ConstantValue", "DataFlowIssue"})
     void nestedSwitches() {
         rewriteRun(
           //language=java
@@ -752,8 +752,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/3076")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3076")
     void multipleSwitchExpressions() {
         rewriteRun(
           //language=java
@@ -847,8 +847,8 @@ class MinimumSwitchCasesTest implements RewriteTest {
     }
 
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/284")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/284")
     void caseWithBitwiseOperation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/MissingOverrideAnnotationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MissingOverrideAnnotationTest.java
@@ -91,8 +91,8 @@ class MissingOverrideAnnotationTest implements RewriteTest {
       }
       """;
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void whenIgnoreAnonymousClassMethodsIsFalseAndAMethodOverridesWithinAnAnonymousClass() {
         rewriteRun(
           spec -> spec.recipe(new MissingOverrideAnnotation(false)),

--- a/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
@@ -25,8 +25,8 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
-@SuppressWarnings("UnnecessaryModifier")
 @Issue("https://github.com/openrewrite/rewrite/issues/466")
+@SuppressWarnings("UnnecessaryModifier")
 class ModifierOrderTest implements RewriteTest {
 
     @Override
@@ -34,8 +34,8 @@ class ModifierOrderTest implements RewriteTest {
         spec.recipe(new ModifierOrder());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void changeModifierOrder() {
         rewriteRun(
           //language=java
@@ -73,8 +73,8 @@ class ModifierOrderTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/187")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/187")
     void putDefaultModifierAtJLSRightPosition() {
         // default modifier must be placed between abstract and static modifiers
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/MultipleVariableDeclarationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MultipleVariableDeclarationsTest.java
@@ -31,8 +31,8 @@ class MultipleVariableDeclarationsTest implements RewriteTest {
         spec.recipe(new MultipleVariableDeclarations());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceWithIndividualVariableDeclarations() {
         rewriteRun(
           //language=java
@@ -66,8 +66,8 @@ class MultipleVariableDeclarationsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/812")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/812")
     void arrayDimensionsBeforeName() {
         rewriteRun(
           //language=java
@@ -91,8 +91,8 @@ class MultipleVariableDeclarationsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/812")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/812")
     void arrayDimensionsBeforeName2() {
         rewriteRun(
           //language=java
@@ -195,8 +195,8 @@ class MultipleVariableDeclarationsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2287")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2287")
     void removeNewlinesFromMultivariablePrefix() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
@@ -49,8 +49,8 @@ class NeedBracesTest implements RewriteTest {
         spec.recipe(new NeedBraces());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void addBraces() {
         rewriteRun(
           //language=java
@@ -356,8 +356,8 @@ class NeedBracesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/315")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/315")
     void commentsBeforeElseBlockWithNoBraces() {
         rewriteRun(
           //language=java
@@ -403,8 +403,8 @@ class NeedBracesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/315")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/315")
     void commentsBeforeElseBlockWithBraces() {
         rewriteRun(
           //language=java
@@ -437,8 +437,8 @@ class NeedBracesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/315")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/315")
     void trailingCommentsElseBlock() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NestedEnumsAreNotStaticTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NestedEnumsAreNotStaticTest.java
@@ -30,8 +30,8 @@ class NestedEnumsAreNotStaticTest implements RewriteTest {
         spec.recipe(new NestedEnumsAreNotStatic());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void nestedEnumIsStatic() {
         rewriteRun(
           //language=java
@@ -94,8 +94,8 @@ class NestedEnumsAreNotStaticTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1222")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1222")
     void doesNotReformatWholeEnum() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NewStringBuilderBufferWithCharArgumentTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NewStringBuilderBufferWithCharArgumentTest.java
@@ -28,9 +28,9 @@ class NewStringBuilderBufferWithCharArgumentTest implements RewriteTest {
         spec.recipe(new NewStringBuilderBufferWithCharArgument());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("NewStringBufferWithCharArgument")
-    @Test
     void charIsConstructorArg() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoDoubleBraceInitializationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoDoubleBraceInitializationTest.java
@@ -30,9 +30,9 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         spec.recipe(new NoDoubleBraceInitialization());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("WrapperTypeMayBePrimitive")
-    @Test
     void addStatementInForLoop() {
         rewriteRun(
           //language=java
@@ -100,8 +100,8 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/356")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/356")
     void dropsConstructorCollectionParameterInClass() {
         rewriteRun(
           //language=java
@@ -132,8 +132,8 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2674")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2674")
     void possibleMistakenlyMissedAddingToCollection() {
         rewriteRun(
           //language=java
@@ -173,8 +173,8 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2674")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2674")
     void possibleMistakenlyMissedAddingToCollectionWithDifferentMethodName() {
         rewriteRun(
           //language=java
@@ -219,8 +219,8 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2674")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2674")
     void noCollectionInitializedInDoubleBraceIgnored() {
         rewriteRun(
           //language=java
@@ -506,8 +506,8 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/407")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/407")
     void skipDoubleBraceInInterface() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoEmptyCollectionWithRawTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoEmptyCollectionWithRawTypeTest.java
@@ -29,8 +29,8 @@ class NoEmptyCollectionWithRawTypeTest implements RewriteTest {
         spec.recipe(new NoEmptyCollectionWithRawType());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void emptyListFullyQualified() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoEqualityInForConditionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoEqualityInForConditionTest.java
@@ -23,16 +23,16 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-@SuppressWarnings("StatementWithEmptyBody")
 @Issue("https://github.com/openrewrite/rewrite/issues/811")
+@SuppressWarnings("StatementWithEmptyBody")
 class NoEqualityInForConditionTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new NoEqualityInForCondition());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceWithRelationalOperator() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoFinalizedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoFinalizedLocalVariablesTest.java
@@ -31,8 +31,8 @@ class NoFinalizedLocalVariablesTest implements RewriteTest {
         spec.recipe(new NoFinalizedLocalVariables(null));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeFinal() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoFinalizerTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoFinalizerTest.java
@@ -23,9 +23,9 @@ import static org.openrewrite.java.Assertions.java;
 
 class NoFinalizerTest implements RewriteTest {
 
+    @Test
     @DocumentExample
     @SuppressWarnings("FinalizeCalledExplicitly")
-    @Test
     void noFinalizer() {
         rewriteRun(
           spec -> spec.recipe(new NoFinalizer()),

--- a/src/test/java/org/openrewrite/staticanalysis/NoPrimitiveWrappersForToStringOrCompareToTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoPrimitiveWrappersForToStringOrCompareToTest.java
@@ -30,9 +30,9 @@ class NoPrimitiveWrappersForToStringOrCompareToTest implements RewriteTest {
         spec.recipe(new NoPrimitiveWrappersForToStringOrCompareTo());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings({"removal", "UnnecessaryTemporaryOnConversionToString"})
-    @Test
     void noPrimitiveWrapperForToString() {
         rewriteRun(
           //language=java
@@ -63,8 +63,8 @@ class NoPrimitiveWrappersForToStringOrCompareToTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UseCompareMethod")
     @Test
+    @SuppressWarnings("UseCompareMethod")
     void noPrimitiveWrapperForCompareTo() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoRedundantJumpStatementsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoRedundantJumpStatementsTest.java
@@ -24,8 +24,8 @@ import static org.openrewrite.java.Assertions.java;
 @SuppressWarnings({"UnnecessaryContinue", "UnnecessaryReturnStatement"})
 class NoRedundantJumpStatementsTest implements RewriteTest {
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void noRedundantJumpStatements() {
         rewriteRun(
           spec -> spec.recipe(new NoRedundantJumpStatements()),

--- a/src/test/java/org/openrewrite/staticanalysis/NoToStringOnStringTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoToStringOnStringTypeTest.java
@@ -29,9 +29,9 @@ class NoToStringOnStringTypeTest implements RewriteTest {
         spec.recipe(new NoToStringOnStringType());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("StringOperationCanBeSimplified")
-    @Test
     void toStringOnString() {
         rewriteRun(
           //language=java
@@ -70,8 +70,8 @@ class NoToStringOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("StringOperationCanBeSimplified")
     @Test
+    @SuppressWarnings("StringOperationCanBeSimplified")
     void toStringOnStringVariable() {
         rewriteRun(
           //language=java
@@ -94,8 +94,8 @@ class NoToStringOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("StringOperationCanBeSimplified")
     @Test
+    @SuppressWarnings("StringOperationCanBeSimplified")
     void toStringOnMethodInvocation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NoValueOfOnStringTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoValueOfOnStringTypeTest.java
@@ -30,13 +30,13 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         spec.recipe(new NoValueOfOnStringType());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings({
     "UnnecessaryCallToStringValueOf",
     "UnusedAssignment",
     "StringConcatenationMissingWhitespace",
     })
-    @Test
     void valueOfOnLiterals() {
         rewriteRun(
           //language=java
@@ -103,8 +103,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryCallToStringValueOf")
     @Test
+    @SuppressWarnings("UnnecessaryCallToStringValueOf")
     void valueOfOnNonStringPrimitiveWithinBinaryConcatenation() {
         rewriteRun(
           //language=java
@@ -143,8 +143,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/456")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/456")
     void valueOfOnNonStringPrimitiveWithBinaryArgument() {
         rewriteRun(
           //language=java
@@ -160,8 +160,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1200")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1200")
     void valueOfIsMethodInvocationPartOfBinary() {
         rewriteRun(
           //language=java
@@ -181,8 +181,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings({"UnnecessaryCallToStringValueOf", "StringConcatenationMissingWhitespace"})
     @Test
+    @SuppressWarnings({"UnnecessaryCallToStringValueOf", "StringConcatenationMissingWhitespace"})
     void valueOfOnStandaloneNonStringPrimitive() {
         rewriteRun(
           //language=java
@@ -221,9 +221,9 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1200")
     @SuppressWarnings({"IndexOfReplaceableByContains", "StatementWithEmptyBody"})
-    @Test
     void valueOfOnIntWithinBinaryComparison() {
         rewriteRun(
           //language=java
@@ -241,8 +241,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryCallToStringValueOf")
     @Test
+    @SuppressWarnings("UnnecessaryCallToStringValueOf")
     void valueOfOnMethodInvocation() {
         rewriteRun(
           //language=java
@@ -273,8 +273,8 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/441")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/441")
     void concatenationExpressionNeedsParentheses() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/NullableOnMethodReturnTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NullableOnMethodReturnTypeTest.java
@@ -30,8 +30,8 @@ class NullableOnMethodReturnTypeTest implements RewriteTest {
         spec.recipe(new NullableOnMethodReturnType());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void nullableOnMethodReturnType() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ObjectFinalizeCallsSuperTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ObjectFinalizeCallsSuperTest.java
@@ -29,8 +29,8 @@ class ObjectFinalizeCallsSuperTest implements RewriteTest {
         spec.recipe(new ObjectFinalizeCallsSuper());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void addsSuperFinalizeInvocation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/OperatorWrapTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/OperatorWrapTest.java
@@ -45,8 +45,8 @@ class OperatorWrapTest implements RewriteTest {
         spec.recipe(new OperatorWrap(null));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void binaryOnNewline() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().styles(operatorWrapStyle())),

--- a/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
@@ -33,8 +33,8 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
         spec.recipe(new PrimitiveWrapperClassConstructorToValueOf());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void newClassToValueOf() {
         rewriteRun(
           //language=java
@@ -71,8 +71,8 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2945")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2945")
     void ternaryWithBinary() {
         rewriteRun(
           //language=java
@@ -150,8 +150,8 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/901")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/901")
     void templateIsNewClassArgumentForNewClass() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RedundantFileCreationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RedundantFileCreationTest.java
@@ -28,9 +28,9 @@ class RedundantFileCreationTest implements RewriteTest {
         spec.recipe(new RedundantFileCreation());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings({"resource", "RedundantFileCreation"})
-    @Test
     void redundantFileCreation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReferentialEqualityToObjectEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReferentialEqualityToObjectEqualsTest.java
@@ -33,8 +33,8 @@ class ReferentialEqualityToObjectEqualsTest implements RewriteTest {
         spec.recipe(new ReferentialEqualityToObjectEquals());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void bothSidesOverrideEquals() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveCallsToObjectFinalizeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveCallsToObjectFinalizeTest.java
@@ -29,8 +29,8 @@ class RemoveCallsToObjectFinalizeTest implements RewriteTest {
         spec.recipe(new RemoveCallsToObjectFinalize());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeCallToFinalize() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveCallsToSystemGcTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveCallsToSystemGcTest.java
@@ -29,8 +29,8 @@ class RemoveCallsToSystemGcTest implements RewriteTest {
         spec.recipe(new RemoveCallsToSystemGc());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void noGc() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveEmptyJavaDocParametersTest.java
@@ -33,8 +33,8 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
         spec.recipe(new RemoveEmptyJavaDocParameters());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void emptyParam() {
         rewriteRun(
           //language=java
@@ -167,8 +167,8 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/98")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/98")
     void removeTrailingEmptyLines() {
         rewriteRun(
           //language=java
@@ -635,8 +635,8 @@ class RemoveEmptyJavaDocParametersTest implements RewriteTest {
     }
 
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/3078")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3078")
     void visitingQuarkMustNotFail() {
         rewriteRun(
           other(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
@@ -36,8 +36,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         spec.recipe(new RemoveExtraSemicolons());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void emptyBlockStatements() {
         rewriteRun(
           //language=java
@@ -92,8 +92,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1587")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1587")
     void enumSemicolons() {
         rewriteRun(
           //language=java
@@ -114,8 +114,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1587")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1587")
     void enumSemicolonsWithOtherStatements() {
         rewriteRun(
           //language=java
@@ -171,8 +171,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/99")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/99")
     void semicolonBeforeStatement() {
         rewriteRun(
           //language=java
@@ -197,8 +197,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/99")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/99")
     void manySemicolonBeforeStatement() {
         rewriteRun(
           //language=java
@@ -247,8 +247,8 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/5146")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/5146")
     void noValuesJustSemicolon() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
@@ -30,9 +30,9 @@ class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
         spec.recipe(new RemoveHashCodeCallsFromArrayInstances());
     }
 
+    @Test
     @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/44")
-    @Test
     void replaceHashCodeCalls() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatchTest.java
@@ -519,8 +519,8 @@ class RemoveInstanceOfPatternMatchTest implements RewriteTest {
             14));
     }
 
-    @Disabled("Not supported")
     @Test
+    @Disabled("Not supported")
     void negationLocalVariable() {
         rewriteRun(
           version(
@@ -558,8 +558,8 @@ class RemoveInstanceOfPatternMatchTest implements RewriteTest {
             14));
     }
 
-    @Disabled("Not supported")
     @Test
+    @Disabled("Not supported")
     void negationWithoutElse() {
         rewriteRun(
           version(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTagTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveJavaDocAuthorTagTest.java
@@ -29,9 +29,9 @@ class RemoveJavaDocAuthorTagTest implements RewriteTest {
         spec.recipe(new RemoveJavaDocAuthorTag());
     }
 
+    @Test
     @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite/issues/1640")
-    @Test
     void preserveDocsBeforeTag() {
         rewriteRun(
           //language=java
@@ -55,8 +55,8 @@ class RemoveJavaDocAuthorTagTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1640")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1640")
     void tagOnFirstLine() {
         rewriteRun(
           //language=java
@@ -73,8 +73,8 @@ class RemoveJavaDocAuthorTagTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/119")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/119")
     void tagOnSecondLine() {
         rewriteRun(
           //language=java
@@ -92,8 +92,8 @@ class RemoveJavaDocAuthorTagTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/119")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/119")
     void tagOnSecondLineSourroundedByEmptyLines() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -31,8 +31,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         spec.recipe(new RemoveRedundantTypeCast());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void downCastParameterizedTypes() {
         rewriteRun(
           //language=java
@@ -67,8 +67,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1784")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1784")
     void objectToObjectArray() {
         rewriteRun(
           //language=java
@@ -84,8 +84,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1783")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1783")
     void parametersDoNotMatch() {
         rewriteRun(
           //language=java
@@ -169,8 +169,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1739")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1739")
     void changeTypeCastInReturn() {
         rewriteRun(
           //language=java
@@ -209,8 +209,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     void redundantTypeCast() {
         rewriteRun(
           //language=java
@@ -307,8 +307,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     void downCast() {
         rewriteRun(
           //language=java
@@ -337,8 +337,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     void downCastExtendedObject() {
         rewriteRun(
           //language=java
@@ -364,8 +364,8 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     void downCastExtendedObjectArray() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveSystemOutPrintlnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveSystemOutPrintlnTest.java
@@ -29,8 +29,8 @@ class RemoveSystemOutPrintlnTest implements RewriteTest {
         spec.recipe(new RemoveSystemOutPrintln());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removePrintln() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
@@ -30,9 +30,9 @@ class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
         spec.recipe(new RemoveToStringCallsFromArrayInstances());
     }
 
+    @Test
     @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/44")
-    @Test
     void fixNonCompliantToString() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededAssertionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededAssertionTest.java
@@ -31,8 +31,8 @@ class RemoveUnneededAssertionTest implements RewriteTest {
         spec.recipe(new RemoveUnneededAssertion());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void assertTrue() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededBlockTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnneededBlockTest.java
@@ -30,8 +30,8 @@ class RemoveUnneededBlockTest implements RewriteTest {
         spec.recipe(new RemoveUnneededBlock());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void simplifyNestedBlock() {
         rewriteRun(
           //language=java
@@ -415,8 +415,8 @@ class RemoveUnneededBlockTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/3073")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3073")
     void preserveComments() {
         rewriteRun(
           //language=java
@@ -528,8 +528,8 @@ class RemoveUnneededBlockTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("EmptyFinallyBlock")
     @Test
+    @SuppressWarnings("EmptyFinallyBlock")
     void removeEmptyTryFinallyBlock() {
         rewriteRun(
           //language=java
@@ -575,8 +575,8 @@ class RemoveUnneededBlockTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("EmptyFinallyBlock")
     @Test
+    @SuppressWarnings("EmptyFinallyBlock")
     void keepNonEmptyTryFinallyBlock2() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -49,8 +49,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         spec.recipe(new RemoveUnusedLocalVariables(new String[0], null, null));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeUnusedLocalVariables() {
         rewriteRun(
           //language=java
@@ -76,8 +76,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/841")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/841")
     void ignoreSuppressWarnings() {
         rewriteRun(
           //language=java
@@ -95,9 +95,9 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1332")
     @SuppressWarnings("MethodMayBeStatic")
-    @Test
     void ignoreVariablesNamed() {
         rewriteRun(
           spec -> spec.recipe(new RemoveUnusedLocalVariables(new String[]{"unused"}, null, null)),
@@ -122,9 +122,9 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1278")
     @SuppressWarnings("MethodMayBeStatic")
-    @Test
     void keepRightHandSideStatement() {
         rewriteRun(
           //language=java
@@ -181,8 +181,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1742")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1742")
     void preserveComment() {
         rewriteRun(
           //language=java
@@ -364,8 +364,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/apache/dubbo/blob/747282cdf851c144af562d3f92e10349cc315e36/dubbo-metadata/dubbo-metadata-definition-protobuf/src/test/java/org/apache/dubbo/metadata/definition/protobuf/model/GooglePB.java#L938-L944")
     @Test
+    @Issue("https://github.com/apache/dubbo/blob/747282cdf851c144af562d3f92e10349cc315e36/dubbo-metadata/dubbo-metadata-definition-protobuf/src/test/java/org/apache/dubbo/metadata/definition/protobuf/model/GooglePB.java#L938-L944")
     void keepLocalVariablesAssignmentOperationToOtherVariables() {
         rewriteRun(
           //language=java
@@ -387,8 +387,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     void keepLocalVariableAssignmentOperation() {
         rewriteRun(
           //language=java
@@ -405,8 +405,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     void removeUnusedLocalVariableBitwiseAssignmentOperation() {
         rewriteRun(
           //language=java
@@ -433,8 +433,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     void keepLocalVariableBitwiseAssignmentOperationWithinExpression() {
         rewriteRun(
           //language=java
@@ -456,8 +456,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/blob/706a172ed5449214a4a08637a27dbe768fb4eecd/rewrite-core/src/main/java/org/openrewrite/internal/StringUtils.java#L55-L65")
     void handleInstanceOf() {
         rewriteRun(
           //language=java
@@ -564,8 +564,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("All")
     @Test
+    @SuppressWarnings("All")
     void ignoreAnonymousClassVariables() {
         rewriteRun(
           //language=java
@@ -586,8 +586,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/apache/dubbo/blob/747282cdf851c144af562d3f92e10349cc315e36/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java#L108-L118")
     @Test
+    @Issue("https://github.com/apache/dubbo/blob/747282cdf851c144af562d3f92e10349cc315e36/dubbo-rpc/dubbo-rpc-api/src/main/java/org/apache/dubbo/rpc/RpcStatus.java#L108-L118")
     void forLoopWithExternalIncrementLogic() {
         rewriteRun(
           //language=java
@@ -795,8 +795,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/txazo/spring-cloud-sourcecode/blob/5ffe615558e76f3bb37f19026ece5cbaff4d0404/eureka-client/src/main/java/com/netflix/discovery/converters/jackson/builder/StringInterningAmazonInfoBuilder.java#L114-L124")
     @Test
+    @Issue("https://github.com/txazo/spring-cloud-sourcecode/blob/5ffe615558e76f3bb37f19026ece5cbaff4d0404/eureka-client/src/main/java/com/netflix/discovery/converters/jackson/builder/StringInterningAmazonInfoBuilder.java#L114-L124")
     void recognizeUsedVariableWithinWhileLoop() {
         rewriteRun(
           //language=java
@@ -855,8 +855,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("This still causes SonarQube to warn, but there isn't much that can be done in these cases. Maybe change to a while loop?")
     @Test
+    @Issue("This still causes SonarQube to warn, but there isn't much that can be done in these cases. Maybe change to a while loop?")
     void ignoreForLoopIncrementVariableNeverRead() {
         rewriteRun(
           //language=java
@@ -877,8 +877,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("This still causes SonarQube to warn, but there isn't much that can be done in these cases. Maybe change to a forEach?")
     @Test
+    @Issue("This still causes SonarQube to warn, but there isn't much that can be done in these cases. Maybe change to a forEach?")
     void ignoreEnhancedForLoops() {
         rewriteRun(
           //language=java
@@ -950,8 +950,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1743")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1743")
     void assignmentWithinExpression() {
         rewriteRun(
           //language=java
@@ -975,8 +975,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2509")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2509")
     void recordCompactConstructor() {
         rewriteRun(
           version(
@@ -1037,8 +1037,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/152")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/152")
     void retainUnusedInsideCase() {
         rewriteRun(
           //language=java
@@ -1072,8 +1072,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-feature-flags/pull/35")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-feature-flags/pull/35")
     void removeDespiteSideEffects() {
         rewriteRun(
           spec -> spec.recipe(new RemoveUnusedLocalVariables(null, null, true)),
@@ -1234,8 +1234,8 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
             );
         }
 
-        @ExpectedToFail("Not yet implemented")
         @Test
+        @ExpectedToFail("Not yet implemented")
         void retainUnusedLocalVariableConst() {
             rewriteRun(
               //language=kotlin

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateFieldsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateFieldsTest.java
@@ -33,8 +33,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         spec.recipe(new RemoveUnusedPrivateFields());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeUnusedPrivateField() {
         rewriteRun(
           //language=java
@@ -164,8 +164,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
+    @SuppressWarnings("UnnecessaryLocalVariable")
     void nameIsShadowed() {
         rewriteRun(
           //language=java
@@ -224,8 +224,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/3061")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/3061")
     void findReferencesInOuterScope() {
         rewriteRun(
           //language=java
@@ -403,8 +403,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/242")
     @ParameterizedTest
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/242")
     @ValueSource(strings = {
       "@lombok.Data",
       "@lombok.Value",
@@ -426,8 +426,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/242")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/242")
     void doRemoveFieldsIfLombokLoggingAnnotationIsPresent() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),
@@ -448,8 +448,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/524")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/524")
     void removeUntilStable() {
         rewriteRun(
           //language=java
@@ -469,8 +469,8 @@ class RemoveUnusedPrivateFieldsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/524")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/524")
     void doNotRemoveWhenThereAreMissingTypes() {
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.all().identifiers(false)),

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -32,8 +32,8 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-params"));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeUnusedPrivateMethods() {
         rewriteRun(
           //language=java
@@ -103,8 +103,8 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("MissingSerialAnnotation")
     @Test
+    @SuppressWarnings("MissingSerialAnnotation")
     void doNotRemoveCustomizedSerialization() {
         rewriteRun(
           //language=java
@@ -142,8 +142,8 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1536")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1536")
     void privateMethodWithBoundedGenericTypes() {
         rewriteRun(
           //language=java
@@ -204,8 +204,8 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
     void doNotRemoveMethodsWithUnusedSuppressWarningsOnClass() {
         rewriteRun(
           //language=java
@@ -229,8 +229,8 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/4076")
     void doNotRemoveMethodsWithUnusedSuppressWarningsOnClassNestedClass() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RenameExceptionInEmptyCatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameExceptionInEmptyCatchTest.java
@@ -29,8 +29,8 @@ class RenameExceptionInEmptyCatchTest implements RewriteTest {
         spec.recipe(new RenameExceptionInEmptyCatch());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void nameScopeTest() {
         rewriteRun(
           //language=java
@@ -121,8 +121,8 @@ class RenameExceptionInEmptyCatchTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("all")
     @Test
+    @SuppressWarnings("all")
     void multipleCatches() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameLocalVariablesToCamelCaseTest.java
@@ -36,8 +36,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         spec.recipe(new RenameLocalVariablesToCamelCase());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void renameAllCapsAcronyms() {
         rewriteRun(
           //language=java
@@ -60,8 +60,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2227")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2227")
     void lowerCamelVariableHasNonLowerCamelVariableSibling() {
         rewriteRun(
           //language=java
@@ -114,10 +114,10 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
+    @Test
     @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/2437")
     @SuppressWarnings("JavadocDeclaration")
-    @Test
     void renameJavaDocParam() {
         rewriteRun(
           //language=java
@@ -285,8 +285,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
     }
 
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     void doNotRenameUnderscoreNumber() {
         rewriteRun(
           //language=java
@@ -304,8 +304,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     void doNotRenameUnderscoresOnly() {
         rewriteRun(
           //language=java
@@ -375,8 +375,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/171")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/171")
     void renameMultipleOcurrencesDifferentScope() {
         rewriteRun(
           java(
@@ -461,8 +461,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/205")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/205")
     void doNotRenameMethodArguments() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/RenameMethodsNamedHashcodeEqualOrToStringTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameMethodsNamedHashcodeEqualOrToStringTest.java
@@ -30,8 +30,8 @@ class RenameMethodsNamedHashcodeEqualOrToStringTest implements RewriteTest {
         spec.recipe(new RenameMethodsNamedHashcodeEqualOrToString());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void noncompliantMethodNames() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenamePrivateFieldsToCamelCaseTest.java
@@ -35,8 +35,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         spec.recipe(new RenamePrivateFieldsToCamelCase());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void renamePrivateMembers() {
         rewriteRun(
           //language=java
@@ -83,8 +83,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2461")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2461")
     void upperSnakeToLowerCamel() {
         rewriteRun(
           //language=java
@@ -117,8 +117,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2294")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2294")
     void nameConflict() {
         rewriteRun(
           //language=java
@@ -141,8 +141,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2285")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2285")
     void doesNotRenameAssociatedIdentifiers() {
         rewriteRun(
           //language=java
@@ -478,8 +478,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     void doNotRenameUnderscoreNumber() {
         rewriteRun(
           //language=java
@@ -540,8 +540,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/103")
     void doNotRenameUnderscoresOnly() {
         rewriteRun(
           //language=java
@@ -558,8 +558,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2526")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2526")
     void recordCompactConstructor() {
         rewriteRun(
           spec -> spec.beforeRecipe(cu -> {
@@ -587,8 +587,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
     void doNotChangeLombokAnnotatedClasses() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),
@@ -604,8 +604,8 @@ class RenamePrivateFieldsToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/267")
     void doNotChangeLombokAnnotatedFields() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion().classpath("lombok")),

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -29,8 +29,8 @@ class ReorderAnnotationsTest implements RewriteTest {
         spec.recipe(new ReorderAnnotations());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void reordersMethodAnnotations() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReorderAnnotationsTest.java
@@ -52,9 +52,9 @@ class ReorderAnnotationsTest implements RewriteTest {
               import org.junitpioneer.jupiter.ExpectedToFail;
               import org.junitpioneer.jupiter.Issue;
               class A {
+                  @Test
                   @ExpectedToFail
                   @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                  @Test
                   void explicitImplementationClassInApi() {
                   }
               }
@@ -139,11 +139,11 @@ class ReorderAnnotationsTest implements RewriteTest {
               import org.junitpioneer.jupiter.Issue;
               class A {
                   // Before first
-                  @ExpectedToFail
-                  // Before second
-                  @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                  // Before third
                   @Test
+                  // Before second
+                  @ExpectedToFail
+                  // Before third
+                  @Issue("https://github.com/openrewrite/rewrite/issues/2973")
                   // Before method
                   void explicitImplementationClassInApi() {
                   }
@@ -192,9 +192,9 @@ class ReorderAnnotationsTest implements RewriteTest {
                   import org.junitpioneer.jupiter.ExpectedToFail;
                   import org.junitpioneer.jupiter.Issue;
                   class A {
+                      @Test
                       @ExpectedToFail
                       @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-                      @Test
                       void explicitImplementationClassInApi() {
                       }
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceApacheCommonsLang3ValidateNotNullWithObjectsRequireNonNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceApacheCommonsLang3ValidateNotNullWithObjectsRequireNonNullTest.java
@@ -38,8 +38,8 @@ class ReplaceApacheCommonsLang3ValidateNotNullWithObjectsRequireNonNullTest impl
             .activateRecipes("org.openrewrite.staticanalysis.ReplaceApacheCommonsLang3ValidateNotNullWithObjectsRequireNonNull"));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceWithOneArgument() {
         rewriteRun(
           //language=java
@@ -83,8 +83,8 @@ class ReplaceApacheCommonsLang3ValidateNotNullWithObjectsRequireNonNullTest impl
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/457")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/457")
     void replaceWithOneArgumentAsString() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceClassIsInstanceWithInstanceofTest.java
@@ -31,8 +31,8 @@ class ReplaceClassIsInstanceWithInstanceofTest implements RewriteTest {
         spec.recipe(new ReplaceClassIsInstanceWithInstanceof());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void changeInstanceOf() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
@@ -29,8 +29,8 @@ class ReplaceCollectionToArrayArgWithEmptyArrayTest implements RewriteTest {
         spec.recipe(new ReplaceCollectionToArrayArgWithEmptyArray());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceSizeArgumentWithZero() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceDuplicateStringLiteralsTest.java
@@ -31,8 +31,8 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
         spec.recipe(new ReplaceDuplicateStringLiterals(true));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceRedundantFinalStrings() {
         rewriteRun(
           //language=java
@@ -74,8 +74,8 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1740")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1740")
     void doesNotApplyToTest() {
         rewriteRun(
           spec -> spec.recipe(new ReplaceDuplicateStringLiterals(false)),
@@ -94,8 +94,8 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1740")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1740")
     void sourcesEnabled() {
         rewriteRun(
           srcTestJava(
@@ -622,8 +622,8 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2329")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2329")
     void unicodeCharacterEquivalents() {
         rewriteRun(
           //language=java
@@ -647,8 +647,8 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2330")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2330")
     void enumDefinition() {
         rewriteRun(
           //language=java
@@ -728,8 +728,8 @@ class ReplaceDuplicateStringLiteralsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/384")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/384")
     void staticWithObjectArray() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -36,8 +36,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         spec.recipe(new ReplaceLambdaWithMethodReference());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void functionMultiParamReference() {
         rewriteRun(
           //language=java
@@ -105,8 +105,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1926")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1926")
     void multipleMethodInvocations() {
         rewriteRun(
           //language=java
@@ -130,8 +130,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/96")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/96")
     void ignoreAmbiguousMethodReference() {
         rewriteRun(
           //language=java
@@ -171,8 +171,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1772")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1772")
     void typeCastOnMethodInvocationReturnType() {
         rewriteRun(
           //language=java
@@ -194,8 +194,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/201")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/201")
     void typeCastOnConstructorCall() {
         rewriteRun(
           //language=java
@@ -366,8 +366,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2875")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2875")
     void instanceOfLeftHandIsNotLambdaParameter() {
         rewriteRun(
           //language=java
@@ -725,8 +725,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2897")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2897")
     void notNullToObjectsNonNullError() {
         rewriteRun(
           //language=java
@@ -790,8 +790,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("Convert2MethodRef")
     @Test
+    @SuppressWarnings("Convert2MethodRef")
     void isEqualToNull() {
         rewriteRun(
           //language=java
@@ -930,8 +930,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2178")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2178")
     void doNotReplaceInvocationWhichAcceptsArgument() {
         rewriteRun(
           //language=java
@@ -1028,8 +1028,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2949")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2949")
     void multipleConstructors() {
         rewriteRun(
           //language=java
@@ -1065,8 +1065,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2949")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2949")
     void anotherMultipleConstructorsCaseEasyUnderstanding() {
         rewriteRun(
           //language=java
@@ -1099,9 +1099,9 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2949")
     @SuppressWarnings("StringOperationCanBeSimplified")
-    @Test
     void anotherSimplerMultipleConstructorsCase() {
         rewriteRun(
           //language=java
@@ -1124,8 +1124,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2958")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2958")
     void insideIfConditionAfterInstanceOfPatternVariable() {
         rewriteRun(
           //language=java
@@ -1156,8 +1156,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("EmptyTryBlock")
     @Test
+    @SuppressWarnings("EmptyTryBlock")
     void tryInAForLoop() {
         rewriteRun(
           //language=java
@@ -1195,9 +1195,9 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
     }
 
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/3071")
     @SuppressWarnings("OptionalOfNullableMisuse")
-    @Test
     void missingImportForDeclaringType() {
         rewriteRun(
           //language=java
@@ -1235,9 +1235,9 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/200")
     @SuppressWarnings({"ConstantValue"})
-    @Test
     void nestedType() {
         rewriteRun(
           //language=java
@@ -1275,8 +1275,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/132")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/pull/132")
     void dontReplaceLambdaSupplierOfMethodReference() {
         rewriteRun(
           //language=java
@@ -1328,8 +1328,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/237")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/237")
     void groupingByGetClass() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceOptionalIsPresentWithIfPresentTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceOptionalIsPresentWithIfPresentTest.java
@@ -35,8 +35,8 @@ class ReplaceOptionalIsPresentWithIfPresentTest implements RewriteTest {
           .recipe(new ReplaceOptionalIsPresentWithIfPresent());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void ignoreReturnInsideLambda() {
         rewriteRun(
           //language=java
@@ -412,8 +412,8 @@ class ReplaceOptionalIsPresentWithIfPresentTest implements RewriteTest {
         );
     }
 
-    @Disabled("Due to limitation of FinalizeLocalVariables functionality")
     @Test
+    @Disabled("Due to limitation of FinalizeLocalVariables functionality")
     void replace2() {
         rewriteRun(
           //language=java
@@ -724,8 +724,8 @@ class ReplaceOptionalIsPresentWithIfPresentTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/435")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/435")
     void doNothingIfMethodThrowsException() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceRedundantFormatWithPrintfTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceRedundantFormatWithPrintfTest.java
@@ -29,8 +29,8 @@ class ReplaceRedundantFormatWithPrintfTest implements RewriteTest {
         spec.recipe(new ReplaceRedundantFormatWithPrintf());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void transformsNonLiteralFormatStringForPrint() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
@@ -30,8 +30,8 @@ class ReplaceStackWithDequeTest implements RewriteTest {
         spec.recipe(new ReplaceStackWithDeque());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceStack() {
         rewriteRun(
           //language=java
@@ -64,8 +64,8 @@ class ReplaceStackWithDequeTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
+    @Disabled
     void doNotReplaceIfReturned() {
         rewriteRun(
           //language=java
@@ -86,8 +86,8 @@ class ReplaceStackWithDequeTest implements RewriteTest {
         );
     }
 
-    @Disabled
     @Test
+    @Disabled
     void dataFlow() {
         rewriteRun(
           spec -> spec.recipe(new FindMethods("java.util.Stack <constructor>(..)", false, "data")),

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceStringBuilderWithStringTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceStringBuilderWithStringTest.java
@@ -30,8 +30,8 @@ class ReplaceStringBuilderWithStringTest implements RewriteTest {
         spec.recipe(new ReplaceStringBuilderWithString());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceLiteralConcatenation() {
         rewriteRun(
           //language=java
@@ -54,8 +54,8 @@ class ReplaceStringBuilderWithStringTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/88")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/88")
     void replaceWhileMaintainingSpaces() {
         rewriteRun(
           //language=java
@@ -194,8 +194,8 @@ class ReplaceStringBuilderWithStringTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2930")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2930")
     void withConstructor() {
         rewriteRun(
           //language=java
@@ -230,8 +230,8 @@ class ReplaceStringBuilderWithStringTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/88")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/88")
     void retainComments() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceTextBlockWithStringTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceTextBlockWithStringTest.java
@@ -31,8 +31,8 @@ class ReplaceTextBlockWithStringTest implements RewriteTest {
         spec.recipe(new ReplaceTextBlockWithString()).allSources(s -> s.markers(javaVersion(14)));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void newLine() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceThreadRunWithThreadStartTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceThreadRunWithThreadStartTest.java
@@ -33,9 +33,9 @@ class ReplaceThreadRunWithThreadStartTest implements RewriteTest {
           .activateRecipes("org.openrewrite.staticanalysis.ReplaceThreadRunWithThreadStart"));
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("CallToThreadRun")
-    @Test
     void replaceThreadRun() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceValidateNotNullHavingVarargsWithObjectsRequireNonNullTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceValidateNotNullHavingVarargsWithObjectsRequireNonNullTest.java
@@ -33,8 +33,8 @@ class ReplaceValidateNotNullHavingVarargsWithObjectsRequireNonNullTest implement
           .recipe(new ReplaceValidateNotNullHavingVarargsWithObjectsRequireNonNull());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void replaceMethodsWithTwoArg() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceWeekYearWithYearTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceWeekYearWithYearTest.java
@@ -31,9 +31,9 @@ class ReplaceWeekYearWithYearTest implements RewriteTest {
           .recipe(new ReplaceWeekYearWithYear());
     }
 
+    @Test
     @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/58")
-    @Test
     void changeSimpleDateFormat() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionTest.java
@@ -31,8 +31,8 @@ class SimplifyBooleanExpressionTest implements RewriteTest {
         spec.recipe(new SimplifyBooleanExpression());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void simplifyEqualsLiteralTrueIf() {
         rewriteRun(
           java(
@@ -310,8 +310,8 @@ class SimplifyBooleanExpressionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/502")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/502")
     void autoFormatIsConditionallyApplied() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanReturnTest.java
@@ -32,8 +32,8 @@ class SimplifyBooleanReturnTest implements RewriteTest {
         spec.recipe(new SimplifyBooleanReturn());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void simplifyBooleanReturn() {
         rewriteRun(
           //language=java
@@ -222,8 +222,8 @@ class SimplifyBooleanReturnTest implements RewriteTest {
     }
 
 
-    @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/671#discussion_r1947004208")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/pull/671#discussion_r1947004208")
     void avoidDoubleNegation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyCompoundStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyCompoundStatementTest.java
@@ -29,8 +29,8 @@ class SimplifyCompoundStatementTest implements RewriteTest {
         spec.recipe(new SimplifyCompoundStatement());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeCompoundAnd() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConsecutiveAssignmentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConsecutiveAssignmentsTest.java
@@ -29,8 +29,8 @@ class SimplifyConsecutiveAssignmentsTest implements RewriteTest {
         spec.recipe(new SimplifyConsecutiveAssignments());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void assignmentAndIncrement() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConstantIfBranchExecutionTest.java
@@ -30,8 +30,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         spec.recipe(new SimplifyConstantIfBranchExecution());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void simplifyConstantIfTrue() {
         rewriteRun(
           //language=java
@@ -75,8 +75,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/286")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/286")
     void doNotChangeParenthesisOnly() {
         rewriteRun(
           //language=java
@@ -145,8 +145,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("DuplicateCondition")
     @Test
+    @SuppressWarnings("DuplicateCondition")
     void simplifyConstantIfTrueOrTrue() {
         rewriteRun(
           //language=java
@@ -685,8 +685,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("InfiniteLoopStatement")
     @Test
+    @SuppressWarnings("InfiniteLoopStatement")
     void simplifyConstantIfFalseElseWhileTrueEmptyBlock() {
         rewriteRun(
           //language=java
@@ -1355,8 +1355,8 @@ class SimplifyConstantIfBranchExecutionTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/89")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/89")
     void preserveComments() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyDurationCreationUnitsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyDurationCreationUnitsTest.java
@@ -30,8 +30,8 @@ class SimplifyDurationCreationUnitsTest implements RewriteTest {
         spec.recipe(new SimplifyDurationCreationUnits());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void simplifyLiteralMillisToSeconds() {
         rewriteRun(
           //language=java
@@ -313,8 +313,8 @@ class SimplifyDurationCreationUnitsTest implements RewriteTest {
      * <p>
      * This test just documents the current behavior.
      */
-    @SuppressWarnings("IntegerMultiplicationImplicitCastToLong")
     @Test
+    @SuppressWarnings("IntegerMultiplicationImplicitCastToLong")
     void doesNotChangeNonConstantUnitCount() {
         rewriteRun(
           //language=java
@@ -331,8 +331,8 @@ class SimplifyDurationCreationUnitsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/support-public/issues/30")
     @Test
+    @Issue("https://github.com/moderneinc/support-public/issues/30")
     void doesNotChangeZeroConstant() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyTernaryTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyTernaryTest.java
@@ -22,8 +22,8 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 class SimplifyTernaryTest implements RewriteTest {
-    @DocumentExample
     @Test
+    @DocumentExample
     void simplified() {
         rewriteRun(
           spec -> spec.recipe(new SimplifyTernaryRecipes()),

--- a/src/test/java/org/openrewrite/staticanalysis/SortedSetStreamToLinkedHashSetTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SortedSetStreamToLinkedHashSetTest.java
@@ -30,8 +30,8 @@ class SortedSetStreamToLinkedHashSetTest implements RewriteTest {
         spec.recipe(new SortedSetStreamToLinkedHashSet());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void changeSortedSetStreamToLinkedHashSet() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/StaticMethodNotFinalTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/StaticMethodNotFinalTest.java
@@ -25,9 +25,9 @@ import static org.openrewrite.java.Assertions.java;
 @Issue("https://github.com/openrewrite/rewrite/issues/466")
 class StaticMethodNotFinalTest implements RewriteTest {
 
+    @Test
     @DocumentExample
     @SuppressWarnings("FinalStaticMethod")
-    @Test
     void removeFinalFromStaticMethods() {
         rewriteRun(
           spec -> spec.recipe(new StaticMethodNotFinal()),

--- a/src/test/java/org/openrewrite/staticanalysis/StringLiteralEqualityTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/StringLiteralEqualityTest.java
@@ -37,8 +37,8 @@ class StringLiteralEqualityTest implements RewriteTest {
         spec.recipe(new StringLiteralEquality());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void stringLiteralEqualityReplacedWithEquals() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/TernaryOperatorsShouldNotBeNestedTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/TernaryOperatorsShouldNotBeNestedTest.java
@@ -36,8 +36,8 @@ class TernaryOperatorsShouldNotBeNestedTest {
             spec.recipe(new TernaryOperatorsShouldNotBeNested()).allSources(s -> s.markers(javaVersion(11)));
         }
 
-        @DocumentExample
         @Test
+        @DocumentExample
         void doReplaceNestedOrTernaryWithIfFollowedByTernary() {
             rewriteRun(
               //language=java
@@ -246,8 +246,8 @@ class TernaryOperatorsShouldNotBeNestedTest {
             );
         }
 
-        @ExpectedToFail("Comment `dont forget about c` falls off. It is part of a `before` that is dropped when falsePart is extracted")
         @Test
+        @ExpectedToFail("Comment `dont forget about c` falls off. It is part of a `before` that is dropped when falsePart is extracted")
         void doReplaceMultiLevelTernariesWithComments() {
             rewriteRun(
               //language=java
@@ -302,9 +302,9 @@ class TernaryOperatorsShouldNotBeNestedTest {
             );
         }
 
+        @Test
         @ExpectedToFail("only directly returned ternaries are taken into account")
         @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/112")
-        @Test
         void doReplaceNestedOrAssignmentTernaryWithIfElse() {
             rewriteRun(
               //language=java
@@ -600,8 +600,8 @@ class TernaryOperatorsShouldNotBeNestedTest {
 
         @Nested
         class ReplaceWithSwitchExpression {
-            @DocumentExample
             @Test
+            @DocumentExample
             void doReplaceNestedOrTernaryWithSwitchExpression() {
                 rewriteRun(
                   //language=java
@@ -767,9 +767,9 @@ class TernaryOperatorsShouldNotBeNestedTest {
                 );
             }
 
+            @Test
             @ExpectedToFail("switch(null) is not supported before Java 18. This would break null safety.")
             @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/157")
-            @Test
             void doReplaceNestedOrTernaryWithSwitchExpressionNullSafeEquals() {
                 rewriteRun(
                   //language=java
@@ -797,9 +797,9 @@ class TernaryOperatorsShouldNotBeNestedTest {
                 );
             }
 
+            @Test
             @ExpectedToFail("switch(null) is not supported before Java 18. This would break null safety.")
             @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/157")
-            @Test
             void doReplaceNestedOrTernaryWithSwitchExpressionNullSafeEqualsInverted() {
                 rewriteRun(
                   //language=java
@@ -1125,9 +1125,9 @@ class TernaryOperatorsShouldNotBeNestedTest {
                 );
             }
 
+            @Test
             @ExpectedToFail("Pattern matching not yet implemented")
             @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/158")
-            @Test
             void doReplaceNestedOrTernaryInStreamWithPatternMatchingSwitch() {
                 rewriteRun(
                   //language=java
@@ -1166,9 +1166,9 @@ class TernaryOperatorsShouldNotBeNestedTest {
                 );
             }
 
+            @Test
             @ExpectedToFail("not yet implemented collapsing cases")
             @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/159")
-            @Test
             void doReplaceNestedOrTernaryContainingNullCollapsingSameCases() {
                 rewriteRun(
                   //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/TypecastParenPadTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/TypecastParenPadTest.java
@@ -31,8 +31,8 @@ class TypecastParenPadTest implements RewriteTest {
         spec.recipe(new TypecastParenPad());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void typecastParenPad() {
         rewriteRun(
           //language=java
@@ -61,8 +61,8 @@ class TypecastParenPadTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/561")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/561")
     void noChangeForGroovy() {
         rewriteRun(
           //language=groovy

--- a/src/test/java/org/openrewrite/staticanalysis/URLEqualsHashCodeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/URLEqualsHashCodeTest.java
@@ -29,8 +29,8 @@ class URLEqualsHashCodeTest implements RewriteTest {
         spec.recipe(new URLEqualsHashCodeRecipes());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void urlHashCode() {
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
@@ -30,8 +30,8 @@ class UnnecessaryCatchTest implements RewriteTest {
         spec.recipe(new UnnecessaryCatch(false, false));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void unwrapTry() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCloseInTryWithResourcesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCloseInTryWithResourcesTest.java
@@ -29,8 +29,8 @@ class UnnecessaryCloseInTryWithResourcesTest implements RewriteTest {
         spec.recipe(new UnnecessaryCloseInTryWithResources());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void hasUnnecessaryClose() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -35,8 +35,8 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         spec.recipe(new UnnecessaryExplicitTypeArguments());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void unnecessaryExplicitTypeArguments() {
         rewriteRun(
           //language=java
@@ -71,8 +71,8 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Not implemented yet")
     @Test
+    @ExpectedToFail("Not implemented yet")
     void withinLambda() {
         rewriteRun(
           //language=java
@@ -107,8 +107,8 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1211")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1211")
     void doesNotIntroduceAmbiguity() {
         rewriteRun(
           //language=java
@@ -139,9 +139,9 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
+    @Test
     @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/164")
-    @Test
     void doesNotRemoveNecessaryTypeArguments() {
         rewriteRun(
           //language=java
@@ -167,9 +167,9 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
     }
 
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2818")
     @SuppressWarnings("UnnecessaryLocalVariable")
-    @Test
     void assignedToVar() {
         rewriteRun(
           //language=java
@@ -304,8 +304,8 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
             );
         }
 
-        @ExpectedToFail("Not matching yet")
         @Test
+        @ExpectedToFail("Not matching yet")
         void changeIfHasTypeInference() {
             rewriteRun(
               kotlin(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryParenthesesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryParenthesesTest.java
@@ -40,8 +40,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         spec.recipe(new UnnecessaryParentheses());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void fullUnwrappingDefault() {
         //language=java
         rewriteRun(
@@ -105,8 +105,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2170")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2170")
     void minimumSpace() {
         //language=java
         rewriteRun(
@@ -129,9 +129,9 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
+    @Test
     @Disabled
     @Issue("https://github.com/openrewrite/rewrite/issues/798")
-    @Test
     void unwrapExpr() {
         //language=java
         rewriteRun(
@@ -224,8 +224,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings({"PointlessBooleanExpression", "MismatchedStringCase"})
     @Test
+    @SuppressWarnings({"PointlessBooleanExpression", "MismatchedStringCase"})
     void unwrapLiteral() {
         //language=java
         rewriteRun(
@@ -278,8 +278,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("SillyAssignment")
     @Test
+    @SuppressWarnings("SillyAssignment")
     void unwrapAssignment() {
         //language=java
         rewriteRun(
@@ -519,8 +519,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1486")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1486")
     void unwrapMinusReturnExpression() {
         //language=java
         rewriteRun(
@@ -737,8 +737,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/798")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/798")
     void unwrapDoubleParens() {
         //language=java
         rewriteRun(
@@ -823,8 +823,8 @@ class UnnecessaryParenthesesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("PointlessBooleanExpression")
     @Test
+    @SuppressWarnings("PointlessBooleanExpression")
     void doNotUnwrapIfParens() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryPrimitiveAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryPrimitiveAnnotationsTest.java
@@ -30,8 +30,8 @@ class UnnecessaryPrimitiveAnnotationsTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath("jsr305"));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void unnecessaryNullable() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryReturnAsLastStatementTest.java
@@ -28,8 +28,8 @@ class UnnecessaryReturnAsLastStatementTest implements RewriteTest {
         spec.recipe(new UnnecessaryReturnAsLastStatement());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void simpleReturn() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
@@ -32,8 +32,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         spec.recipe(new UnnecessaryThrows());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void unnecessaryThrows() {
         rewriteRun(
           //language=java
@@ -69,8 +69,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2144")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2144")
     void genericException() {
         rewriteRun(
           //language=java
@@ -85,9 +85,9 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/631")
     @SuppressWarnings("EmptyTryBlock")
-    @Test
     void necessaryThrowsFromCloseable() {
         rewriteRun(
           //language=java
@@ -128,8 +128,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/519")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/519")
     void interfaces() {
         rewriteRun(
           //language=java
@@ -145,8 +145,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/519")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/519")
     void abstractMethods() {
         rewriteRun(
           //language=java
@@ -162,8 +162,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1059")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1059")
     void necessaryThrowsFromStaticMethod() {
         rewriteRun(
           //language=java
@@ -181,8 +181,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/443")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/443")
     void necessaryThrowsFromConstructor() {
         rewriteRun(
           //language=java
@@ -202,9 +202,9 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
+    @Test
     @ExpectedToFail("Not yet implemented")
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/443")
-    @Test
     void necessaryThrowsFromConstructorWithUnused() {
         rewriteRun(
           //language=java
@@ -236,8 +236,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/897")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/897")
     void necessaryThrowsOnInterfaceWithExplicitOverride() {
         rewriteRun(
           //language=java
@@ -311,8 +311,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1298")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1298")
     void doNotRemoveExceptionCoveringOtherExceptions() {
         rewriteRun(
           //language=java
@@ -332,8 +332,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2105")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2105")
     void preventTransformationIfAnyThrownExceptionHasNullOrUnknownType() {
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.none()),
@@ -354,8 +354,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/429")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/429")
     void interfaceWithGenericTypeThrown() {
         rewriteRun(
 
@@ -396,8 +396,8 @@ class UnnecessaryThrowsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/apache/maven/pull/2291")
     @Test
+    @Issue("https://github.com/apache/maven/pull/2291")
     void retainExceptionsForOverrides() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UnwrapRepeatableAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnwrapRepeatableAnnotationsTest.java
@@ -59,8 +59,8 @@ class UnwrapRepeatableAnnotationsTest implements RewriteTest {
           );
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void unwrapRepeatable() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UpperCaseLiteralSuffixesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UpperCaseLiteralSuffixesTest.java
@@ -31,8 +31,8 @@ class UpperCaseLiteralSuffixesTest implements RewriteTest {
         spec.recipe(new UpperCaseLiteralSuffixes());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void useUppercaseLiteralSuffix() {
         rewriteRun(
           //language=java
@@ -63,8 +63,8 @@ class UpperCaseLiteralSuffixesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2429")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2429")
     void usesPrimitive() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -37,8 +37,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         spec.recipe(new UseCollectionInterfaces());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void rawReturnType() {
         rewriteRun(
           //language=java
@@ -132,8 +132,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/223")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/223")
     void annotatedReturnType() {
         rewriteRun(
           spec -> spec
@@ -260,8 +260,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/223")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/223")
     void annotatedFieldType() {
         rewriteRun(
           spec -> spec
@@ -462,8 +462,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     void enumMap() {
         rewriteRun(
           //language=java
@@ -731,8 +731,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/179")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/179")
     void enumSetHasDifferentGenericTypeThanSet() {
         rewriteRun(
           //language=java
@@ -827,8 +827,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     void privateVariable() {
         rewriteRun(
           //language=java
@@ -852,8 +852,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     void noModifierOnVariable() {
         rewriteRun(
           //language=java
@@ -877,8 +877,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     void privateMethod() {
         rewriteRun(
           //language=java
@@ -906,8 +906,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1703")
     void noModifierOnMethod() {
         rewriteRun(
           //language=java
@@ -935,9 +935,9 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
+    @Test
     @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite/issues/2973")
-    @Test
     void explicitImplementationClassInApi() {
         rewriteRun(
           //language=java
@@ -962,8 +962,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1771")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1771")
     void variableWithVar() {
         var javaRuntimeVersion = System.getProperty("java.runtime.version");
         var javaVendor = System.getProperty("java.vm.vendor");
@@ -1002,8 +1002,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
     void danglingGenericReference() {
         rewriteRun(
           //language=java
@@ -1032,8 +1032,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
     void danglingReference() {
         rewriteRun(
           //language=java
@@ -1062,8 +1062,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/357")
     void removeImportWhenUsingFieldAccess() {
         rewriteRun(
           //language=java
@@ -1093,8 +1093,8 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/592")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/592")
     void anonymousInstanceInvocation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
@@ -35,8 +35,8 @@ class UseDiamondOperatorTest implements RewriteTest {
         spec.recipe(new UseDiamondOperator());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void useDiamondOperator() {
         rewriteRun(
           //language=java
@@ -184,8 +184,8 @@ class UseDiamondOperatorTest implements RewriteTest {
 
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2274")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2274")
     void returnTypeParamsDoNotMatchNewClassParams() {
         rewriteRun(
           //language=java
@@ -230,8 +230,8 @@ class UseDiamondOperatorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1297")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1297")
     void doNotUseDiamondOperatorsForVariablesHavingNullOrUnknownTypes() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseForEachRemoveInsteadOfSetRemoveAllTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseForEachRemoveInsteadOfSetRemoveAllTest.java
@@ -30,8 +30,8 @@ class UseForEachRemoveInsteadOfSetRemoveAllTest implements RewriteTest {
         spec.recipe(new UseForEachRemoveInsteadOfSetRemoveAll());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void returnExpressionIgnored() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseJavaStyleArrayDeclarationsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseJavaStyleArrayDeclarationsTest.java
@@ -29,8 +29,8 @@ class UseJavaStyleArrayDeclarationsTest implements RewriteTest {
         spec.recipe(new UseJavaStyleArrayDeclarations());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void javaStyleArrayForVariableDeclarations() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -32,8 +32,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         spec.recipe(new UseLambdaForFunctionalInterface());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void useLambda() {
         rewriteRun(
           //language=java
@@ -59,9 +59,9 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/10")
     @SuppressWarnings("removal")
-    @Test
     void castingAmbiguity() {
         rewriteRun(
           spec -> spec.recipe(new UseLambdaForFunctionalInterface()),
@@ -105,9 +105,9 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/194")
     @SuppressWarnings("ConstantConditions")
-    @Test
     void gson() {
         rewriteRun(
           spec -> spec.recipe(new UseLambdaForFunctionalInterface())
@@ -150,8 +150,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings({"Convert2Lambda", "TrivialFunctionalExpressionUsage"})
     @Test
+    @SuppressWarnings({"Convert2Lambda", "TrivialFunctionalExpressionUsage"})
     void usedAsStatementWithNonInferrableType() {
         rewriteRun(
           spec -> spec.recipe(new UseLambdaForFunctionalInterface()),
@@ -172,8 +172,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Disabled("The recipe currently avoids simplifying anonymous classes that use the this keyword.")
     @Test
+    @Disabled("The recipe currently avoids simplifying anonymous classes that use the this keyword.")
     void useLambdaThenSimplifyFurther() {
         rewriteRun(
           spec -> spec.recipes(
@@ -231,8 +231,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnusedAssignment")
     @Test
+    @SuppressWarnings("UnusedAssignment")
     void emptyLambda() {
         rewriteRun(
           //language=java
@@ -266,8 +266,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1828")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1828")
     void nestedLambdaInMethodArgument() {
         rewriteRun(
           //language=java
@@ -330,8 +330,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("UnnecessaryLocalVariable")
     @Test
+    @SuppressWarnings("UnnecessaryLocalVariable")
     void dontUseLambdaWhenShadowsLocalVariable() {
         rewriteRun(
           //language=java
@@ -355,9 +355,9 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1915")
     @SuppressWarnings("UnnecessaryLocalVariable")
-    @Test
     void dontUseLambdaWhenShadowsClassField() {
         rewriteRun(
           //language=java
@@ -381,9 +381,9 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/1915")
     @SuppressWarnings("UnnecessaryLocalVariable")
-    @Test
     void dontUseLambdaWhenShadowsMethodDeclarationParam() {
         rewriteRun(
           //language=java
@@ -465,8 +465,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @SuppressWarnings("DataFlowIssue")
     @Test
+    @SuppressWarnings("DataFlowIssue")
     void noReplaceOnReferenceToUninitializedFinalField() {
         rewriteRun(
           //language=java
@@ -664,8 +664,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/support-app/issues/17")
     @Test
+    @Issue("https://github.com/moderneinc/support-app/issues/17")
     void lambdaWithComplexTypeInference() {
         rewriteRun(
           //language=java
@@ -736,8 +736,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/309")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/309")
     void dontUseLambdaForMethodWithTypeParameter() {
         //language=java
         rewriteRun(
@@ -775,8 +775,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
     void dontUseLambdaWhenEnumAccessesStaticFieldFromConstructor() {
         rewriteRun(
           //language=java
@@ -803,8 +803,8 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/413")
     void dontUseLambdaWhenEnumAccessesStaticFieldFromFromMethod() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseListSortTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseListSortTest.java
@@ -29,8 +29,8 @@ class UseListSortTest implements RewriteTest {
         spec.recipe(new UseListSort());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void hasSelect() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseObjectNotifyAllTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseObjectNotifyAllTest.java
@@ -29,8 +29,8 @@ class UseObjectNotifyAllTest implements RewriteTest {
         spec.recipe(new UseObjectNotifyAll());
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1645")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1645")
     void useObjectNotifyAll() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseStandardCharsetTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseStandardCharsetTest.java
@@ -30,8 +30,8 @@ class UseStandardCharsetTest implements RewriteTest {
         spec.recipe(new UseStandardCharset());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void changeCharsetForName() {
         rewriteRun(
           //language=java
@@ -81,8 +81,8 @@ class UseStandardCharsetTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2450")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2450")
     void convertAnyValidName() {
         rewriteRun(
           //language=java
@@ -110,8 +110,8 @@ class UseStandardCharsetTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/support-public/issues/29")
     @Test
+    @Issue("https://github.com/moderneinc/support-public/issues/29")
     void nonConstantCharset() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseStringReplaceTest.java
@@ -31,9 +31,9 @@ class UseStringReplaceTest implements RewriteTest {
         spec.recipe(new UseStringReplace());
     }
 
+    @Test
     @DisplayName("String#replaceAll replaced by String#replace, because first argument is not a regular expression")
     @DocumentExample
-    @Test
     void replaceAllReplacedByReplace() {
         rewriteRun(
           //language=java
@@ -58,9 +58,9 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2222")
     @SuppressWarnings("ReplaceOnLiteralHasNoEffect")
-    @Test
     void literalValueSourceAccountsForEscapeCharacters() {
         rewriteRun(
           //language=java
@@ -79,8 +79,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1781")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1781")
     void replaceAllContainsEscapedQuotes() {
         rewriteRun(
           //language=java
@@ -103,8 +103,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @DisplayName("String#replaceAll replaced by String#replace, because first argument is not a regular expression and it contains special characters")
     @Test
+    @DisplayName("String#replaceAll replaced by String#replace, because first argument is not a regular expression and it contains special characters")
     void replaceAllReplacedByReplaceWithSpecialCharacters() {
         rewriteRun(
           //language=java
@@ -129,8 +129,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @DisplayName("String#replaceAll is not replaced by String#replace, because first argument is a real regular expression")
     @Test
+    @DisplayName("String#replaceAll is not replaced by String#replace, because first argument is a real regular expression")
     void replaceAllUnchanged() {
         rewriteRun(
           //language=java
@@ -147,9 +147,9 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
+    @Test
     @DisplayName("String#replaceAll is not replaced by String#replace, because second argument has a backslash in it")
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
-    @Test
     void replaceAllUnchangedIfBackslashInReplacementString() {
         rewriteRun(
           //language=java
@@ -165,9 +165,9 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
+    @Test
     @DisplayName("String#replaceAll is not replaced by String#replace, because second argument has a dollar sign in it")
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/301")
-    @Test
     void replaceAllUnchangedIfDollarInReplacementString() {
         rewriteRun(
           //language=java
@@ -188,8 +188,8 @@ class UseStringReplaceTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/330")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/330")
     void equalsSignOnlyWhenSafeToReplace() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UseSystemLineSeparatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseSystemLineSeparatorTest.java
@@ -29,8 +29,8 @@ class UseSystemLineSeparatorTest implements RewriteTest {
         spec.recipe(new UseSystemLineSeparator());
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2363")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2363")
     void useSystemLineSeparator() {
         rewriteRun(
           //language=java
@@ -55,8 +55,8 @@ class UseSystemLineSeparatorTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2363")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2363")
     void useSystemLineSeparatorStaticImport() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/WhileInsteadOfForTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/WhileInsteadOfForTest.java
@@ -28,9 +28,9 @@ class WhileInsteadOfForTest implements RewriteTest {
         spec.recipe(new WhileInsteadOfFor());
     }
 
+    @Test
     @DocumentExample
     @SuppressWarnings("ALL")
-    @Test
     void replaceWithWhile() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimalTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimalTest.java
@@ -29,8 +29,8 @@ class WriteOctalValuesAsDecimalTest implements RewriteTest {
         spec.recipe(new WriteOctalValuesAsDecimal());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void writeAsDecimal() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/csharp/CatchClauseOnlyRethrowsCsharpTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/csharp/CatchClauseOnlyRethrowsCsharpTest.java
@@ -38,8 +38,8 @@ class CatchClauseOnlyRethrowsCsharpTest implements RewriteTest {
         spec.recipe(toCsRecipe(new CatchClauseOnlyRethrows()));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void verifyCsharpImplicitThrow() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/csharp/ExplicitInitializationVisitorCsharpTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/csharp/ExplicitInitializationVisitorCsharpTest.java
@@ -47,8 +47,8 @@ class ExplicitInitializationVisitorCsharpTest implements RewriteTest {
           );
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void removeExplicitInitialization() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/groovy/ExplicitInitializationVisitorGroovyTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/groovy/ExplicitInitializationVisitorGroovyTest.java
@@ -31,16 +31,16 @@ class ExplicitInitializationVisitorGroovyTest implements RewriteTest {
         spec.recipe(new ExplicitInitialization());
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1272")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1272")
     void gTypes() {
         rewriteRun(
           groovy("int a = 0")
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/1272")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/1272")
     void removeExplicitInitialization() {
         rewriteRun(
           groovy(

--- a/src/test/java/org/openrewrite/staticanalysis/groovy/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/groovy/MinimumSwitchCasesTest.java
@@ -32,9 +32,9 @@ class MinimumSwitchCasesTest implements RewriteTest {
         spec.recipe(new MinimumSwitchCases());
     }
 
+    @Test
     @DocumentExample
     @ExpectedToFail("Temporarily until we have investigated why the behavior has changed here")
-    @Test
     void twoCases() {
         rewriteRun(
           //language=groovy
@@ -62,9 +62,9 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
+    @Test
     @Issue("https://github.com/openrewrite/rewrite/issues/2566")
     @SuppressWarnings("GrMethodMayBeStatic")
-    @Test
     void nonIdentifierEnum() {
         rewriteRun(
           //language=groovy

--- a/src/test/java/org/openrewrite/staticanalysis/groovy/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/groovy/ReplaceLambdaWithMethodReferenceTest.java
@@ -30,8 +30,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         spec.recipe(new ReplaceLambdaWithMethodReference());
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/2566")
     @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/2566")
     void groovyLangClosure() {
         rewriteRun(
           groovy(

--- a/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
@@ -31,8 +31,8 @@ class MoveFieldAnnotationToTypeTest implements RewriteTest {
         spec.recipe(new MoveFieldAnnotationToType("org.openrewrite..*"));
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void fieldAnnotation() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/kotlin/NeedBracesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/kotlin/NeedBracesTest.java
@@ -30,8 +30,8 @@ class NeedBracesTest implements RewriteTest {
         spec.recipe(new NeedBraces());
     }
 
-    @Disabled("AutoFormat needs to be updated to support Kotlin")
     @Test
+    @Disabled("AutoFormat needs to be updated to support Kotlin")
     void addBracesForIfBranch() {
         rewriteRun(
           //language=kotlin

--- a/src/test/java/org/openrewrite/staticanalysis/kotlin/RenameLocalVariablesToCamelCaseTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/kotlin/RenameLocalVariablesToCamelCaseTest.java
@@ -31,8 +31,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         spec.recipe(new RenameLocalVariablesToCamelCase());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void regular() {
         rewriteRun(
           kotlin(
@@ -52,8 +52,8 @@ class RenameLocalVariablesToCamelCaseTest implements RewriteTest {
         );
     }
 
-    @Disabled("A bug to be fixed")
     @Test
+    @Disabled("A bug to be fixed")
     void renameBothVariableAndUsage() {
         rewriteRun(
           kotlin(

--- a/src/test/java/org/openrewrite/staticanalysis/kotlin/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/kotlin/ReplaceLambdaWithMethodReferenceTest.java
@@ -29,8 +29,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         spec.recipe(new ReplaceLambdaWithMethodReference());
     }
 
-    @ExpectedToFail("Kotlin visitor to be implemented")
     @Test
+    @ExpectedToFail("Kotlin visitor to be implemented")
     void toQualifiedMethodReference() {
         rewriteRun(
           kotlin(
@@ -70,8 +70,8 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Kotlin visitor to be implemented")
     @Test
+    @ExpectedToFail("Kotlin visitor to be implemented")
     void toUnqualifiedMethodReference() {
         rewriteRun(
           kotlin(

--- a/src/test/java/org/openrewrite/staticanalysis/kotlin/SimplifyBooleanExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/kotlin/SimplifyBooleanExpressionTest.java
@@ -30,8 +30,8 @@ class SimplifyBooleanExpressionTest implements RewriteTest {
         spec.recipe(new SimplifyBooleanExpression());
     }
 
-    @DocumentExample
     @Test
+    @DocumentExample
     void regular() {
         rewriteRun(
           kotlin(


### PR DESCRIPTION
## What's your motivation?
We saw `@ParameterizedTest` moved down, which looks quite odd.

## Anything in particular you'd like reviewers to focus on?
Are we ok to force this convention on others?

## Have you considered any alternatives or workarounds?
* Tolerate the change: apply as it was without this change
* Add an option with a sensible default that controls this behavior: we don't like a growing number of options here