### PR TITLE
Issue #622: precompile regexes in FixStringFormatExpressions.java and…

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
@@ -35,6 +35,8 @@ public class FixStringFormatExpressions extends Recipe {
 
     // %[argument_index$][flags][width][.precision][t]conversion
     private static final Pattern FS_PATTERN = Pattern.compile("%(\\d+\\$)?([-#+ 0,(<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])");
+    private static final Pattern NEWLINE_PATTERN = Pattern.compile("(?<!\\\\)\\n");
+    private static final Pattern ESCAPED_NEWLINE_PATTERN = Pattern.compile("(?<!\\\\)\\\\n");
 
     private static final MethodMatcher FORMAT_MATCHER = new MethodMatcher("java.lang.String format(..)");
     private static final MethodMatcher FORMATTED_MATCHER = new MethodMatcher("java.lang.String formatted(..)");
@@ -108,10 +110,14 @@ public class FixStringFormatExpressions extends Recipe {
                         if (arg0 instanceof J.Literal) {
                             J.Literal fmt = (J.Literal) arg0;
                             if (fmt.getValue() != null) {
-                                fmt = fmt.withValue(fmt.getValue().toString().replaceAll("(?<!\\\\)\n", "%n"));
+                                String v = fmt.getValue().toString();
+                                v = NEWLINE_PATTERN.matcher(v).replaceAll("%n");
+                                fmt = fmt.withValue(v);
                             }
                             if (fmt.getValueSource() != null) {
-                                fmt = fmt.withValueSource(fmt.getValueSource().replaceAll("(?<!\\\\)\\\\n", "%n"));
+                                String vs = fmt.getValueSource();
+                                vs = ESCAPED_NEWLINE_PATTERN.matcher(vs).replaceAll("%n");
+                                fmt = fmt.withValueSource(vs);
                             }
                             return fmt;
                         }

--- a/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
@@ -110,14 +110,10 @@ public class FixStringFormatExpressions extends Recipe {
                         if (arg0 instanceof J.Literal) {
                             J.Literal fmt = (J.Literal) arg0;
                             if (fmt.getValue() != null) {
-                                String v = fmt.getValue().toString();
-                                v = NEWLINE_PATTERN.matcher(v).replaceAll("%n");
-                                fmt = fmt.withValue(v);
+                                fmt = fmt.withValue(NEWLINE_PATTERN.matcher(fmt.getValue().toString()).replaceAll("%n"));
                             }
                             if (fmt.getValueSource() != null) {
-                                String vs = fmt.getValueSource();
-                                vs = ESCAPED_NEWLINE_PATTERN.matcher(vs).replaceAll("%n");
-                                fmt = fmt.withValueSource(vs);
+                                fmt = fmt.withValueSource(ESCAPED_NEWLINE_PATTERN.matcher(fmt.getValueSource()).replaceAll("%n"));
                             }
                             return fmt;
                         }

--- a/src/main/java/org/openrewrite/staticanalysis/MaskCreditCardNumbers.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MaskCreditCardNumbers.java
@@ -42,6 +42,7 @@ public class MaskCreditCardNumbers extends Recipe {
     }
 
     private static final Pattern CC_PATTERN = Pattern.compile("([0-9]{4} ?[0-9]{4} ?)([0-9]{4} ?[0-9]{4} ?)");
+    private static final Pattern DIGIT_PATTERN = Pattern.compile("[0-9]");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -64,6 +65,6 @@ public class MaskCreditCardNumbers extends Recipe {
     }
 
     private static String maskDigits(String digits) {
-        return digits.replaceAll("[0-9]", "X");
+        return DIGIT_PATTERN.matcher(digits).replaceAll("X");
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/MaskCreditCardNumbers.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MaskCreditCardNumbers.java
@@ -38,11 +38,11 @@ public class MaskCreditCardNumbers extends Recipe {
     @Override
     public String getDescription() {
         return "When encountering string literals which appear to be credit card numbers, " +
-               "mask the last eight digits with the letter 'X'.";
+                "mask the last eight digits with the letter 'X'.";
     }
 
     private static final Pattern CC_PATTERN = Pattern.compile("([0-9]{4} ?[0-9]{4} ?)([0-9]{4} ?[0-9]{4} ?)");
-    private static final Pattern DIGIT_PATTERN = Pattern.compile("[0-9]");
+    private static final Pattern DIGIT_PATTERN = Pattern.compile("\\d");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -50,11 +50,11 @@ public class MaskCreditCardNumbers extends Recipe {
             @Override
             public J.Literal visitLiteral(J.Literal literal, ExecutionContext ctx) {
                 J.Literal l = super.visitLiteral(literal, ctx);
-                if(l.getValue() instanceof String) {
+                if (l.getValue() instanceof String) {
                     String value = (String) l.getValue();
                     Matcher m = CC_PATTERN.matcher(value);
-                    if(m.matches()) {
-                        String masked = m.group(1) +maskDigits(m.group(2));
+                    if (m.matches()) {
+                        String masked = m.group(1) + maskDigits(m.group(2));
                         l = l.withValue(masked)
                                 .withValueSource("\"" + masked + "\"");
                     }


### PR DESCRIPTION
Hoisted inline Pattern.compile and String.replaceAll calls into private static final Pattern constants in these two classes:

MaskCreditCardNumbers.java
FixStringFormatExpressions.java