### PR TITLE
Add CollectionToArrayShouldHaveProperType recipe (RSPEC-S3020)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ out/
 .project
 .settings/
 bin/
+
+# Exclude files from being added to git index
+.gitmodules
+docs
+Sonar.MD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,83 @@
-# Recipe Development Instructions
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the OpenRewrite Static Analysis repository - a collection of recipes that automatically fix SAST-like issues in Java, Kotlin, Groovy, and C# codebases. It's built on the OpenRewrite framework for automated code transformation.
+
+## Build and Test Commands
+
+### Building the Project
+```bash
+./gradlew build
+```
+
+### Running Tests
+```bash
+# Run all tests
+./gradlew test
+
+# Run a specific test class
+./gradlew test --tests RemoveRedundantNullCheckBeforeInstanceofTest
+
+# Run tests matching a pattern
+./gradlew test --tests "*NullCheck*"
+
+# Run a specific test method
+./gradlew test --tests "RemoveRedundantNullCheckBeforeInstanceofTest.testMethodName"
+```
+
+### Other Commands
+```bash
+# Clean build
+./gradlew clean
+
+# Check code (compile + test)
+./gradlew check
+
+# Assemble without running tests
+./gradlew assemble
+```
+
+## High-Level Architecture
+
+### Recipe Development Pattern
+
+1. **Recipe Structure**: Each recipe extends `org.openrewrite.Recipe` and implements:
+   - `getDisplayName()` - Human-readable name
+   - `getDescription()` - Detailed description
+   - `getTags()` - Tags for categorization (often RSPEC rule IDs)
+   - `getVisitor()` - Returns a TreeVisitor that performs the transformation
+
+2. **Visitor Pattern**: Recipes use `JavaVisitor<ExecutionContext>` to traverse and transform the AST:
+   - Override specific visit methods (`visitBinary()`, `visitMethodInvocation()`, etc.)
+   - Work with immutable AST nodes (J.Binary, J.Unary, J.InstanceOf, etc.)
+   - Use `.with*()` methods for transformations while preserving formatting
+
+3. **Recipe Collections**: YAML files in `src/main/resources/META-INF/rewrite/` group recipes:
+   - `common-static-analysis.yml` - Common static analysis fixes
+   - `java-best-practices.yml` - Java-specific best practices
+   - `static-analysis.yml` - General static analysis recipes
+
+### Test Pattern
+
+Tests implement `RewriteTest` and follow this structure:
+```java
+@Test
+void testName() {
+    rewriteRun(
+        java(
+            """
+            // before code
+            """,
+            """
+            // after code
+            """
+        )
+    );
+}
+```
 
 ## Code Style Preferences
 
@@ -46,10 +125,11 @@
   - `"ConstantConditions"` - for redundant null checks that the recipe will remove
   - Other suppressions as needed based on the specific warnings in test cases
 
-## Testing Commands
-After making changes to a recipe, always run the respective tests, such as for instance:
-```bash
-./gradlew test --tests RemoveRedundantNullCheckBeforeInstanceofTest
-```
+## Important Notes
 
-Ensure all tests pass before considering the changes complete.
+- The project uses Gradle with build caching and parallel execution enabled
+- Build scans are available at https://ge.openrewrite.org/
+- Documentation for recipes is available at https://docs.openrewrite.org/recipes/staticanalysis
+- Contributions should follow the [OpenRewrite contributing guide](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md)
+- **Recipe development documentation** is available in the `./docs` submodule - consult this for detailed guidance on writing recipes, using JavaTemplate, and testing patterns
+- **Recipe writing lessons** are captured in `recipe-writing-lessons.md` - check this file for specific learnings and best practices discovered during recipe development, and continue adding new insights as they are discovered

--- a/recipe-writing-lessons.md
+++ b/recipe-writing-lessons.md
@@ -1,0 +1,284 @@
+# Recipe Writing Lessons
+
+This document captures key lessons learned while developing OpenRewrite recipes.
+
+## TypeUtils Best Practices
+
+### Use TypeUtils methods instead of instanceof checks
+
+When working with JavaType objects, prefer using TypeUtils helper methods over direct instanceof checks:
+
+**Good:**
+```java
+JavaType.Array arrayType = TypeUtils.asArray(targetType);
+if (arrayType != null) {
+    JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(componentType);
+    if (fqType != null) {
+        // Use fqType
+    }
+}
+```
+
+**Avoid:**
+```java
+if (targetType instanceof JavaType.Array) {
+    JavaType.Array arrayType = (JavaType.Array) targetType;
+    if (componentType instanceof JavaType.FullyQualified) {
+        JavaType.FullyQualified fqType = (JavaType.FullyQualified) componentType;
+        // Use fqType
+    }
+}
+```
+
+### Benefits of TypeUtils
+- Safer type checking and casting
+- More idiomatic OpenRewrite code
+- Handles null cases gracefully
+- Consistent with the framework's patterns
+
+## JavaType Hierarchy
+
+### JavaType.Class extends JavaType.FullyQualified
+Since `JavaType.Class` is a subtype of `JavaType.FullyQualified`, you only need to check for the parent type:
+
+**Simplified:**
+```java
+JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(componentType);
+if (fqType != null) {
+    // This handles both JavaType.Class and JavaType.FullyQualified
+}
+```
+
+## MethodMatcher for Reliable Method Matching
+
+When checking for specific method calls, use `MethodMatcher` instead of manual checks:
+
+**Good:**
+```java
+private static final MethodMatcher TO_ARRAY = new MethodMatcher("java.util.Collection toArray()", true);
+
+if (TO_ARRAY.matches(methodInvocation)) {
+    // Handle toArray() call
+}
+```
+
+**Avoid:**
+```java
+if (methodInvocation.getName().getSimpleName().equals("toArray") &&
+    methodInvocation.getArguments().size() == 0 &&
+    methodInvocation.getMethodType() != null &&
+    TypeUtils.isAssignableTo("java.util.Collection", methodInvocation.getMethodType().getDeclaringType())) {
+    // Handle toArray() call
+}
+```
+
+## JavaTemplate Usage
+
+### Import handling
+Always declare imports when the template introduces types:
+```java
+JavaTemplate template = JavaTemplate.builder("#{any()}.toArray(new #{}[0])")
+        .imports(fqn)  // Important: declare the import
+        .build();
+```
+
+### Don't forget maybeAddImport()
+After applying a template that uses a type, add the import to the compilation unit:
+```java
+Expression result = template.apply(...);
+maybeAddImport(fqn);  // Add the import to the source file
+```
+
+## Testing Best Practices
+
+### Type Validation in Tests
+For tests involving custom types that may have incomplete type information, consider disabling type validation.
+But only use this as an absolute last resort. Prefer to specify types that exist.
+
+```java
+@Test
+void withCustomType() {
+    rewriteRun(
+      spec -> spec.typeValidationOptions(TypeValidation.none()),
+      java(
+        // test code
+      )
+    );
+}
+```
+
+### Suppressing IDE Warnings in Tests
+When testing code that contains intentional issues (that your recipe will fix), suppress IDE warnings:
+
+```java
+// For a single test method
+@SuppressWarnings("RedundantCast")
+@Test
+void testRedundantCast() {
+    rewriteRun(
+      java(
+        """
+          String[] array = (String[]) list.toArray(); // IntelliJ warns about redundant cast
+          """
+      )
+    );
+}
+
+// For multiple tests with the same warning, move to class level
+@SuppressWarnings({"ConstantConditions", "RedundantCast"})
+class MyRecipeTest implements RewriteTest {
+    // All test methods inherit these suppressions
+}
+```
+
+Common suppressions for recipe tests:
+- `"RedundantCast"` - for recipes fixing unnecessary casts
+- `"ConstantConditions"` - for null checks that will be removed
+- `"unused"` - for unused variables/methods that will be removed
+- `"unchecked"` - for unchecked operations that will be fixed
+
+### Test Coverage
+Ensure comprehensive test coverage including:
+- Basic cases
+- Edge cases (custom types, fully qualified types)
+- Cases where the recipe should NOT make changes
+- Import handling scenarios
+- Formatting preservation
+
+### IDE Support with Language Comments
+Add language comments before string templates containing code to enable IDE syntax highlighting.
+
+When using `java("before", "after")` with no customization, place the comment before `java`:
+```java
+@Test
+void testMethod() {
+    rewriteRun(
+      //language=java
+      java(
+        """
+          public class Before {
+              // Both strings get syntax highlighting
+          }
+          """,
+        """
+          public class After {
+              // Both strings get syntax highlighting
+          }
+          """
+      )
+    );
+}
+```
+
+When there's customization or multiple `java()` calls, place comments on individual strings:
+```java
+@Test
+void testWithCustomization() {
+    rewriteRun(
+      spec -> spec.typeValidationOptions(TypeValidation.none()),
+      //language=java
+      java(
+        """
+          public class Test {
+              // Java code with syntax highlighting
+          }
+          """
+      )
+    );
+}
+```
+
+**Important**: Do NOT add `//language=java` to JavaTemplate strings that contain parameters like `#{any()}` or `#{}`, as these are not valid Java syntax and will cause IDE errors:
+```java
+// DON'T DO THIS - parameters make it invalid Java
+JavaTemplate template = JavaTemplate.builder(
+    //language=java  // ❌ Wrong!
+    "#{any()}.toArray(new #{}[0])"
+).build();
+
+// Only use language comments for valid Java code
+JavaTemplate template = JavaTemplate.builder(
+    //language=java  // ✅ OK - valid Java
+    "System.out.println(\"Hello\")"
+).build();
+```
+
+## Recipe Metadata
+
+### Always include RSPEC tags
+When implementing SonarQube rules, include the RSPEC identifier:
+```java
+@Override
+public Set<String> getTags() {
+    return Collections.singleton("RSPEC-S3020");
+}
+```
+
+### Accurate time estimates
+Provide realistic time estimates for manual fixes. When implementing SonarQube rules, use the same time estimate that is on the SonarQube definition.
+```java
+@Override
+public Duration getEstimatedEffortPerOccurrence() {
+    return Duration.ofMinutes(2);
+}
+```
+
+## Visitor Patterns
+
+### JavaVisitor vs JavaIsoVisitor
+
+Use `JavaIsoVisitor` when:
+- You're returning the same type of LST element that you're visiting
+- You want to avoid casting the visited element
+- Most common for simple transformations
+
+Use `JavaVisitor` when:
+- You need to return a different type of LST element than what you're visiting
+- Example: Visiting a `J.Parentheses` but returning an `Expression` after unwrapping/replacing it
+- This is necessary when the transformation fundamentally changes the tree structure
+
+```java
+// JavaVisitor example - returning different type
+@Override
+public J visitParentheses(J.Parentheses parentheses, ExecutionContext ctx) {
+    // ... some logic ...
+    return someExpression;  // Not a J.Parentheses
+}
+
+// JavaIsoVisitor example - returning same type
+@Override
+public J.TypeCast visitTypeCast(J.TypeCast typeCast, ExecutionContext ctx) {
+    J.TypeCast tc = super.visitTypeCast(typeCast, ctx);
+    // ... some logic ...
+    return tc;  // Still a J.TypeCast
+}
+```
+
+### Handle parentheses explicitly
+When dealing with expressions that might be parenthesized, consider visiting parentheses nodes:
+```java
+@Override
+public J visitParentheses(J.Parentheses parentheses, ExecutionContext ctx) {
+    // Handle parenthesized expressions
+}
+```
+
+### Preserve formatting
+When replacing expressions, be mindful of preserving prefixes and formatting:
+```java
+return visitedParentheses.withTree(result);  // Preserves parentheses structure
+```
+
+## YAML Configuration
+
+### Add recipes to appropriate recipe collections
+Don't forget to add new recipes to relevant YAML files:
+```yaml
+recipeList:
+  - org.openrewrite.staticanalysis.CollectionToArrayShouldHaveProperType
+```
+
+Common collections:
+- `common-static-analysis.yml` - General static analysis fixes
+- `java-best-practices.yml` - Java-specific best practices
+- `static-analysis.yml` - Broader static analysis recipes

--- a/src/main/java/org/openrewrite/staticanalysis/CollectionToArrayShouldHaveProperType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CollectionToArrayShouldHaveProperType.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class CollectionToArrayShouldHaveProperType extends Recipe {
+    private static final MethodMatcher TO_ARRAY = new MethodMatcher("java.util.Collection toArray()", true);
+
+    @Override
+    public String getDisplayName() {
+        return "'Collection.toArray()' should be passed an array of the proper type";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Using `Collection.toArray()` without parameters returns an `Object[]`, which requires casting. " +
+                "It is more efficient and clearer to use `Collection.toArray(new T[0])` instead.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(2);
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Collections.singleton("RSPEC-S3020");
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+            @Override
+            public <T extends J> J visitParentheses(J.Parentheses<T> parentheses, ExecutionContext ctx) {
+                J visited = super.visitParentheses(parentheses, ctx);
+                if (visited instanceof J.Parentheses) {
+                    @SuppressWarnings("unchecked") J.Parentheses<T> visitedParentheses = (J.Parentheses<T>) visited;
+                    if (visitedParentheses.getTree() instanceof J.TypeCast) {
+                        J.TypeCast typeCast = (J.TypeCast) visitedParentheses.getTree();
+                        Expression expression = typeCast.getExpression();
+
+                        // Check if the expression is a method invocation of toArray() with no arguments
+                        if (expression instanceof J.MethodInvocation) {
+                            J.MethodInvocation methodInvocation = (J.MethodInvocation) expression;
+                            if (TO_ARRAY.matches(methodInvocation)) {
+                                // Get the target type from the cast
+                                JavaType targetType = typeCast.getType();
+                                JavaType.Array arrayType = TypeUtils.asArray(targetType);
+                                if (arrayType != null) {
+                                    JavaType componentType = arrayType.getElemType();
+
+                                    // Use TypeUtils for safer type checking and casting
+                                    JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(componentType);
+                                    if (fqType != null) {
+                                        String className = fqType.getClassName();
+                                        String fqn = fqType.getFullyQualifiedName();
+                                        // Build the toArray call with the proper array argument
+                                        JavaTemplate template = JavaTemplate.builder("#{any()}.toArray(new #{}[0])")
+                                                .imports(fqn)
+                                                .build();
+
+                                        // Apply the template, replacing the entire parentheses expression
+                                        Expression result = template.apply(getCursor(), visitedParentheses.getCoordinates().replace(),
+                                                requireNonNull(methodInvocation.getSelect()),
+                                                className);
+
+                                        // Add the import if needed
+                                        maybeAddImport(fqn);
+
+                                        // Return the result wrapped in parentheses to preserve the original structure
+                                        //noinspection unchecked
+                                        return visitedParentheses.withTree((T) result);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                return visited;
+            }
+
+            @Override
+            public J visitTypeCast(J.TypeCast typeCast, ExecutionContext ctx) {
+                J visited = super.visitTypeCast(typeCast, ctx);
+                if (!(visited instanceof J.TypeCast)) {
+                    return visited;
+                }
+
+                J.TypeCast visitedTypeCast = (J.TypeCast) visited;
+                Expression expression = visitedTypeCast.getExpression();
+
+                // Check if the expression is a method invocation of toArray() with no arguments
+                if (expression instanceof J.MethodInvocation) {
+                    J.MethodInvocation methodInvocation = (J.MethodInvocation) expression;
+                    if (TO_ARRAY.matches(methodInvocation)) {
+
+                        // Get the target type from the cast
+                        JavaType targetType = visitedTypeCast.getType();
+                        JavaType.Array arrayType = TypeUtils.asArray(targetType);
+                        if (arrayType != null) {
+                            JavaType componentType = arrayType.getElemType();
+
+                            // Use TypeUtils for safer type checking and casting
+                            JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(componentType);
+                            if (fqType != null) {
+                                String className = fqType.getClassName();
+                                String fqn = fqType.getFullyQualifiedName();
+                                // Build the toArray call with the proper array argument
+                                JavaTemplate template = JavaTemplate.builder("#{any()}.toArray(new #{}[0])")
+                                        .imports(fqn)
+                                        .build();
+
+                                // Apply the template, replacing the cast expression
+                                Expression result = template.apply(getCursor(), visitedTypeCast.getCoordinates().replace(),
+                                        requireNonNull(methodInvocation.getSelect()),
+                                        className);
+
+                                // Add the import if needed
+                                maybeAddImport(fqn);
+
+                                return result;
+                            }
+                        }
+                    }
+                }
+
+                return visitedTypeCast;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/common-static-analysis.yml
+++ b/src/main/resources/META-INF/rewrite/common-static-analysis.yml
@@ -29,6 +29,7 @@ recipeList:
   - org.openrewrite.staticanalysis.CaseInsensitiveComparisonsDoNotChangeCase
   - org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
   - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
+  - org.openrewrite.staticanalysis.CollectionToArrayShouldHaveProperType
   - org.openrewrite.staticanalysis.CovariantEquals
   - org.openrewrite.staticanalysis.DefaultComesLast
   - org.openrewrite.staticanalysis.EmptyBlock

--- a/src/test/java/org/openrewrite/staticanalysis/CollectionToArrayShouldHaveProperTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CollectionToArrayShouldHaveProperTypeTest.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings({"ConstantConditions", "RedundantCast"})
+class CollectionToArrayShouldHaveProperTypeTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new CollectionToArrayShouldHaveProperType());
+    }
+
+    @Test
+    @DocumentExample
+    void basicCase() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list) {
+                      String[] array = (String[]) list.toArray();
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list) {
+                      String[] array = list.toArray(new String[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withFullyQualifiedType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void test(java.util.List<String> list) {
+                      String[] array = (String[]) list.toArray();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(java.util.List<String> list) {
+                      String[] array = list.toArray(new String[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withCustomType() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              public class MyClass {
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              import java.util.List;
+
+              class Test {
+                  void test(List<MyClass> list) {
+                      MyClass[] array = (MyClass[]) list.toArray();
+                  }
+              }
+              """,
+            """
+              package com.example;
+
+              import java.util.List;
+
+              class Test {
+                  void test(List<MyClass> list) {
+                      MyClass[] array = list.toArray(new MyClass[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withImportNeeded() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+              import java.time.LocalDate;
+
+              class Test {
+                  void test(List<LocalDate> list) {
+                      LocalDate[] array = (LocalDate[]) list.toArray();
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              import java.time.LocalDate;
+
+              class Test {
+                  void test(List<LocalDate> list) {
+                      LocalDate[] array = list.toArray(new LocalDate[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withFullyQualifiedTypeNeedsImport() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  void test(List<java.time.LocalDate> list) {
+                      java.time.LocalDate[] array = (java.time.LocalDate[]) list.toArray();
+                  }
+              }
+              """,
+            """
+              import java.time.LocalDate;
+              import java.util.List;
+
+              class Test {
+                  void test(List<LocalDate> list) {
+                      LocalDate[] array = list.toArray(new LocalDate[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preservesMethodChaining() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list) {
+                      int length = ((String[]) list.toArray()).length;
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list) {
+                      int length = (list.toArray(new String[0])).length;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotChangeToArrayWithArguments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list) {
+                      String[] array = list.toArray(new String[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotChangeNonCollectionToArray() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void test() {
+                      MyObject obj = new MyObject();
+                      String[] array = (String[]) obj.toArray();
+                  }
+
+                  class MyObject {
+                      Object[] toArray() {
+                          return new Object[0];
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotChangeCastToNonArrayType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  void test(List<String> list) {
+                      Object obj = (Object) list.toArray();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void worksWithSets() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Set;
+
+              class Test {
+                  void test(Set<String> set) {
+                      String[] array = (String[]) set.toArray();
+                  }
+              }
+              """,
+            """
+              import java.util.Set;
+
+              class Test {
+                  void test(Set<String> set) {
+                      String[] array = set.toArray(new String[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void worksWithArrayLists() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.ArrayList;
+
+              class Test {
+                  void test(ArrayList<String> list) {
+                      String[] array = (String[]) list.toArray();
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayList;
+
+              class Test {
+                  void test(ArrayList<String> list) {
+                      String[] array = list.toArray(new String[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void inMethodParameter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  void process(String[] array) {}
+
+                  void test(List<String> list) {
+                      process((String[]) list.toArray());
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  void process(String[] array) {}
+
+                  void test(List<String> list) {
+                      process(list.toArray(new String[0]));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void inReturnStatement() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  String[] test(List<String> list) {
+                      return (String[]) list.toArray();
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  String[] test(List<String> list) {
+                      return list.toArray(new String[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Implements RSPEC-S3020 to fix redundant casts when using Collection.toArray() without parameters
- Replaces calls like `(String[]) list.toArray()` with `list.toArray(new String[0])`