### PR TITLE
Add RemovePrivateFieldUnderscores recipe

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemovePrivateFieldUnderscores.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemovePrivateFieldUnderscores.java
@@ -60,6 +60,10 @@ public class RemovePrivateFieldUnderscores extends Recipe {
                     String oldName = variable.getSimpleName();
                     if (oldName.startsWith("_") || oldName.endsWith("_")) {
                         String newName = oldName.startsWith("_") ? oldName.substring(1) : oldName.substring(0, oldName.length() - 1);
+                        if (newName.startsWith("_") || newName.endsWith("_") || newName.isEmpty()) {
+                            continue;
+                        }
+
                         doAfterVisit(new QualifyAmbiguousFieldAccess(variable, newName));
                         doAfterVisit(new RenameVariable(variable, newName));
                     }

--- a/src/test/java/org/openrewrite/staticanalysis/RemovePrivateFieldUnderscoresTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemovePrivateFieldUnderscoresTest.java
@@ -273,4 +273,19 @@ class RemovePrivateFieldUnderscoresTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotRenameToUnnamedVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class MyClass {
+                  private String __;
+                  private int ___;
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
This recipe removes prefix or suffix underscores from private class field names. This helps enforce modern Java coding standards.

For clarity and consistency, the recipe also adds a  qualifier to all updated field accesses. This prevents ambiguity with local variables and ensures a uniform style throughout the class.

## What's your motivation?
- Fixes #630

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
