### PR TITLE
fix false positive in `RemoveUnusedPrivateMethods`

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedPrivateMethodsTest.java
@@ -1151,7 +1151,7 @@ class RemoveUnusedPrivateMethodsTest implements RewriteTest {
                           try {
                               Mapper.Builder builder = currentBuilder.get();
                               for (int i = 1; i < parts.length; i++) {
-                                  List<Mapper.Builder> childBuilders = getChildBuilders(builder);
+                                  List<Mapper.Builder> childBuilders = getChildBuilders(builder); // fixme gets removed
                                   int finalI = i;
 
                                   // First try to find in regular child builders


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

- https://github.com/opensearch-project/OpenSearch/pull/18791

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
