### PR TITLE
Heap size of 1G for tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,3 +43,7 @@ dependencies {
     testRuntimeOnly("org.openrewrite:rewrite-java-21")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
 }
+
+tasks.withType<Test> {
+    jvmArgs("-Xmx1g", "-Xms512m")
+}


### PR DESCRIPTION
## What's changed?

Increasing the max heap size (Xmx) for tests to 1G as opposed to default 0.5G.

## What's your motivation?

I keep on getting OOME for selected runs of the tests both in IntelliJ and in command line Gradle:
```
                    Caused by:
                    java.lang.OutOfMemoryError
                        at java.base/java.lang.invoke.DirectMethodHandle$Holder.newInvokeSpecial(DirectMethodHandle$Holder)
                        at java.base/java.lang.invoke.Invokers$Holder.invokeExact_MT(Invokers$Holder)
                        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
                        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
                        at java.base/java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:542)
                        at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:567)
                        at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:653)
                        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
                        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
                        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
                        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
                        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)

                        Caused by:
                        java.lang.OutOfMemoryError: Java heap space
```