### PR TITLE
SimplifyBooleanExpressionWithDeMorgan - Add parens when converting to OR

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorgan.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorgan.java
@@ -107,8 +107,8 @@ public class SimplifyBooleanExpressionWithDeMorgan extends Recipe {
             @Override
             public @Nullable J postVisit(@NonNull J tree, ExecutionContext ctx) {
                 J ret = super.postVisit(tree, ctx);
+                if (getCursor().pollMessage("MIGHT_NEED_PARENTHESES") != null) {
                     return new ParenthesizeVisitor<>().visit(ret, ctx);
-                    return new ParenthesizeVisitor<>().visit(ret, executionContext);
                 };
                 return ret;
             }

--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorgan.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorgan.java
@@ -105,9 +105,9 @@ public class SimplifyBooleanExpressionWithDeMorgan extends Recipe {
             }
 
             @Override
-            public @Nullable J postVisit(@NonNull J tree, ExecutionContext executionContext) {
-                J ret = super.postVisit(tree, executionContext);
-                if (getCursor().pollMessage("MIGHT_NEED_PARENTHESES") != null) {
+            public @Nullable J postVisit(@NonNull J tree, ExecutionContext ctx) {
+                J ret = super.postVisit(tree, ctx);
+                    return new ParenthesizeVisitor<>().visit(ret, ctx);
                     return new ParenthesizeVisitor<>().visit(ret, executionContext);
                 };
                 return ret;

--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorgan.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorgan.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
@@ -95,11 +97,20 @@ public class SimplifyBooleanExpressionWithDeMorgan extends Recipe {
                         comments.addAll(parenthesesBinary.getComments());
                         comments.addAll(binary.getComments());
                         prefix = prefix.withComments(comments);
-                        binary = binary.withLeft(left).withRight(right).withOperator(newOperator).withPrefix(prefix);
-                        return new ParenthesizeVisitor<>().visit(binary, ctx);
+                        getCursor().getParent().putMessage("MIGHT_NEED_PARENTHESES", true);
+                        return binary.withLeft(left).withRight(right).withOperator(newOperator).withPrefix(prefix);
                     }
                 }
                 return requireNonNull(super.visitUnary(unary, ctx));
+            }
+
+            @Override
+            public @Nullable J postVisit(@NonNull J tree, ExecutionContext executionContext) {
+                J ret = super.postVisit(tree, executionContext);
+                if (getCursor().pollMessage("MIGHT_NEED_PARENTHESES") != null) {
+                    return new ParenthesizeVisitor<>().visit(ret, executionContext);
+                };
+                return ret;
             }
 
             private Expression negate(Expression expression) {

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorganTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanExpressionWithDeMorganTest.java
@@ -311,4 +311,25 @@ class SimplifyBooleanExpressionWithDeMorganTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void mixedOperators2() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            class Test {
+                boolean a, b, c;
+                boolean x = a && !(b && c);
+            }
+            """,
+            """
+            class Test {
+                boolean a, b, c;
+                boolean x = a && (!b || !c);
+            }
+            """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Follow-up on #659. Adding a call to ParenthesizeVisitor on the changed node's parent.

## What's your motivation?

Fixing a bug discovered when running the recipe against some OSS projects.
This is needed in some cases, especially when `&&` which is high precedence gets converted to `||` which has lower precedence.
