### PR TITLE
Fixing `twoCases` test case in `MinimumSwitchCasesTest`

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/groovy/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/groovy/MinimumSwitchCasesTest.java
@@ -33,7 +33,6 @@ class MinimumSwitchCasesTest implements RewriteTest {
     }
 
     @DocumentExample
-    @ExpectedToFail("Temporarily until we have investigated why the behavior has changed here")
     @Test
     void twoCases() {
         rewriteRun(
@@ -52,7 +51,7 @@ class MinimumSwitchCasesTest implements RewriteTest {
               """,
             """
               def s = "prod"
-              if (s == "prod") {
+              if ("prod".equals(s)) {
                   println("prod")
               } else {
                   println("default")


### PR DESCRIPTION
## What's changed?
Fixing `twoCases` test case in `MinimumSwitchCasesTest`.

## What's your motivation?

The fix is simple. Better test coverage.
