### PR TITLE
Add MavenJavadocNonAsciiRecipe to remove non-ASCII characters from Ja…

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/maven/MavenJavadocNonAsciiRecipe.java
+++ b/src/main/java/org/openrewrite/staticanalysis/maven/MavenJavadocNonAsciiRecipe.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.maven;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Javadoc;
+
+import java.text.Normalizer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Maven's javadoc-plugin configuration does not support non-ASCII characters in Javadoc comments.
+ * This can cause build failures with ambiguous error messages that don't clearly indicate the root cause.
+ * 
+ * This recipe removes non-ASCII characters from Javadoc comments by:
+ * 1. Normalizing text using Unicode NFKD form
+ * 2. Removing any characters that are not in the ASCII character set
+ * 
+ * This is particularly useful when working with international codebases or when comments
+ * contain accented characters, special symbols, or other non-ASCII content.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class MavenJavadocNonAsciiRecipe extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove non-ASCII characters from Javadoc";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Maven's javadoc-plugin configuration does not support non-ASCII characters. " +
+               "What makes it tricky is the error is very ambiguous and doesn't help in any way. " +
+               "This recipe removes those non-ASCII characters.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenJavadocNonAsciiPruner();
+    }
+
+    public class MavenJavadocNonAsciiPruner extends JavaIsoVisitor<ExecutionContext> {
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            return processComments(super.visitClassDeclaration(classDecl, executionContext), classDecl.getComments());
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+            return processComments(super.visitMethodDeclaration(method, executionContext), method.getComments());
+        }
+
+        @Override
+        public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext executionContext) {
+            return processComments(super.visitVariable(variable, executionContext), variable.getComments());
+        }
+
+        private <T extends J> T processComments(T jElement, List<Comment> comments) {
+            List<CommentChangeResult> prunedComments = pruneComments(comments);
+            if (prunedComments.stream().anyMatch(CommentChangeResult::isChanged)) {
+                return jElement.withComments(prunedComments.stream().map(CommentChangeResult::getComment).collect(Collectors.toList()));
+            }
+            return jElement;
+        }
+
+        private List<CommentChangeResult> pruneComments(List<Comment> comments) {
+            return comments.stream()
+                    .map(this::pruneNonAsciiCharacters)
+                    .collect(Collectors.toList());
+        }
+
+        private CommentChangeResult pruneNonAsciiCharacters(Comment comment) {
+            if (comment instanceof Javadoc.DocComment) {
+                Javadoc.DocComment jdc = (Javadoc.DocComment) comment;
+                AtomicBoolean changed = new AtomicBoolean(false);
+                return new CommentChangeResult(jdc.withBody(
+                        jdc.getBody().stream().map(jd -> {
+                            if (jd instanceof Javadoc.Text) {
+                                Javadoc.Text jdText = (Javadoc.Text) jd;
+                                String oldText = jdText.getText();
+                                String newText = Normalizer.normalize(jdText.getText(), Normalizer.Form.NFKD)
+                                        .replaceAll("[^\\p{ASCII}]", "");
+                                if (!oldText.equals(newText)) {
+                                    changed.set(true);
+                                }
+                                return jdText.withText(newText);
+                            }
+                            return jd;
+                        }).collect(Collectors.toList())
+                ), changed.get());
+            }
+            return new CommentChangeResult(comment, false);
+        }
+    }
+
+    public class CommentChangeResult {
+        private final Comment comment;
+        private final boolean changed;
+
+        public CommentChangeResult(Comment comment, boolean changed) {
+            this.comment = comment;
+            this.changed = changed;
+        }
+
+        public Comment getComment() {
+            return comment;
+        }
+
+        public boolean isChanged() {
+            return changed;
+        }
+    }
+} 

--- a/src/test/java/org/openrewrite/staticanalysis/maven/MavenJavadocNonAsciiRecipeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/maven/MavenJavadocNonAsciiRecipeTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.maven;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MavenJavadocNonAsciiRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MavenJavadocNonAsciiRecipe());
+    }
+
+    @DocumentExample
+    @Test
+    void originalTestCase() {
+        rewriteRun(
+            java(
+                """
+                /**
+                * this is a sample class
+                * ₤€ contains non ascii characters
+                */
+                class A {
+                    /**
+                    * this is the main method
+                    */
+                    public static void main(String... args) {
+                        System.out.println("Hello World!");
+                    }
+                }
+                """,
+                """
+                /**
+                * this is a sample class
+                *  contains non ascii characters
+                */
+                class A {
+                    /**
+                    * this is the main method
+                    */
+                    public static void main(String... args) {
+                        System.out.println("Hello World!");
+                    }
+                }
+                """
+            )
+        );
+    }
+
+    @Test
+    void doesNotChangeRegularAsciiJavadoc() {
+        rewriteRun(
+            java(
+                """
+                /**
+                 * This is a regular ASCII comment.
+                 * No changes should be made here.
+                 */
+                public class Example {
+                    
+                    /**
+                     * Another regular method comment.
+                     */
+                    public void regularMethod() {
+                    }
+                }
+                """
+            )
+        );
+    }
+} 


### PR DESCRIPTION
…vadoc

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added `MavenJavadocNonAsciiRecipe` to automatically remove non-ASCII characters from Javadoc comments. This recipe helps prevent Maven javadoc-plugin build failures caused by non-ASCII characters with ambiguous error messages.

## What's your motivation?
Maven's javadoc-plugin does not handle non-ASCII characters well and often fails with very ambiguous error messages that don't clearly indicate the root cause. This makes it difficult for developers to identify and fix the issue, especially in international codebases where accented characters, special symbols, or other non-ASCII content may be present in documentation.

## Anything in particular you'd like reviewers to focus on?
- **Recipe Logic**: The Unicode normalization approach using `Normalizer.Form.NFKD` followed by ASCII filtering
- **Test Coverage**: Verification that both positive cases (non-ASCII removal) and negative cases (ASCII preservation) work correctly
- **Performance**: The recipe processes comments efficiently without unnecessary tree traversals
- **Edge Cases**: Handling of empty/null text and various Unicode character types

