### PR TITLE
Keep indentation when running `FinalizePrivateFields`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizePrivateFields.java
@@ -106,13 +106,12 @@ public class FinalizePrivateFields extends Recipe {
                         .allMatch(privateFieldsToBeFinalized::contains);
 
                 if (canAllVariablesBeFinalized) {
-                    mv = autoFormat(mv.withVariables(ListUtils.map(mv.getVariables(), v -> {
+                    return mv.withVariables(ListUtils.map(mv.getVariables(), v -> {
                         JavaType.Variable type = v.getVariableType();
-                        return type != null ? v.withVariableType(type.withFlags(
-                                Flag.bitMapToFlags(type.getFlagsBitMap() | Flag.Final.getBitMask()))) : null;
+                        return type != null ? v.withVariableType(type.withFlags(Flag.bitMapToFlags(type.getFlagsBitMap() | Flag.Final.getBitMask()))) : null;
                     })).withModifiers(ListUtils.concat(mv.getModifiers(),
-                            new J.Modifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, isInstanceOfCs(topLevel) ? "readonly" : "final",
-                                    isInstanceOfCs(topLevel) ? J.Modifier.Type.LanguageExtension : J.Modifier.Type.Final, emptyList()))), ctx);
+                            new J.Modifier(Tree.randomId(), mv.getModifiers().isEmpty() ? Space.EMPTY : Space.SINGLE_SPACE, Markers.EMPTY, isInstanceOfCs(topLevel) ? "readonly" : "final",
+                                    isInstanceOfCs(topLevel) ? J.Modifier.Type.LanguageExtension : J.Modifier.Type.Final, emptyList())));
                 }
 
                 return mv;

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizePrivateFieldsTest.java
@@ -896,4 +896,34 @@ class FinalizePrivateFieldsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void keepIndentation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.InputStream;
+
+              class A {
+                private InputStream in;
+
+                public A(InputStream aInputStream) {
+                  in = aInputStream;
+                }
+              }
+              """,
+            """
+              import java.io.InputStream;
+
+              class A {
+                private final InputStream in;
+
+                public A(InputStream aInputStream) {
+                  in = aInputStream;
+                }
+              }
+              """
+          ));
+    }
 }


### PR DESCRIPTION
## What's changed?
Indentation is kept when running the `FinalizePrivateFields` recipe.

## What's your motivation?
Prior to this PR, it would always create an indentation of 4 spaces prior to the modifiers.

## Any additional context
You could argue this problem should actually be fixed in the `autoFormat` function. Though I do agree with that kind of thought, in this case it's still better to no use the auto formatting feature at all, as there are only two options:
- Newly added `final` modifier is the first modifier: no prefix
- Newly added `final` modifier is the not the first modifier: prefix.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
