### PR TITLE
Prefer System getProperty() over getenv()

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/PreferSystemGetPropertyOverGetenv.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PreferSystemGetPropertyOverGetenv.java
@@ -1,0 +1,43 @@
+package org.openrewrite.staticanalysis;
+
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+
+public class PreferSystemGetPropertyOverGetenv extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Prefer System.getProperty(\"user.home\") over System.getenv(\"HOME\")";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces System.getenv(\"HOME\") with System.getProperty(\"user.home\") for better portability.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (method.getSimpleName().equals("getenv")
+                        && method.getArguments().size() == 1
+                        && method.getArguments().get(0).printTrimmed().equals("\"HOME\"")) {
+
+                    maybeAddImport("java.lang.System");
+
+                    return JavaTemplate.builder("System.getProperty(\"user.home\")")
+                            .imports("java.lang.System")
+                            .build()
+                            .apply(updateCursor(method), method.getCoordinates().replace());
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+        };
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/PreferSystemGetPropertyOverGetenvTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PreferSystemGetPropertyOverGetenvTest.java
@@ -1,0 +1,36 @@
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import static org.openrewrite.java.Assertions.java;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+class PreferSystemGetPropertyOverGetenvTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new PreferSystemGetPropertyOverGetenv());
+    }
+
+    @Test
+    void replacesEnvWithProperty() {
+        rewriteRun(
+          java(
+            """
+            class A {
+                void test() {
+                    String home = System.getenv("HOME");
+                }
+            }
+            """,
+            """
+            class A {
+                void test() {
+                    String home = System.getProperty("user.home");
+                }
+            }
+            """
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Added a new recipe that replaces 'System.getenv("HOME")' with 'System.getProperty("user.home")'.

## What's your motivation?
Draft PR for #624 

## Anything in particular you'd like reviewers to focus on?
Nothing in specific

## Have you considered any alternatives or workarounds?
Not yet, but open to discussion

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
