### PR TITLE
PreferIncrementOperator - more coverage - compound assignment operators

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/PreferIncrementOperator.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PreferIncrementOperator.java
@@ -39,7 +39,7 @@ public class PreferIncrementOperator extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Prefer the use of increment and decrement operators (`++`, `--`, `+=`, `-=`) over their more verbose equivalents when incrementing or decrementing.";
+        return "Prefer the use of increment and decrement operators (`++`, `--`, `+=`, `-=`) over their more verbose equivalents.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/PreferIncrementOperator.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PreferIncrementOperator.java
@@ -33,12 +33,12 @@ public class PreferIncrementOperator extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Prefer increment and decrement operators";
+        return "Prefer increment/decrement and compound assignment operators";
     }
 
     @Override
     public String getDescription() {
-        return "Prefer the use of increment and decrement operators (`++` and `--`) over their more verbose equivalents.";
+        return "Prefer the use of increment and decrement operators (`++`, `--`, `+=`, `-=`) over their more verbose equivalents when incrementing or decrementing. ";
     }
 
     @Override
@@ -84,6 +84,20 @@ public class PreferIncrementOperator extends Recipe {
                                                         assignment.getMarkers(),
                                                         new JLeftPadded<>(Space.EMPTY, unaryType, Markers.EMPTY),
                                                         variable.withPrefix(Space.EMPTY),
+                                                        assignment.getType()
+                                                );
+                                            } else if (literal.getValue() instanceof Integer || literal.getValue() instanceof Long) {
+                                                // For values other than 1, convert to compound assignment
+                                                J.AssignmentOperation.Type opType = binary.getOperator() == J.Binary.Type.Addition ?
+                                                        J.AssignmentOperation.Type.Addition : J.AssignmentOperation.Type.Subtraction;
+
+                                                return new J.AssignmentOperation(
+                                                        Tree.randomId(),
+                                                        assignment.getPrefix(),
+                                                        assignment.getMarkers(),
+                                                        variable.withPrefix(Space.EMPTY),
+                                                        new JLeftPadded<>(Space.SINGLE_SPACE, opType, Markers.EMPTY),
+                                                        literal.withPrefix(Space.SINGLE_SPACE),
                                                         assignment.getType()
                                                 );
                                             }

--- a/src/main/java/org/openrewrite/staticanalysis/PreferIncrementOperator.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PreferIncrementOperator.java
@@ -21,6 +21,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -38,7 +39,7 @@ public class PreferIncrementOperator extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Prefer the use of increment and decrement operators (`++`, `--`, `+=`, `-=`) over their more verbose equivalents when incrementing or decrementing. ";
+        return "Prefer the use of increment and decrement operators (`++`, `--`, `+=`, `-=`) over their more verbose equivalents when incrementing or decrementing.";
     }
 
     @Override
@@ -62,47 +63,45 @@ public class PreferIncrementOperator extends Recipe {
                     if (statement instanceof J.Assignment) {
                         J.Assignment assignment = (J.Assignment) statement;
 
-                        if (assignment.getVariable() instanceof J.Identifier && assignment.getAssignment() instanceof J.Binary) {
-                            J.Identifier variable = (J.Identifier) assignment.getVariable();
+                        if (assignment.getAssignment() instanceof J.Binary) {
+                            Expression variable = assignment.getVariable();
                             J.Binary binary = (J.Binary) assignment.getAssignment();
 
                             if (binary.getOperator() == J.Binary.Type.Addition || binary.getOperator() == J.Binary.Type.Subtraction) {
-                                if (binary.getLeft() instanceof J.Identifier) {
-                                    J.Identifier binaryLeft = (J.Identifier) binary.getLeft();
-                                    if (variable.getSimpleName().equals(binaryLeft.getSimpleName()) &&
-                                        TypeUtils.isOfType(variable.getType(), binaryLeft.getType())) {
+                                Expression binaryLeft = binary.getLeft();
 
-                                        if (binary.getRight() instanceof J.Literal) {
-                                            J.Literal literal = (J.Literal) binary.getRight();
-                                            if (literal.getValue() instanceof Integer && (Integer) literal.getValue() == 1) {
-                                                J.Unary.Type unaryType = binary.getOperator() == J.Binary.Type.Addition ?
-                                                        J.Unary.Type.PostIncrement : J.Unary.Type.PostDecrement;
+                                if (SemanticallyEqual.areEqual(variable, binaryLeft)) {
+                                    Expression right = binary.getRight();
 
-                                                return new J.Unary(
-                                                        Tree.randomId(),
-                                                        assignment.getPrefix(),
-                                                        assignment.getMarkers(),
-                                                        new JLeftPadded<>(Space.EMPTY, unaryType, Markers.EMPTY),
-                                                        variable.withPrefix(Space.EMPTY),
-                                                        assignment.getType()
-                                                );
-                                            } else if (literal.getValue() instanceof Integer || literal.getValue() instanceof Long) {
-                                                // For values other than 1, convert to compound assignment
-                                                J.AssignmentOperation.Type opType = binary.getOperator() == J.Binary.Type.Addition ?
-                                                        J.AssignmentOperation.Type.Addition : J.AssignmentOperation.Type.Subtraction;
+                                    if (right instanceof J.Literal) {
+                                        J.Literal literal = (J.Literal) right;
+                                        if (literal.getValue() instanceof Integer && (Integer) literal.getValue() == 1) {
+                                            J.Unary.Type unaryType = binary.getOperator() == J.Binary.Type.Addition ?
+                                                    J.Unary.Type.PostIncrement : J.Unary.Type.PostDecrement;
 
-                                                return new J.AssignmentOperation(
-                                                        Tree.randomId(),
-                                                        assignment.getPrefix(),
-                                                        assignment.getMarkers(),
-                                                        variable.withPrefix(Space.EMPTY),
-                                                        new JLeftPadded<>(Space.SINGLE_SPACE, opType, Markers.EMPTY),
-                                                        literal.withPrefix(Space.SINGLE_SPACE),
-                                                        assignment.getType()
-                                                );
-                                            }
+                                            return new J.Unary(
+                                                    Tree.randomId(),
+                                                    assignment.getPrefix(),
+                                                    assignment.getMarkers(),
+                                                    new JLeftPadded<>(Space.EMPTY, unaryType, Markers.EMPTY),
+                                                    variable.withPrefix(Space.EMPTY),
+                                                    assignment.getType()
+                                            );
                                         }
                                     }
+
+                                    J.AssignmentOperation.Type opType = binary.getOperator() == J.Binary.Type.Addition ?
+                                            J.AssignmentOperation.Type.Addition : J.AssignmentOperation.Type.Subtraction;
+
+                                    return new J.AssignmentOperation(
+                                            Tree.randomId(),
+                                            assignment.getPrefix(),
+                                            assignment.getMarkers(),
+                                            variable.withPrefix(Space.EMPTY),
+                                            new JLeftPadded<>(Space.SINGLE_SPACE, opType, Markers.EMPTY),
+                                            right.withPrefix(Space.SINGLE_SPACE),
+                                            assignment.getType()
+                                    );
                                 }
                             }
                         }

--- a/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
@@ -23,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings({"ConstantConditions", "UnusedAssignment"})
 class PreferIncrementOperatorTest implements RewriteTest {
 
     @Override
@@ -132,7 +132,8 @@ class PreferIncrementOperatorTest implements RewriteTest {
           java(
             """
               class Test {
-                  void test(int i, int j) {
+                  int i, j = 0;
+                  Test() {
                       i = j + 1;
                   }
               }
@@ -143,6 +144,7 @@ class PreferIncrementOperatorTest implements RewriteTest {
 
     @Test
     void doNotChangeIfOrderIsReversed() {
+        // No strong feelings here, just documenting the current behavior of not applying the change here.
         rewriteRun(
           java(
             """

--- a/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
@@ -204,26 +204,45 @@ class PreferIncrementOperatorTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Not implemented yet")
     @Test
-    void fieldIncrement() {
+    void compoundAssignmentWithNonLiterals() {
         rewriteRun(
           java(
             """
               class Test {
-                  int count;
+                  int field = 4;
+                  int[] arr = new int[10];
+                  Test other;
 
-                  void test() {
-                      this.count = this.count + 1;
+                  void test(int i, int j, int k, int size) {
+                      i = i + j;
+                      k = k - size;
+                      i = i + "alef".length();
+                      j = j - (k * 2);
+                      field = field + 4;
+                      this.field = this.field + 3;
+                      this.field = field + 6; // This is not changed as the logic to detect "this.field" is equivalent to "field" in this case is not implemented.
+                      arr/*comment*/[0] = arr/*other comment*/[0] + 1;
+                      other.field = other.field + 2;
                   }
               }
               """,
             """
               class Test {
-                  int count;
+                  int field = 4;
+                  int[] arr = new int[10];
+                  Test other;
 
-                  void test() {
-                      this.count++;
+                  void test(int i, int j, int k, int size) {
+                      i += j;
+                      k -= size;
+                      i += "alef".length();
+                      j -= (k * 2);
+                      field += 4;
+                      this.field += 3;
+                      this.field = field + 6; // This is not changed as the logic to detect "this.field" is equivalent to "field" in this case is not implemented.
+                      arr/*comment*/[0]++;
+                      other.field += 2;
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PreferIncrementOperatorTest.java
@@ -105,37 +105,20 @@ class PreferIncrementOperatorTest implements RewriteTest {
     }
 
     @Test
-    void multipleIncrements() {
-        rewriteRun(
-          java(
-            """
-              class Test {
-                  void test(int i, int j) {
-                      i = i + 1;
-                      j = j - 1;
-                  }
-              }
-              """,
-            """
-              class Test {
-                  void test(int i, int j) {
-                      i++;
-                      j--;
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doNotChangeNonLiteralOne() {
+    void incrementByTwo() {
         rewriteRun(
           java(
             """
               class Test {
                   void test(int i) {
                       i = i + 2;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int i) {
+                      i += 2;
                   }
               }
               """
@@ -174,20 +157,46 @@ class PreferIncrementOperatorTest implements RewriteTest {
     }
 
     @Test
-    void longType() {
+    void compoundAssignmentForVariousValues() {
         rewriteRun(
           java(
             """
               class Test {
-                  void test(long l) {
-                      l = l + 1;
+                  void test(int i, int j, long l, long n) {
+                      i = i + 1;
+                      j = j + 5;
+                      i = i + 100;
+                      l = l + 2L;
+                      n = n - 2;
                   }
               }
               """,
             """
               class Test {
-                  void test(long l) {
-                      l++;
+                  void test(int i, int j, long l, long n) {
+                      i++;
+                      j += 5;
+                      i += 100;
+                      l += 2L;
+                      n -= 2;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeAssignmentInIfCondition() {
+        // No strong feelings here, just documenting the current behavior of not applying the change here.
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test(int i) {
+                      if ((i = i + 1) > 10) {
+                          System.out.println(i);
+                      }
                   }
               }
               """


### PR DESCRIPTION
## What's changed?

Extensions of `PreferIncrementOperator` added in #676 to cover more cases - i.e. when the increment is not by `1`, but by some expression.

## What's your motivation?

Cover more cases in the recipe.
