### PR TITLE
Fix RemoveExtraSemicolons to handle semicolons after imports

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveExtraSemicolons.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveExtraSemicolons.java
@@ -21,6 +21,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 
@@ -57,6 +58,15 @@ public class RemoveExtraSemicolons extends Recipe {
     @SuppressWarnings("ConstantConditions")
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public Space visitSpace(Space space, Space.Location loc, ExecutionContext ctx) {
+                Space s = super.visitSpace(space, loc, ctx);
+                String whitespace = s.getWhitespace();
+                if (whitespace.contains(";")) {
+                    return s.withWhitespace(whitespace.replace(";", ""));
+                }
+                return s;
+            }
 
             @Override
             public J.Block visitBlock(final J.Block block, final ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveExtraSemicolons.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveExtraSemicolons.java
@@ -21,7 +21,6 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -360,25 +360,6 @@ examples:
 - description: ''
   sources:
   - before: |
-      class A {
-          void foo() throws IllegalAccessException {
-              try {
-                  throw new IllegalAccessException();
-              } catch (Exception e) {
-                  throw e; // `e` is removed below
-              }
-          }
-      }
-    after: |
-      class A {
-          void foo() throws IllegalAccessException {
-              throw new IllegalAccessException();
-          }
-      }
-    language: java
-- description: ''
-  sources:
-  - before: |
       import java.io.FileReader;
       import java.io.IOException;
 
@@ -398,6 +379,25 @@ examples:
       class A {
           void foo() throws IOException {
               new FileReader("").read();
+          }
+      }
+    language: java
+- description: ''
+  sources:
+  - before: |
+      class A {
+          void foo() throws IllegalAccessException {
+              try {
+                  throw new IllegalAccessException();
+              } catch (Exception e) {
+                  throw e; // `e` is removed below
+              }
+          }
+      }
+    after: |
+      class A {
+          void foo() throws IllegalAccessException {
+              throw new IllegalAccessException();
           }
       }
     language: java
@@ -2941,18 +2941,6 @@ examples:
 - description: ''
   sources:
   - before: |
-      fun getSymbol() : String? {
-          return null
-      }
-    language: kotlin
-  - before: |
-      val isPositive = getSymbol().equals("+") == true
-    after: |
-      val isPositive = getSymbol().equals("+")
-    language: kotlin
-- description: ''
-  sources:
-  - before: |
       public class A {
           boolean a;
           {
@@ -2969,6 +2957,18 @@ examples:
           }
       }
     language: java
+- description: ''
+  sources:
+  - before: |
+      fun getSymbol() : String? {
+          return null
+      }
+    language: kotlin
+  - before: |
+      val isPositive = getSymbol().equals("+") == true
+    after: |
+      val isPositive = getSymbol().equals("+")
+    language: kotlin
 ---
 type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.staticanalysis.SimplifyBooleanExpressionWithDeMorgan

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveExtraSemicolonsTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import java.util.List;
 
@@ -258,6 +259,28 @@ class RemoveExtraSemicolonsTest implements RewriteTest {
                  public static final String X = "receipt-id";
              }
              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/669")
+    @Test
+    void afterImport() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.all().allowNonWhitespaceInWhitespace(true)),
+          java(
+            """
+              import java.util.List;;
+              interface A {
+                  List<String> getList();
+              }
+              """,
+            """
+              import java.util.List;
+              interface A {
+                  List<String> getList();
+              }
+              """
           )
         );
     }


### PR DESCRIPTION
## Summary
- Modified `RemoveExtraSemicolons` recipe to remove semicolons from all whitespace by overriding `visitSpace`
- Added test case to verify extra semicolons after imports are properly removed
- The solution handles the parsing issue where extra semicolons get placed into whitespace

## What's changed?
The recipe now removes any semicolons found in whitespace throughout the AST. This addresses the issue where extra semicolons after imports (like `import java.util.List;;`) are parsed into the whitespace rather than being parsed as separate tokens.

## Test plan
- [x] Added new test case `afterImport()` that verifies semicolons after imports are removed
- [x] All existing tests continue to pass
- [x] Test includes `TypeValidation.all().allowNonWhitespaceInWhitespace(true)` to handle the parser behavior

Fixes #669

🤖 Generated with [Claude Code](https://claude.ai/code)