### PR TITLE
Fix NPE for new arrays with initializers in `ReplaceCollectionToArrayArgWithEmptyArray`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArray.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArray.java
@@ -64,7 +64,9 @@ public class ReplaceCollectionToArrayArgWithEmptyArray extends Recipe {
 
         @Override
         public J.NewArray visitNewArray(J.NewArray newArray, P p) {
-            if (COLLECTION_TO_ARRAY.advanced().isFirstArgument(getCursor()) && newArray.getDimensions().size() == 1) {
+            boolean isInitializerEmpty = newArray.getInitializer() == null
+                    || (newArray.getInitializer().size() == 1 && newArray.getInitializer().get(0) instanceof J.Empty);
+            if (COLLECTION_TO_ARRAY.advanced().isFirstArgument(getCursor()) && isInitializerEmpty) {
                 J.NewArray newArrayZero = newArray.withDimensions(ListUtils.mapFirst(newArray.getDimensions(), d -> {
                     if (d.getIndex() instanceof J.Literal && Integer.valueOf(0).equals(((J.Literal) d.getIndex()).getValue())) {
                         return d;

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArray.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArray.java
@@ -69,6 +69,13 @@ public class ReplaceCollectionToArrayArgWithEmptyArray extends Recipe {
                     if (d.getIndex() instanceof J.Literal && Integer.valueOf(0).equals(((J.Literal) d.getIndex()).getValue())) {
                         return d;
                     }
+                    JavaType.Primitive type;
+                    if (d.getIndex() instanceof J.Empty) {
+                        type = JavaType.Primitive.Int;
+                    } else {
+                        type = (JavaType.Primitive) requireNonNull(d.getIndex().getType());
+                    }
+
                     return d.withIndex(new J.Literal(
                             Tree.randomId(),
                             Space.EMPTY,
@@ -76,9 +83,10 @@ public class ReplaceCollectionToArrayArgWithEmptyArray extends Recipe {
                             0,
                             "0",
                             emptyList(),
-                            (JavaType.Primitive) requireNonNull(d.getIndex().getType())
+                            type
                     ));
                 }));
+                newArrayZero = newArrayZero.withInitializer(null);
                 return maybeAutoFormat(newArray, newArrayZero, p);
             }
             return super.visitNewArray(newArray, p);

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
@@ -85,7 +85,7 @@ class ReplaceCollectionToArrayArgWithEmptyArrayTest implements RewriteTest {
     }
 
     @Test
-    void replaceEmptyArrayWithZero() {
+    void replaceEmptyArrayInitializerWithZero() {
         rewriteRun(
           //language=java
           java(
@@ -104,6 +104,24 @@ class ReplaceCollectionToArrayArgWithEmptyArrayTest implements RewriteTest {
               class A {
                   void test(Collection<Integer> args){
                       Integer[] array = args.toArray(new Integer[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dontChangeNonEmptyInitializer() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Collection;
+
+              class A {
+                  void test(Collection<Integer> args){
+                      Integer[] array = args.toArray(new Integer[]{1, 2, 3});
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArrayTest.java
@@ -83,4 +83,31 @@ class ReplaceCollectionToArrayArgWithEmptyArrayTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void replaceEmptyArrayWithZero() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Collection;
+
+              class A {
+                  void test(Collection<Integer> args){
+                      Integer[] array = args.toArray(new Integer[]{});
+                  }
+              }
+              """,
+            """
+              import java.util.Collection;
+
+              class A {
+                  void test(Collection<Integer> args){
+                      Integer[] array = args.toArray(new Integer[0]);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

Amending `ReplaceCollectionToArrayArgWithEmptyArray` to handle the case of new array syntax with initializers:
- `new Integer[]{}`
- or `new Integer[]{1,2,3}`

The former is now converted to `new Integer[0]` as any other cases.
The latter is not touched.

## What's your motivation?
- fixes #703 