### PR TITLE
fix: Enhanced UseCollectionInterfaces to prevent conversions when non interface methods are used

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -276,17 +276,11 @@ public class UseCollectionInterfaces extends Recipe {
                 return method;
             }
             if (method.getSelect() != null) {
-                JavaType selectType = method.getSelect().getType();
-                JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(selectType);
-
-                if (fqType != null) {
-                    String className = fqType.getFullyQualifiedName();
-                    Set<String> concreteMethods = nonInterfaceMethods.get(className);
-
-                    if (concreteMethods != null && concreteMethods.contains(method.getSimpleName())) {
-                        foundNonInterfaceMethod.set(true);
-                        return method;
-                    }
+                JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(method.getSelect().getType());
+                if (fqType != null && nonInterfaceMethods.getOrDefault(fqType.getFullyQualifiedName(), emptySet())
+                        .contains(method.getSimpleName())) {
+                    foundNonInterfaceMethod.set(true);
+                    return method;
                 }
             }
             return super.visitMethodInvocation(method, foundNonInterfaceMethod);

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -268,6 +268,8 @@ public class UseCollectionInterfaces extends Recipe {
                     "contains", "elements", "keys"))));
             nonInterfaceMethods.put("java.util.Vector", unmodifiableSet(new HashSet<>(Arrays.asList(
                     "addElement", "capacity", "copyInto", "elementAt", "elements", "ensureCapacity", "insertElementAt", "removeAllElements", "removeElement", "removeElementAt", "setElementAt", "setSize", "trimToSize"))));
+            nonInterfaceMethods.put("java.util.ArrayList", unmodifiableSet(new HashSet<>(Arrays.asList(
+                    "ensureCapacity", "trimToSize"))));
         }
 
         @Override

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -64,6 +64,7 @@ public class UseCollectionInterfaces extends Recipe {
         rspecRulesReplaceTypeMap.put("java.util.AbstractSequentialList", "java.util.List");
         rspecRulesReplaceTypeMap.put("java.util.ArrayList", "java.util.List");
         rspecRulesReplaceTypeMap.put("java.util.concurrent.CopyOnWriteArrayList", "java.util.List");
+        rspecRulesReplaceTypeMap.put("java.util.Vector", "java.util.List");
         // Map
         rspecRulesReplaceTypeMap.put("java.util.AbstractMap", "java.util.Map");
         rspecRulesReplaceTypeMap.put("java.util.EnumMap", "java.util.Map");
@@ -85,6 +86,9 @@ public class UseCollectionInterfaces extends Recipe {
         rspecRulesReplaceTypeMap.put("java.util.concurrent.CopyOnWriteArraySet", "java.util.Set");
 
         nonInterfaceMethods.put("java.util.Hashtable", unmodifiableSet(new HashSet<>(Arrays.asList("keys", "elements", "contains"))));
+        nonInterfaceMethods.put("java.util.Vector", unmodifiableSet(new HashSet<>(Arrays.asList("elements", "capacity", "ensureCapacity", "setSize",
+                "copyInto", "trimToSize", "elementAt", "setElementAt", "removeElementAt",
+                "insertElementAt", "addElement", "removeElement", "removeAllElements"))));
     }
 
     @Override

--- a/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseCollectionInterfaces.java
@@ -24,9 +24,15 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
-import static java.util.Collections.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
 
@@ -87,8 +93,7 @@ public class UseCollectionInterfaces extends Recipe {
 
         nonInterfaceMethods.put("java.util.Hashtable", unmodifiableSet(new HashSet<>(Arrays.asList("keys", "elements", "contains"))));
         nonInterfaceMethods.put("java.util.Vector", unmodifiableSet(new HashSet<>(Arrays.asList("elements", "capacity", "ensureCapacity", "setSize",
-                "copyInto", "trimToSize", "elementAt", "setElementAt", "removeElementAt",
-                "insertElementAt", "addElement", "removeElement", "removeAllElements"))));
+                "copyInto", "trimToSize", "elementAt", "setElementAt", "removeElementAt", "insertElementAt", "addElement", "removeElement", "removeAllElements"))));
     }
 
     @Override

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
@@ -935,7 +934,6 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail
     @Issue("https://github.com/openrewrite/rewrite/issues/2973")
     @Test
     void explicitImplementationClassInApi() {
@@ -948,7 +946,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
 
               class Test {
                   List<Integer> m() {
-                      List<Integer> result = new ArrayList<>();
+                      ArrayList<Integer> result = new ArrayList<>();
                       m2(result);
                       return result;
                   }
@@ -1121,7 +1119,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Hashtable;
 
               class A {
-                  public Hashtable<String, Integer> useOnlyMapMethods() {
+                  Hashtable<String, Integer> useOnlyMapMethods() {
                       Hashtable<String, Integer> table = new Hashtable<>();
                       table.put("key", 1);
                       return table;
@@ -1133,7 +1131,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Map;
 
               class A {
-                  public Map<String, Integer> useOnlyMapMethods() {
+                  Map<String, Integer> useOnlyMapMethods() {
                       Map<String, Integer> table = new Hashtable<>();
                       table.put("key", 1);
                       return table;
@@ -1154,7 +1152,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Hashtable;
 
               class A {
-                  public Enumeration<Integer> usesMethodNotOnInterface() {
+                  Enumeration<Integer> usesMethodNotOnInterface() {
                       Hashtable<Integer,Object> table = new Hashtable<>();
                       return table.keys();
                   }
@@ -1172,7 +1170,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Vector;
 
               class A {
-                  public Vector getData() {
+                  Vector getData() {
                       Vector<String> vector = new Vector<>();
                       vector.add("item");
                       return vector;
@@ -1184,7 +1182,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Vector;
 
               class A {
-                  public List getData() {
+                  List getData() {
                       List<String> vector = new Vector<>();
                       vector.add("item");
                       return vector;
@@ -1204,7 +1202,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Vector;
 
               class A {
-                  public Enumeration<String> usesVectorElements() {
+                  Enumeration<String> usesVectorElements() {
                       Vector<String> vector = new Vector<>();
                       return vector.elements();
                   }

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -1119,16 +1119,16 @@ class UseCollectionInterfacesTest implements RewriteTest {
         rewriteRun(
           java(
             """
-                import java.util.Enumeration;
-                import java.util.Hashtable;
+              import java.util.Enumeration;
+              import java.util.Hashtable;
 
-                public class A {
-                    public Enumeration<Integer> usesMethodNotOnInterface() {
-                        Hashtable<Integer,Object> table = new Hashtable<>();
+              public class A {
+                  public Enumeration<Integer> usesMethodNotOnInterface() {
+                      Hashtable<Integer,Object> table = new Hashtable<>();
 
-                        return table.keys();
-                    }
-                }
+                      return table.keys();
+                  }
+              }
               """
           )
         );

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -1112,4 +1112,56 @@ class UseCollectionInterfacesTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/688")
+    @Test
+    void usesMethodNotOnInterface() {
+        rewriteRun(
+          java(
+            """
+                import java.util.Enumeration;
+                import java.util.Hashtable;
+
+                public class A {
+                    public Enumeration<Integer> usesMethodNotOnInterface() {
+                        Hashtable<Integer,Object> table = new Hashtable<>();
+
+                        return table.keys();
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void hashtableWithOnlyMapMethods() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Hashtable;
+
+              public class A {
+                  public Hashtable<String, Integer> useOnlyMapMethods() {
+                      Hashtable<String, Integer> table = new Hashtable<>();
+                      table.put("key", 1);
+                      return table;
+                  }
+              }
+              """,
+            """
+              import java.util.Hashtable;
+              import java.util.Map;
+
+              public class A {
+                  public Map<String, Integer> useOnlyMapMethods() {
+                      Map<String, Integer> table = new Hashtable<>();
+                      table.put("key", 1);
+                      return table;
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -1164,4 +1164,55 @@ class UseCollectionInterfacesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void vectorWithOnlyListMethods() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Vector;
+
+              public class A {
+                  public Vector getData() {
+                      Vector<String> vector = new Vector<>();
+                      vector.add("item");
+                      return vector;
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              import java.util.Vector;
+
+              public class A {
+                  public List getData() {
+                      List<String> vector = new Vector<>();
+                      vector.add("item");
+                      return vector;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void usesVectorElementsMethod() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Enumeration;
+              import java.util.Vector;
+
+              public class A {
+                  public Enumeration<String> usesVectorElements() {
+                      Vector<String> vector = new Vector<>();
+                      return vector.elements();
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseCollectionInterfacesTest.java
@@ -1113,27 +1113,6 @@ class UseCollectionInterfacesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/688")
-    @Test
-    void usesMethodNotOnInterface() {
-        rewriteRun(
-          java(
-            """
-              import java.util.Enumeration;
-              import java.util.Hashtable;
-
-              public class A {
-                  public Enumeration<Integer> usesMethodNotOnInterface() {
-                      Hashtable<Integer,Object> table = new Hashtable<>();
-
-                      return table.keys();
-                  }
-              }
-              """
-          )
-        );
-    }
-
     @Test
     void hashtableWithOnlyMapMethods() {
         rewriteRun(
@@ -1141,7 +1120,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
             """
               import java.util.Hashtable;
 
-              public class A {
+              class A {
                   public Hashtable<String, Integer> useOnlyMapMethods() {
                       Hashtable<String, Integer> table = new Hashtable<>();
                       table.put("key", 1);
@@ -1153,11 +1132,31 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Hashtable;
               import java.util.Map;
 
-              public class A {
+              class A {
                   public Map<String, Integer> useOnlyMapMethods() {
                       Map<String, Integer> table = new Hashtable<>();
                       table.put("key", 1);
                       return table;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/688")
+    @Test
+    void hashtableMethodNotOnInterface() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Enumeration;
+              import java.util.Hashtable;
+
+              class A {
+                  public Enumeration<Integer> usesMethodNotOnInterface() {
+                      Hashtable<Integer,Object> table = new Hashtable<>();
+                      return table.keys();
                   }
               }
               """
@@ -1172,7 +1171,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
             """
               import java.util.Vector;
 
-              public class A {
+              class A {
                   public Vector getData() {
                       Vector<String> vector = new Vector<>();
                       vector.add("item");
@@ -1184,7 +1183,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.List;
               import java.util.Vector;
 
-              public class A {
+              class A {
                   public List getData() {
                       List<String> vector = new Vector<>();
                       vector.add("item");
@@ -1204,7 +1203,7 @@ class UseCollectionInterfacesTest implements RewriteTest {
               import java.util.Enumeration;
               import java.util.Vector;
 
-              public class A {
+              class A {
                   public Enumeration<String> usesVectorElements() {
                       Vector<String> vector = new Vector<>();
                       return vector.elements();
@@ -1214,5 +1213,4 @@ class UseCollectionInterfacesTest implements RewriteTest {
           )
         );
     }
-
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Enhanced `UseCollectionInterfaces` recipe to prevent type conversions when concrete-class-specific methods are being used. 
Also, added support for  `java.util.Vector`

## What's your motivation?
- Closes #688
- Fixes https://github.com/openrewrite/rewrite-static-analysis/issues/671

## Anything in particular you'd like reviewers to focus on?
- The `nonInterfaceMethods` to ensure we've covered all the important methods
- Two-phase approach, ie first detect and then transform. Whether this is the most efficient way


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
