### PR TITLE
Improve support method invocations for `RemoveRedundantTypeCast`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -75,7 +75,7 @@ public class RemoveRedundantTypeCast extends Recipe {
                 JavaType castType = visitedTypeCast.getType();
 
                 JavaType targetType = null;
-                // Null-check; because for Kotlin's Gradle files, we don't always have all type information available
+                // Necessary null-check; because for Kotlin's Gradle files, we don't have all type information available
                 if (castType != null && castType.equals(expressionType)) {
                     targetType = castType;
                 } else if (parentValue instanceof J.VariableDeclarations) {

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -95,6 +95,9 @@ public class RemoveRedundantTypeCast extends Recipe {
                             }
                         }
                     }
+                    if (TypeUtils.isAssignableTo(castType, expressionType)) {
+                        targetType = castType;
+                    }
                 } else if (parentValue instanceof J.Return && ((J.Return) parentValue).getExpression() == typeCast) {
                     parent = parent.dropParentUntil(is -> is instanceof J.Lambda ||
                                                           is instanceof J.MethodDeclaration ||

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -75,7 +75,8 @@ public class RemoveRedundantTypeCast extends Recipe {
                 JavaType castType = visitedTypeCast.getType();
 
                 JavaType targetType = null;
-                if (castType.equals(expressionType)) {
+                // Null-check; because for Kotlin's Gradle files, we don't always have all type information available
+                if (castType != null && castType.equals(expressionType)) {
                     targetType = castType;
                 } else if (parentValue instanceof J.VariableDeclarations) {
                     targetType = ((J.VariableDeclarations) parentValue).getVariables().get(0).getType();

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -155,7 +155,7 @@ public class RemoveRedundantTypeCast extends Recipe {
             public <T extends J> J visitParentheses(J.Parentheses<T> parens, ExecutionContext ctx) {
                 J.Parentheses<T> parentheses = (J.Parentheses<T>) super.visitParentheses(parens, ctx);
                 if (getCursor().getMessage(REMOVE_UNNECESSARY_PARENTHESES, false)) {
-                    return parentheses.getTree();
+                    return parentheses.getTree().withPrefix(parentheses.getPrefix());
                 }
                 return parentheses;
             }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -149,8 +149,8 @@ public class RemoveRedundantTypeCast extends Recipe {
             }
 
             @Override
-            public <T extends J> J visitParentheses(J.Parentheses<T> parens, ExecutionContext executionContext) {
-                J.Parentheses<T> parentheses = (J.Parentheses<T>) super.visitParentheses(parens, executionContext);
+            public <T extends J> J visitParentheses(J.Parentheses<T> parens, ExecutionContext ctx) {
+                J.Parentheses<T> parentheses = (J.Parentheses<T>) super.visitParentheses(parens, ctx);
                 if (getCursor().getMessage(REMOVE_UNNECESSARY_PARENTHESES, false)) {
                     return parentheses.getTree();
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -98,7 +98,7 @@ public class RemoveRedundantTypeCast extends Recipe {
                     if (TypeUtils.isAssignableTo(castType, expressionType)) {
                         targetType = castType;
                     }
-                } else if (parentValue instanceof J.Return && ((J.Return) parentValue).getExpression() == typeCast) {
+                } else if (parentValue instanceof J.Return && expressionIsTypeCast((J.Return) parentValue, typeCast)) {
                     parent = parent.dropParentUntil(is -> is instanceof J.Lambda ||
                                                           is instanceof J.MethodDeclaration ||
                                                           is instanceof J.ClassDeclaration ||
@@ -168,6 +168,20 @@ public class RemoveRedundantTypeCast extends Recipe {
                 // varargs?
                 JavaType type = parameterTypes.get(parameterTypes.size() - 1);
                 return type instanceof JavaType.Array ? ((JavaType.Array) type).getElemType() : type;
+            }
+
+            private boolean expressionIsTypeCast(J.Return return_, J.TypeCast typeCast) {
+                if (return_.getExpression() instanceof J.Parentheses<?>) {
+                    return expressionIsTypeCast((J.Parentheses<?>) return_.getExpression(), typeCast);
+                }
+                return return_.getExpression() == typeCast;
+            }
+
+            private boolean expressionIsTypeCast(J.Parentheses<?> parentheses, J.TypeCast typeCast) {
+                if (parentheses.getTree() instanceof J.Parentheses) {
+                    return expressionIsTypeCast((J.Parentheses<?> ) parentheses.getTree(), typeCast);
+                }
+               return parentheses.getTree() == typeCast;
             }
         };
     }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -556,4 +556,48 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void chainedMethods() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              class Bar {
+                  String getName() {
+                      return "The bar";
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class Foo {
+                  public void getBarName() {
+                      String.format(((Bar) getBar()).getName());
+                      ((Bar) getBar()).getName();
+                      (((Bar) getBar())).getName();
+                  }
+
+                  private Bar getBar() {
+                      return new Bar();
+                  }
+              }
+              """,
+            """
+              class Foo {
+                  public void getBarName() {
+                      String.format(getBar().getName());
+                      getBar().getName();
+                      (getBar()).getName();
+                  }
+
+                  private Bar getBar() {
+                      return new Bar();
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.staticanalysis;
 
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -24,7 +23,6 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings("ALL")
 class RemoveRedundantTypeCastTest implements RewriteTest {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -22,7 +22,8 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings("ALL")
 class RemoveRedundantTypeCastTest implements RewriteTest {
@@ -606,6 +607,27 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
                   private ChildBar getChildBar() {
                       return new ChildBar();
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinDsl() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              class Test {
+                  val s2 = method() as String
+                  fun method() = "example"
+              }
+              """,
+            """
+              class Test {
+                  val s2 = method()
+                  fun method() = "example"
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -607,27 +608,6 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
                   private ChildBar getChildBar() {
                       return new ChildBar();
                   }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void kotlinDsl() {
-        rewriteRun(
-          //language=kotlin
-          kotlin(
-            """
-              class Test {
-                  val s2 = method() as String
-                  fun method() = "example"
-              }
-              """,
-            """
-              class Test {
-                  val s2 = method()
-                  fun method() = "example"
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -568,6 +568,7 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
                       return "The bar";
                   }
               }
+              class ChildBar extends Bar {}
               """
           ),
           java(
@@ -576,11 +577,16 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
                   public void getBarName() {
                       String.format(((Bar) getBar()).getName());
                       ((Bar) getBar()).getName();
-                      (((Bar) getBar())).getName();
+                      ((Bar) getChildBar()).getName();
+                      ((((Bar) getBar()))).getName();
                   }
 
                   private Bar getBar() {
                       return new Bar();
+                  }
+
+                  private ChildBar getChildBar() {
+                      return new ChildBar();
                   }
               }
               """,
@@ -589,11 +595,16 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
                   public void getBarName() {
                       String.format(getBar().getName());
                       getBar().getName();
-                      (getBar()).getName();
+                      getChildBar().getName();
+                      ((getBar())).getName();
                   }
 
                   private Bar getBar() {
                       return new Bar();
+                  }
+
+                  private ChildBar getChildBar() {
+                      return new ChildBar();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings("ALL")

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -471,7 +471,7 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
 
               class Test {
                   List method(List list) {
-                      return (ArrayList) list;
+                      return ((ArrayList) list);
                   }
               }
               """,


### PR DESCRIPTION
## What's changed?
- If a cast is performed with the **exact** same type as the expression, remove the cast.
- if a cast is performed on a methodCall and the type is a subtype of the expression, remove the cast.

## What's your motivation?
- https://github.com/moderneinc/rewrite-hibernate/pull/28/files#r2266719230

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
