### PR TITLE
Do not move field annotations around arrays

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToType.java
@@ -146,8 +146,7 @@ public class MoveFieldAnnotationToType extends Recipe {
 
             private boolean isQualifiedClass(@Nullable TypeTree tree) {
                 return tree instanceof J.FieldAccess ||
-                       (tree instanceof J.ParameterizedType && ((J.ParameterizedType) tree).getClazz() instanceof J.FieldAccess) ||
-                       tree instanceof J.ArrayType;
+                       (tree instanceof J.ParameterizedType && ((J.ParameterizedType) tree).getClazz() instanceof J.FieldAccess);
             }
 
             private TypeTree annotateInnerClass(TypeTree qualifiedClassRef, J.Annotation annotation) {
@@ -181,10 +180,6 @@ public class MoveFieldAnnotationToType extends Recipe {
                         ((J.ParameterizedType) qualifiedClassRef).getClazz() instanceof TypeTree) {
                     J.ParameterizedType pt = (J.ParameterizedType) qualifiedClassRef;
                     return pt.withClazz(annotateInnerClass((TypeTree) pt.getClazz(), usedAnnotation));
-                }
-                if (qualifiedClassRef instanceof J.ArrayType) {
-                    J.ArrayType at = (J.ArrayType) qualifiedClassRef;
-                    return at.withAnnotations(ListUtils.concat(annotation.withPrefix(Space.SINGLE_SPACE), at.getAnnotations()));
                 }
                 return qualifiedClassRef;
             }

--- a/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/java/MoveFieldAnnotationToTypeTest.java
@@ -93,20 +93,31 @@ class MoveFieldAnnotationToTypeTest implements RewriteTest {
     }
 
     @Test
-    void arrayFieldAnnotation() {
+    void arrayFieldAnnotationUnchanged() {
+        // As per: https://jspecify.dev/docs/user-guide/#type-use-annotation-syntax
         rewriteRun(
           //language=java
           java(
             """
               import org.openrewrite.internal.lang.Nullable;
-              class Test {
+              class ArrayOfNullableElements {
                   @Nullable String[] l;
               }
-              """,
+              """
+          ),
+          java(
             """
               import org.openrewrite.internal.lang.Nullable;
-              class Test {
+              class ArrayItselfNullable {
                   String @Nullable[] l;
+              }
+              """
+          ),
+          java(
+            """
+              import org.openrewrite.internal.lang.Nullable;
+              class NullableArrayOfNullableElements {
+                  @Nullable String @Nullable[] l;
               }
               """
           )


### PR DESCRIPTION
As per: https://jspecify.dev/docs/user-guide/#type-use-annotation-syntax