### PR TITLE
Use classpath from resource for Refaster

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,3 +47,7 @@ dependencies {
 tasks.withType<Test> {
     jvmArgs("-Xmx1g", "-Xms512m")
 }
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-Arewrite.javaParserClasspathFrom=resources")
+}


### PR DESCRIPTION
## What's changed?
Refaster can use type tables.

Mirrors change in
- https://github.com/openrewrite/rewrite-apache/pull/97

## Any additional context
This repository defines Refaster recipes, but those recipes don't need extra jars at all. With other words, there was no `.javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))` call needed. So this PR just adds the option to use the `classpathFromResources`, but actually never uses it.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
