### PR TITLE
`UnwrapElseAfterReturn` - Not unwrapping in case else if a simple if-return

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
@@ -357,11 +357,9 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
                   int foo(String str) {
                       if ("one".equals(str)) {
                           return 1;
-                      }
-                      if ("two".equals(str)) {
+                      } else if ("two".equals(str)) {
                           return 2;
-                      }
-                      if ("three".equals(str)) {
+                      } else if ("three".equals(str)) {
                           return 3;
                       }
                       return Integer.MAX_VALUE;
@@ -519,8 +517,7 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
                   String process(int value) {
                       if (value < 0) {
                           throw new IllegalArgumentException("Negative value");
-                      }
-                      if (value == 0) {
+                      } else if (value == 0) {
                           return "zero";
                       }
                       return "positive";


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
