### PR TITLE
Simplify `else` branch if it only has a single `if` (#666)

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyElseBranch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyElseBranch.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.List;
+
+import static org.openrewrite.java.format.ShiftFormat.indent;
+import static org.openrewrite.java.tree.Space.format;
+
+public class SimplifyElseBranch extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        // language=markdown
+        return "Simplify `else` branch if it only has a single `if`";
+    }
+
+    @Override
+    public String getDescription() {
+        // language=markdown
+        return "Simplify `else` branch if it only has a single `if`.";
+    }
+
+    @Override
+    public JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.If.Else visitElse(J.If.Else else_, ExecutionContext ctx) {
+                J.If.Else elseStatement = super.visitElse(else_, ctx);
+                final Statement body = elseStatement.getBody();
+                if (body instanceof J.Block) {
+                    final J.Block block = (J.Block) body;
+                    if (block.getStatements().size() == 1) {
+                        final Statement firstStatement = block.getStatements().get(0);
+                        if (firstStatement instanceof J.If) {
+                            J.If ifStatement = (J.If) firstStatement;
+                            // Combine comments from the block and the if statement
+                            final List<Comment> blockComments = block.getComments();
+                            final List<Comment> ifComments = ifStatement.getComments();
+                            ifStatement = ifStatement.withPrefix(format(" "));
+                            if (!ifComments.isEmpty() || !blockComments.isEmpty()) {
+                                ifStatement = ifStatement.withComments(ListUtils.concatAll(blockComments, ifComments));
+                            }
+                            elseStatement = elseStatement.withBody(indent(ifStatement, getCursor(), -1));
+                        }
+                    }
+                }
+                return elseStatement;
+            }
+        };
+    }
+}

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyElseBranchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyElseBranchTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SimplifyElseBranchTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new SimplifyElseBranch());
+    }
+
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/666")
+    @Test
+    void simplifyElseBranch() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else {
+                                if (password.length() > 12) {
+                                    System.out.println("Password is too long.");
+                                }
+                            }
+                        }
+                    }
+                    """,
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else if (password.length() > 12) {
+                                System.out.println("Password is too long.");
+                            }
+                        }
+                    }
+                    """
+          )
+        );
+    }
+
+    @Test
+    void noSimplifyWithTwoStatementsInElseBranch() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else {
+                                if (password.length() > 12) {
+                                    System.out.println("Password is too long.");
+                                }
+                                System.out.println("Password is six or more characters long.");
+                            }
+                        }
+                    }
+                    """
+          )
+        );
+    }
+
+    @Test
+    void simplifyIfWithElse() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else {
+                                if (password.length() <= 12) {
+                                    System.out.println("Password is ok.");
+                                } else {
+                                    System.out.println("Password is too long.");
+                                }
+                            }
+                        }
+                    }
+                    """,
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else if (password.length() <= 12) {
+                                System.out.println("Password is ok.");
+                            } else {
+                                System.out.println("Password is too long.");
+                            }
+                        }
+                    }
+                    """
+          )
+        );
+    }
+
+    @Test
+    void simplifyIfWithElseIf() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else {
+                                if (password.length() == 6) {
+                                    System.out.println("Password is six characters long.");
+                                } else if (password.length() == 7) {
+                                    System.out.println("Password is seven characters long.");
+                                } else if (password.length() == 8) {
+                                    System.out.println("Password is eight characters long.");
+                                } else if (password.length() <= 12) {
+                                    System.out.println("Password is ok.");
+                                } else {
+                                    System.out.println("Password is too long.");
+                                }
+                            }
+                        }
+                    }
+                    """,
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else if (password.length() == 6) {
+                                System.out.println("Password is six characters long.");
+                            } else if (password.length() == 7) {
+                                System.out.println("Password is seven characters long.");
+                            } else if (password.length() == 8) {
+                                System.out.println("Password is eight characters long.");
+                            } else if (password.length() <= 12) {
+                                System.out.println("Password is ok.");
+                            } else {
+                                System.out.println("Password is too long.");
+                            }
+                        }
+                    }
+                    """
+          )
+        );
+    }
+
+    @Test
+    void simplifyIfWithComments() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else /* Comment 0 */ { // Comment 1
+                                // Comment 2
+                                if (password.length() <= 12) { // Comment 3
+                                    // Comment 4
+                                    System.out.println("Password is ok.");
+                                } else {
+                                    System.out.println("Password is too long.");
+                                }
+                            }
+                        }
+                    }
+                    """,
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else /* Comment 0 */ // Comment 1
+                            // Comment 2
+                            if (password.length() <= 12) { // Comment 3
+                                // Comment 4
+                                System.out.println("Password is ok.");
+                            } else {
+                                System.out.println("Password is too long.");
+                            }
+                        }
+                    }
+                    """
+          )
+        );
+    }
+
+    @Test
+    void simplifyNestedIfs() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else {
+                                if (password.length() == 6) {
+                                    System.out.println("Password is six characters long.");
+                                } else {
+                                    if (password.length() == 7) {
+                                        System.out.println("Password is seven characters long.");
+                                    } else {
+                                        if (password.length() <= 12) {
+                                            System.out.println("Password is ok.");
+                                        } else {
+                                            System.out.println("Password is too long.");
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    """,
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else if (password.length() == 6) {
+                                System.out.println("Password is six characters long.");
+                            } else if (password.length() == 7) {
+                                System.out.println("Password is seven characters long.");
+                            } else if (password.length() <= 12) {
+                                System.out.println("Password is ok.");
+                            } else {
+                                System.out.println("Password is too long.");
+                            }
+                        }
+                    }
+                    """
+          )
+        );
+    }
+
+    @Test
+    void simplifyOuterIfWithElseIf() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else if (password.length() == 6) {
+                                System.out.println("Password is six characters long.");
+                            } else {
+                                if (password.length() <= 12) {
+                                    System.out.println("Password is ok.");
+                                } else {
+                                    System.out.println("Password is too long.");
+                                }
+                            }
+                        }
+                    }
+                    """,
+            """
+                    class A {
+                        void a(String password) {
+                            if (password.length() < 6) {
+                                System.out.println("Password is too short.");
+                            } else if (password.length() == 6) {
+                                System.out.println("Password is six characters long.");
+                            } else if (password.length() <= 12) {
+                                System.out.println("Password is ok.");
+                            } else {
+                                System.out.println("Password is too long.");
+                            }
+                        }
+                    }
+                    """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Implemented #666

## Anything in particular you'd like reviewers to focus on?
Maybe the way comments are handled between the `else` and the `if`.
They usually apply to the whole `else` branch.
With the simplification they could appear to apply only to the `then` part. 

## Anyone you would like to review specifically?
@greg-at-moderne, @timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
