### PR TITLE
721: Recipe to move fields to the top of class definition

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/MoveFieldsToTopOfClass.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MoveFieldsToTopOfClass.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class MoveFieldsToTopOfClass extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Move fields to the top of class definition";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Reorders class members so that all field declarations appear before any method declarations, " +
+               "constructors, or other class members. This improves code organization and readability by " +
+               "grouping field declarations together at the top of the class. Comments associated with fields " +
+               "are preserved during the reordering.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(2);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+
+                List<Statement> statements = cd.getBody().getStatements();
+                if (statements.isEmpty()) {
+                    return cd;
+                }
+
+                List<Statement> fieldDeclarations = new ArrayList<>();
+                List<Statement> otherStatements = new ArrayList<>();
+
+                // Separate field declarations from other statements
+                for (Statement statement : statements) {
+                    if (statement instanceof J.VariableDeclarations) {
+                        fieldDeclarations.add(statement);
+                    } else {
+                        otherStatements.add(statement);
+                    }
+                }
+
+                // If all fields are already at the top, no changes needed
+                if (fieldDeclarations.isEmpty() || isAlreadyOrdered(statements, fieldDeclarations)) {
+                    return cd;
+                }
+
+                // Reorder: fields first, then other statements
+                List<Statement> reorderedStatements = new ArrayList<>();
+
+                // Add field declarations with preserved comments and proper spacing
+                for (int i = 0; i < fieldDeclarations.size(); i++) {
+                    Statement field = fieldDeclarations.get(i);
+                    if (i == 0) {
+                        // First field should have the same prefix as the first statement originally had,
+                        // but preserve its original comments
+                        Space originalPrefix = field.getPrefix();
+                        Space firstStatementPrefix = statements.get(0).getPrefix();
+                        
+                        // Combine: use first statement's whitespace but preserve field's comments
+                        Space newPrefix = firstStatementPrefix.withComments(originalPrefix.getComments());
+                        field = field.withPrefix(newPrefix);
+                    }
+                    reorderedStatements.add(field);
+                }
+
+                // Add other statements
+                reorderedStatements.addAll(otherStatements);
+
+                return autoFormat(cd.withBody(cd.getBody().withStatements(reorderedStatements)), ctx);
+            }
+
+            private boolean isAlreadyOrdered(List<Statement> allStatements, List<Statement> fieldDeclarations) {
+                if (fieldDeclarations.isEmpty()) {
+                    return true;
+                }
+
+                int firstNonFieldIndex = -1;
+                for (int i = 0; i < allStatements.size(); i++) {
+                    if (!(allStatements.get(i) instanceof J.VariableDeclarations)) {
+                        firstNonFieldIndex = i;
+                        break;
+                    }
+                }
+
+                // If there are no non-field statements, or all fields come before first non-field
+                if (firstNonFieldIndex == -1) {
+                    return true;
+                }
+
+                // Check if any field declarations come after the first non-field statement
+                for (int i = firstNonFieldIndex; i < allStatements.size(); i++) {
+                    if (allStatements.get(i) instanceof J.VariableDeclarations) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/static-analysis.yml
+++ b/src/main/resources/META-INF/rewrite/static-analysis.yml
@@ -25,6 +25,7 @@ recipeList:
   - org.openrewrite.java.format.EmptyNewlineAtEndOfFile
   - org.openrewrite.staticanalysis.ForLoopControlVariablePostfixOperators
   - org.openrewrite.staticanalysis.FinalizePrivateFields
+  - org.openrewrite.staticanalysis.MoveFieldsToTopOfClass
   - org.openrewrite.java.format.MethodParamPad
   - org.openrewrite.java.format.NoWhitespaceAfter
   - org.openrewrite.java.format.NoWhitespaceBefore

--- a/src/test/java/org/openrewrite/staticanalysis/MoveFieldsToTopOfClassTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MoveFieldsToTopOfClassTest.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MoveFieldsToTopOfClassTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new MoveFieldsToTopOfClass());
+    }
+
+    @DocumentExample
+    @Test
+    void moveFieldsToTop() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void foo(String bar) {
+                      int i = Integer.parseInt(bar);
+                  }
+
+                  // Important field
+                  String myField = "important";
+              }
+              """,
+            """
+              class A {
+                  // Important field
+                  String myField = "important";
+
+                  void foo(String bar) {
+                      int i = Integer.parseInt(bar);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void moveMultipleFields() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Example {
+                  public void method1() {
+                      System.out.println("method1");
+                  }
+
+                  private String field1 = "value1";
+
+                  public Example() {
+                      // constructor
+                  }
+
+                  protected int field2 = 42;
+
+                  public void method2() {
+                      System.out.println("method2");
+                  }
+
+                  public static final String CONSTANT = "constant";
+              }
+              """,
+            """
+              class Example {
+                  private String field1 = "value1";
+
+                  protected int field2 = 42;
+
+                  public static final String CONSTANT = "constant";
+
+                  public void method1() {
+                      System.out.println("method1");
+                  }
+
+                  public Example() {
+                      // constructor
+                  }
+
+                  public void method2() {
+                      System.out.println("method2");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldsAlreadyAtTop() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class AlreadyOrdered {
+                  private String field1 = "value1";
+                  protected int field2 = 42;
+                  public static final String CONSTANT = "constant";
+
+                  public void method() {
+                      System.out.println("method");
+                  }
+
+                  public AlreadyOrdered() {
+                      // constructor
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void onlyFieldsInClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class OnlyFields {
+                  private String field1 = "value1";
+                  protected int field2 = 42;
+                  public static final String CONSTANT = "constant";
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void onlyMethodsInClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class OnlyMethods {
+                  public void method1() {
+                      System.out.println("method1");
+                  }
+
+                  public OnlyMethods() {
+                      // constructor
+                  }
+
+                  public void method2() {
+                      System.out.println("method2");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Empty {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldsBetweenMethods() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Mixed {
+                  public void firstMethod() {
+                      System.out.println("first");
+                  }
+
+                  private String field1 = "value1";
+
+                  public void secondMethod() {
+                      System.out.println("second");
+                  }
+
+                  private int field2 = 10;
+
+                  public void thirdMethod() {
+                      System.out.println("third");
+                  }
+              }
+              """,
+            """
+              class Mixed {
+                  private String field1 = "value1";
+
+                  private int field2 = 10;
+
+                  public void firstMethod() {
+                      System.out.println("first");
+                  }
+
+                  public void secondMethod() {
+                      System.out.println("second");
+                  }
+
+                  public void thirdMethod() {
+                      System.out.println("third");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void staticAndInstanceFields() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class StaticAndInstance {
+                  public void method() {
+                      System.out.println("method");
+                  }
+
+                  private static final String STATIC_FIELD = "static";
+                  private String instanceField = "instance";
+                  public final int publicField = 100;
+
+                  public StaticAndInstance() {
+                      // constructor
+                  }
+              }
+              """,
+            """
+              class StaticAndInstance {
+                  private static final String STATIC_FIELD = "static";
+                  private String instanceField = "instance";
+                  public final int publicField = 100;
+
+                  public void method() {
+                      System.out.println("method");
+                  }
+
+                  public StaticAndInstance() {
+                      // constructor
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void innerClassesAndFields() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class OuterClass {
+                  public void outerMethod() {
+                      System.out.println("outer method");
+                  }
+
+                  private String outerField = "outer";
+
+                  class InnerClass {
+                      public void innerMethod() {
+                          System.out.println("inner method");
+                      }
+
+                      private String innerField = "inner";
+                  }
+
+                  protected int anotherOuterField = 42;
+              }
+              """,
+            """
+              class OuterClass {
+                  private String outerField = "outer";
+
+                  protected int anotherOuterField = 42;
+
+                  public void outerMethod() {
+                      System.out.println("outer method");
+                  }
+
+                  class InnerClass {
+                      private String innerField = "inner";
+
+                      public void innerMethod() {
+                          System.out.println("inner method");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveCommentsWithFields() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void foo(String bar) {
+                      int i = Integer.parseInt(bar);
+                  }
+              
+                  // this is my field, not yours
+                  String myField = "important";
+              }
+              """,
+            """
+              class A {
+                  // this is my field, not yours
+                  String myField = "important";
+              
+                  void foo(String bar) {
+                      int i = Integer.parseInt(bar);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveMultilineCommentsWithFields() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  public void method() {
+                      System.out.println("method");
+                  }
+              
+                  /*
+                   * This is a multiline comment
+                   * for my field
+                   */
+                  private String field1 = "value1";
+              
+                  /**
+                   * Javadoc comment for field2
+                   * @deprecated this field is old
+                   */
+                  @Deprecated
+                  private int field2 = 42;
+              }
+              """,
+            """
+              class A {
+                  /*
+                   * This is a multiline comment
+                   * for my field
+                   */
+                  private String field1 = "value1";
+              
+                  /**
+                   * Javadoc comment for field2
+                   * @deprecated this field is old
+                   */
+                  @Deprecated
+                  private int field2 = 42;
+              
+                  public void method() {
+                      System.out.println("method");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveCommentsWithMixedMembers() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Mixed {
+                  // Method comment
+                  public void firstMethod() {
+                      System.out.println("first");
+                  }
+              
+                  // Field comment 1
+                  private String field1 = "value1";
+              
+                  /* Another method comment */
+                  public void secondMethod() {
+                      System.out.println("second");
+                  }
+              
+                  // Field comment 2
+                  private int field2 = 10;
+              }
+              """,
+            """
+              class Mixed {
+                  // Field comment 1
+                  private String field1 = "value1";
+              
+                  // Field comment 2
+                  private int field2 = 10;
+              
+                  // Method comment
+                  public void firstMethod() {
+                      System.out.println("first");
+                  }
+              
+                  /* Another method comment */
+                  public void secondMethod() {
+                      System.out.println("second");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableDeclarationsWithMultipleVariables() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class MultipleVars {
+                  public void method() {
+                      System.out.println("method");
+                  }
+
+                  private int x = 1, y = 2, z = 3;
+
+                  public MultipleVars() {
+                      // constructor
+                  }
+              }
+              """,
+            """
+              class MultipleVars {
+                  private int x = 1, y = 2, z = 3;
+
+                  public void method() {
+                      System.out.println("method");
+                  }
+
+                  public MultipleVars() {
+                      // constructor
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added MoveFieldsToTopOfClass recipe and tests. This recipe reorders class members so that all field declarations appear before any method declarations constructors, or other class members. This improves code organization and readability by  grouping field declarations together at the top of the class. Comments associated with fields are preserved during the reordering.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fixes #721 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
This PR adds the recipe to static-analysis.yml. I'm not sure if that should be done in a separate PR, or not done at all. 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
