### PR TITLE
Fix FinalClass recipe to correctly handle nested static subclasses

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalClassVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalClassVisitor.java
@@ -90,7 +90,7 @@ public class FinalClassVisitor extends JavaIsoVisitor<ExecutionContext> {
     }
 
     private void excludeSupertypes(JavaType.FullyQualified type) {
-        if (type.getSupertype() != null && type.getOwningClass() != null &&
+        if (type.getSupertype() != null &&
                 typesToNotFinalize.add(type.getSupertype().getFullyQualifiedName())) {
             excludeSupertypes(type.getSupertype());
         }

--- a/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
@@ -189,4 +189,22 @@ class FinalClassTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/372")
+    @Test
+    void doNotFinalizeClassWithNestedStaticSubclass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class Reproducer {
+                  private Reproducer() {}
+
+                  public static class Sub extends Reproducer {
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fixed the `FinalClass` recipe which was incorrectly making classes final even when they had nested static subclasses extending them
- Removed unnecessary condition in `excludeSupertypes()` method that was preventing proper exclusion of supertypes

## Description
The issue was in the `excludeSupertypes()` method which had a condition `type.getOwningClass() != null` that meant supertypes were only excluded when the extending class was nested. This was incorrect - we should exclude supertypes regardless of whether the extending class is nested or not.

## Test plan
- [x] Added test case `doNotFinalizeClassWithNestedStaticSubclass()` to verify the fix
- [x] Verified all existing FinalClass tests still pass
- [x] Code compiles successfully

- Fixes #372

🤖 Generated with [Claude Code](https://claude.ai/code)