### PR TITLE
Fix RemoveUnusedLocalVariables producing invalid pattern matching code

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -126,6 +126,16 @@ public class RemoveUnusedLocalVariables extends Recipe {
             }
 
             @Override
+            public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, ExecutionContext ctx) {
+                return instanceOf;
+            }
+
+            @Override
+            public J.DeconstructionPattern visitDeconstructionPattern(J.DeconstructionPattern deconstructionPattern, ExecutionContext ctx) {
+                return deconstructionPattern;
+            }
+
+            @Override
             public J.VariableDeclarations.@Nullable NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext ctx) {
                 // skip matching ignored variable names right away
                 if (ignoreVariableNames != null && ignoreVariableNames.contains(variable.getSimpleName())) {


### PR DESCRIPTION
## Summary
- Fixes #760

The `RemoveUnusedLocalVariables` recipe was incorrectly removing variable names from pattern matching expressions, producing invalid Java code.

**Before:**
```java
if (r instanceof MyRecord(String a, String b)) {bar(b);}
```

**After (broken):**
```java
if (r instanceof MyRecord(String, String b)) {bar(b);}  // Invalid!
```

## Changes
- Added `visitInstanceOf()` and `visitDeconstructionPattern()` visitor methods that return early without calling `super`, preventing the visitor from descending into pattern matching constructs
- This ensures all variables declared within pattern matching contexts are preserved, even when unused
- Added test case `doNotRemoveUnusedPatternMatchingVariables()` to verify the fix

## Test plan
- [x] Added test case for pattern matching with record deconstruction
- [x] All existing tests pass
- [x] Verified fix works with nested patterns and qualified type names

🤖 Generated with [Claude Code](https://claude.com/claude-code)