### PR TITLE
Use constructor changed in rewrite-core

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ControlFlowIndentation.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ControlFlowIndentation.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.format.TabsAndIndentsVisitor;
 import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.style.SpacesStyle;
 import org.openrewrite.java.style.TabsAndIndentsStyle;
+import org.openrewrite.java.style.WrappingAndBracesStyle;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Loop;
@@ -63,6 +64,8 @@ public class ControlFlowIndentation extends Recipe {
             TabsAndIndentsStyle tabsAndIndentsStyle;
             @Nullable
             SpacesStyle spacesStyle;
+            @Nullable
+            WrappingAndBracesStyle wrappingStyle;
 
             @Override
             public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
@@ -70,6 +73,7 @@ public class ControlFlowIndentation extends Recipe {
                     JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
                     tabsAndIndentsStyle = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents);
                     spacesStyle = Style.from(SpacesStyle.class, cu, IntelliJ::spaces);
+                    wrappingStyle = Style.from(WrappingAndBracesStyle.class, cu, IntelliJ::wrappingAndBraces);
                 }
                 return super.visit(tree, ctx);
             }
@@ -83,7 +87,8 @@ public class ControlFlowIndentation extends Recipe {
                         foundControlFlowRequiringReformatting.set(true);
                         return (Statement) new TabsAndIndentsVisitor<>(
                                 requireNonNull(tabsAndIndentsStyle),
-                                requireNonNull(spacesStyle))
+                                requireNonNull(spacesStyle),
+                                requireNonNull(wrappingStyle))
                                 .visit(statement, ctx, getCursor());
                     }
                     return statement;


### PR DESCRIPTION
After publishing of 
- https://github.com/openrewrite/rewrite/pull/6177

This one has to be merged. 
There are no other occurences in the OR recipe base: https://app.moderne.io/results/OHS1kkobf?repo=eyJfX3R5cGVuYW1lIjoiR2l0SHViUmVwb3NpdG9yeSIsImlkIjoiR2l0SHViUmVwb3NpdG9yeX5%252BZ2l0aHViLmNvbX5%252Bb3BlbnJld3JpdGUvcmV3cml0ZS1zdGF0aWMtYW5hbHlzaXN%252Bfm1haW4iLCJicmFuY2giOiJtYWluIiwib3JpZ2luIjoiZ2l0aHViLmNvbSIsInBhdGgiOiJvcGVucmV3cml0ZS9yZXdyaXRlLXN0YXRpYy1hbmFseXNpcyIsIm5hbWUiOiJyZXdyaXRlLXN0YXRpYy1hbmFseXNpcyIsIm9yZ2FuaXphdGlvbiI6Im9wZW5yZXdyaXRlIn0%253D&variant=search