### PR TITLE
Limit `RemoveSystemOutPrintln` to `System.out` and `System.err`

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/RemoveSystemOutPrintlnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveSystemOutPrintlnTest.java
@@ -36,15 +36,30 @@ class RemoveSystemOutPrintlnTest implements RewriteTest {
           //language=java
           java(
             """
+              import java.io.PrintStream;
+
               class Test {
-                  void test() {
+                  void printOut() {
                       System.out.println("Hello, world!");
+                  }
+                  void printErr() {
+                      System.err.println("Hello, world!");
+                  }
+                  void printStream(PrintStream printStream) {
+                      printStream.println("Hello, world!");
                   }
               }
               """,
             """
+              import java.io.PrintStream;
+
               class Test {
-                  void test() {
+                  void printOut() {
+                  }
+                  void printErr() {
+                  }
+                  void printStream(PrintStream printStream) {
+                      printStream.println("Hello, world!");
                   }
               }
               """


### PR DESCRIPTION
Avoids over eager removal from any PrintStream, by only looking at the moment common cases of `System.out` and `System.err`.