### PR TITLE
Fix CombineSemanticallyEqualCatchBlocks for inner exception types

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocksTest.java
@@ -528,4 +528,41 @@ class CombineSemanticallyEqualCatchBlocksTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/771")
+    @Test
+    void removeRedundantInnerExceptionWhenParentIsCaught() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Outer {
+                  public static class InnerException extends Exception {}
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Test {
+                  void method() {
+                      try {
+                      } catch (Outer.InnerException e) {
+                      } catch (Exception e) {
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                      try {
+                      } catch (Exception e) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes inheritance detection in `CombineSemanticallyEqualCatchBlocks` recipe when exception classes are inner/nested types.

## Problem

The recipe was incorrectly combining catch blocks when an inner exception type (e.g., `Outer.InnerException`) extended a parent exception (e.g., `Exception`). Instead of eliminating the redundant child exception, it created invalid code:

```java
// Before
catch (Outer.InnerException e) { }
catch (Exception e) { }

// Incorrect output (syntactically invalid)
catch (Outer.InnerException | Exception e) { }

// Expected output
catch (Exception e) { }
```

## Root Cause

The recipe only tracked `J.Identifier` instances when identifying parent-child exception relationships, but inner/nested exception types are represented as `J.FieldAccess` in the AST (e.g., `Outer.InnerException` is a field access, not a simple identifier).

## Changes

1. **Updated data structures**: Changed from `Set<J.Identifier>` to `Set<NameTree>` to handle both identifier and field access exception types
2. **Enhanced exception tracking**: Added handling for `J.FieldAccess` in addition to `J.Identifier` when tracking parent-child relationships
3. **Improved comparison logic**: Updated `combineEquivalentCatches()` to properly check and exclude both types of exception representations
4. **Added test case**: Added `removeRedundantInnerExceptionWhenParentIsCaught()` test that verifies the fix

## Test plan

- New test `removeRedundantInnerExceptionWhenParentIsCaught` verifies inner exceptions are properly handled
- All existing tests continue to pass, confirming backward compatibility

- Fixes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)