### PR TITLE
Fix ReplaceLambdaWithMethodReference for local records and classes

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
+++ b/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
@@ -80,6 +80,20 @@ final class JavaElementFactory {
             qualifiedName = type.toString();
         }
 
+        // Check if this is a local class (contains $<digit>)
+        // Local classes have names like "Outer$1LocalName" where the digit indicates the scope
+        // For method references, we should use only the simple name without the numeric prefix
+        if (qualifiedName.matches(".*\\$\\d+.*")) {
+            // Extract the simple name after the last $<digit> sequence
+            String simpleName = qualifiedName.replaceAll(".*\\$\\d+", "");
+            // Remove any remaining $ characters and get just the class name
+            simpleName = simpleName.replace('$', '.');
+            if (simpleName.indexOf('.') > 0) {
+                simpleName = simpleName.substring(simpleName.lastIndexOf('.') + 1);
+            }
+            return new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), simpleName, type, null);
+        }
+
         Scanner scanner = new Scanner(qualifiedName.replace('$', '.')).useDelimiter("\\.");
         for (int i = 0; scanner.hasNext(); i++) {
             String part = scanner.next();


### PR DESCRIPTION
## Summary

- Fixes #336

The `ReplaceLambdaWithMethodReference` recipe was generating malformed method references when converting lambdas that use locally-defined records or classes. Instead of producing valid syntax like `R::s`, it generated invalid code like `1R::s`.

**Root Cause:** Local classes in Java bytecode are named with patterns like `OuterClass$1LocalName`, where the digit indicates the method scope. The recipe was including this numeric prefix in the generated method reference.

**Changes:**
- Modified `JavaElementFactory.className()` to detect local classes by checking for `$<digit>` patterns
- Extract only the simple class name without the numeric prefix for local classes
- Added comprehensive test coverage for local records and classes

**Examples:**

```java
// Before (generates invalid code):
record R(String s) {}
stream.map(r -> r.s())  // would become: stream.map(1R::s) ❌

// After (generates valid code):
record R(String s) {}
stream.map(r -> r.s())  // becomes: stream.map(R::s) ✅
```

## Test plan

- [x] Added test `localRecordMethodReference` - verifies lambda to method reference conversion for local records
- [x] Added test `localClassMethodReference` - verifies conversion for local classes  
- [x] Added test `localRecordWithInstanceOfCheck` - verifies instanceof to `isInstance` conversion
- [x] Added test `localRecordWithCast` - verifies type cast to `Class::cast` conversion
- [x] All existing tests pass (2m 5s test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)