### PR TITLE
Prepare formatting refactor

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NeedBraces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NeedBraces.java
@@ -197,6 +197,7 @@ public class NeedBraces extends Recipe {
 
                 if (!prefix.getComments().isEmpty() && prefix.getWhitespace().contains("\n")) {
                     body = body.withPrefix(prefix);
+                    elem = elem.withPrefix(Space.EMPTY);
                 }
 
                 J.Block b = buildBlock(body);

--- a/src/main/java/org/openrewrite/staticanalysis/NestedEnumsAreNotStatic.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NestedEnumsAreNotStatic.java
@@ -60,14 +60,12 @@ public class NestedEnumsAreNotStatic extends Recipe {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
                 if (cd.getKind() == J.ClassDeclaration.Kind.Type.Enum && cd.getType() != null && cd.getType().getOwningClass() != null) {
                     if (J.Modifier.hasModifier(cd.getModifiers(), J.Modifier.Type.Static)) {
-                        J.Block enumBody = cd.getBody();
-                        //noinspection DataFlowIssue
-                        cd = cd.withBody(null);
                         cd = maybeAutoFormat(cd,
                                 cd.withModifiers(ListUtils.map(cd.getModifiers(), mod ->
                                         mod.getType() == J.Modifier.Type.Static ? null : mod)),
-                                ctx);
-                        cd = cd.withBody(enumBody);
+                                cd.getName(),
+                                ctx,
+                                getCursor().getParent());
                     }
                 }
                 return cd;

--- a/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
@@ -535,12 +535,12 @@ class NeedBracesTest implements RewriteTest {
                       else if (true) return; // second else if comment 2
                       else return; // else comment 2
                   }
-                  static void methodTwo(){
+                  static void methodTwo() {
                       if (true) return; // if comment
                       else return; // else comment
                       return; // return comment
                   }
-                  static void methodThreeNested(){
+                  static void methodThreeNested() {
                       if (true){
                           if (true) return; // nested if comment
                           else return; // nested else comment
@@ -567,7 +567,7 @@ class NeedBracesTest implements RewriteTest {
                           return; // else comment 2
                       }
                   }
-                  static void methodTwo(){
+                  static void methodTwo() {
                       if (true) {
                           return; // if comment
                       } else {
@@ -575,7 +575,7 @@ class NeedBracesTest implements RewriteTest {
                       }
                       return; // return comment
                   }
-                  static void methodThreeNested(){
+                  static void methodThreeNested() {
                       if (true) {
                           if (true) {
                               return; // nested if comment


### PR DESCRIPTION
NestedEnumsAreNotStatic.java -> body is not nullable. If we do not want to format the body, we should stop formatting after the class name.

NeedBraces.java -> do not keep comments of the object that moved

NeedBracesTest.java -> Do not expect that this test makes changes to the body parentheses.