### PR TITLE
Fix `AnnotateRequiredParameters` to handle `Objects.requireNonNull` in assignments

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateRequiredParameters.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateRequiredParameters.java
@@ -332,7 +332,15 @@ public class AnnotateRequiredParameters extends Recipe {
             if (REQUIRE_NON_NULL.matches(m) &&
                     m.getArguments().get(0) instanceof J.Identifier &&
                     containsIdentifierByName(requiredIdentifiers, (J.Identifier) m.getArguments().get(0))) {
-                return null;
+                // Check if this is a standalone statement (can be removed entirely)
+                // vs part of a larger expression (should be replaced with the argument)
+                Cursor parent = getCursor().getParentTreeCursor();
+                if (parent.getValue() instanceof J.Block) {
+                    // Standalone statement - safe to remove entirely
+                    return null;
+                }
+                // Part of a larger expression (e.g., assignment) - replace with the first argument
+                return m.getArguments().get(0).withPrefix(m.getPrefix());
             }
 
             return m;

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateRequiredParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateRequiredParametersTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -577,6 +578,42 @@ class AnnotateRequiredParametersTest implements RewriteTest {
               class Test {
                   public void process(@NonNull String value) {
                       System.out.println(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/792")
+    @Test
+    void requireNonNullInAssignmentIsReplacedWithArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Objects;
+
+              class Test {
+                  private String field;
+
+                  public void process(String bar) {
+                      this.field = Objects.requireNonNull(bar, "bar may not be null");
+                      System.out.println(field);
+                  }
+              }
+              """,
+            """
+              import org.jspecify.annotations.NonNull;
+
+              import java.util.Objects;
+
+              class Test {
+                  private String field;
+
+                  public void process(@NonNull String bar) {
+                      this.field = bar;
+                      System.out.println(field);
                   }
               }
               """


### PR DESCRIPTION
## Summary
- Fix `AnnotateRequiredParameters` to correctly handle `Objects.requireNonNull` when used in assignment expressions
- When the method invocation is a standalone statement, it is removed entirely
- When it is part of a larger expression (e.g., assignment), it is replaced with the first argument to preserve valid syntax

## Problem
The recipe incorrectly transformed:
```java
this.field = Objects.requireNonNull(bar, "bar may not be null");
```
into:
```java
this.field;
```
instead of the expected:
```java
this.field = bar;
```

## Test plan
- [x] Added regression test `requireNonNullInAssignmentIsReplacedWithArgument`
- [x] All existing tests pass

- Fixes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)