### PR TITLE
Fix RemoveUnusedLocalVariables to delete unused local variables inside method invocation argument blocks

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -266,7 +266,12 @@ public class RemoveUnusedLocalVariables extends Recipe {
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation m, ExecutionContext ctx) {
             AssignmentToLiteral atl = new AssignmentToLiteral(assignment);
-            return m.withArguments(ListUtils.map(m.getArguments(), it -> (Expression) atl.visitNonNull(it, ctx, getCursor().getParentOrThrow())));
+            return m.withArguments(ListUtils.map(m.getArguments(), it -> {
+                if (it instanceof J.Assignment) {
+                    return (Expression) atl.visitNonNull(it, ctx, getCursor().getParentOrThrow());
+                }
+                return it;
+            }));
         }
     }
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -975,6 +975,47 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void assignmentWithinExpressionSubBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Supplier;
+
+              class A {
+                  void foo() {
+                      consumer(() -> {
+                          String removeMeLiteral;
+                          String removeMeIdentifier;
+                          String bar = "abc";
+                          removeMeLiteral = "123";
+                          removeMeIdentifier = bar;
+                          return bar;
+                      });
+                  }
+
+                  void consumer(Supplier<String> supplier) {}
+              }
+              """,
+            """
+              import java.util.function.Supplier;
+
+              class A {
+                  void foo() {
+                      consumer(() -> {
+                          String bar = "abc";
+                          return bar;
+                      });
+                  }
+
+                  void consumer(Supplier<String> supplier) {}
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2509")
     @Test
     void recordCompactConstructor() {


### PR DESCRIPTION
Fix RemoveUnusedLocalVariables to delete unused local variables inside method invocation argument blocks(lambdas, anonymous classes...) to avoid ClassCastException. 

- introduced since: https://github.com/openrewrite/rewrite/issues/1743

Without this fix the code would unwrap 
```java
                      consumer(() -> {
                          String removeMeLiteral;
                          String removeMeIdentifier;
                          String bar = "abc";
                          removeMeLiteral = "123";
                          removeMeIdentifier = bar;
                          return bar;
                      });
``` 
in the `PruneAssignmentExpression$visitMethodInvocation` and replace both `removeMeLiteral = "123"` and `removeMeIdentifier = bar;` to `"123"` and `bar`. This is then throwing ClassCastException when the `DeleteStatement` postVisit tries to visit the block and finds a `JRighPadded<Identifier|Literal>` where the assignment used to be and then throws ClassCastException as these are not Statements. 


https://github.com/openrewrite/rewrite/blob/8986f6fa1ca2355cd578d4fd8f39e7197a9cc490/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependencyClassifier.java#L169 has an unused variable. It is wrapped in a `Preconditions.check` methodInvocation in a anonymous class block

- fix #786 