### PR TITLE
`UnwrapElseAfterReturn` to handle Python source files gracefully

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     provided("org.openrewrite:rewrite-javascript:${rewriteVersion}")
     provided("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
     provided("org.openrewrite:rewrite-csharp:${rewriteVersion}")
+    provided("org.openrewrite:rewrite-python:${rewriteVersion}")
 
     annotationProcessor("org.openrewrite:rewrite-templating:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-templating:${rewriteVersion}")
@@ -38,6 +39,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.testng:testng:7.+")
     testImplementation("org.openrewrite:rewrite-javascript:${rewriteVersion}")
+    testImplementation("org.openrewrite:rewrite-python:${rewriteVersion}")
 
     testImplementation("com.google.code.gson:gson:latest.release")
 

--- a/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
@@ -20,6 +20,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.Repeat;
+import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaVisitor;
@@ -85,7 +86,10 @@ public class UnwrapElseAfterReturn extends Recipe {
                     alteredBlock = alteredBlock.withEnd(b.getEnd().withComments(mergedComments).withWhitespace(end.getWhitespace()));
                 }
 
-                return maybeAutoFormat(b, alteredBlock, ctx);
+                if (getCursor().firstEnclosingOrThrow(SourceFile.class) instanceof J.CompilationUnit) {
+                    return maybeAutoFormat(b, alteredBlock, ctx);
+                }
+                return alteredBlock;
             }
 
             private List<Statement> flatten(J.If tailIf, Statement tailElse, AtomicReference<@Nullable Space> endWhitespace, J.If ifWithoutElse) {

--- a/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.python.Assertions.python;
 
 @SuppressWarnings("ConstantConditions")
 class UnwrapElseAfterReturnTest implements RewriteTest {
@@ -645,6 +646,29 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
                       return 2; // end 2
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void pythonSimpleIfElseWithReturn() {
+        rewriteRun(
+          python(
+            """
+              def foo(condition) :
+                  if condition :
+                      return 1
+                  else :
+                      return 2
+              """,
+            """
+              def foo(condition) :
+                  if condition :
+                      return 1
+                 \s
+                  return 2
+
               """
           )
         );

--- a/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
@@ -652,23 +652,17 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
     }
 
     @Test
-    void pythonSimpleIfElseWithReturn() {
+    void pythonWithImport() {
         rewriteRun(
           python(
             """
-              def foo(condition) :
-                  if condition :
-                      return 1
-                  else :
-                      return 2
-              """,
-            """
-              def foo(condition) :
-                  if condition :
-                      return 1
-                 \s
-                  return 2
+              from os import path
 
+              def foo(condition):
+                  if condition:
+                      return 1
+                  else:
+                      return 2
               """
           )
         );

--- a/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
@@ -663,6 +663,14 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
                       return 1
                   else:
                       return 2
+              """,
+            """
+              from os import path
+
+              def foo(condition):
+                  if condition:
+                      return 1
+                  return 2
               """
           )
         );


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
