### PR TITLE
Fix switch-related recipe bugs (#6, #9, #14, #687)

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -85,6 +85,13 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
         private final J.Case scope;
 
         @Override
+        public J.Switch visitSwitch(J.Switch switch_, P p) {
+            // Don't descend into nested switches (including switch expressions)
+            // to avoid adding breaks inside their cases/blocks
+            return switch_;
+        }
+
+        @Override
         public J.Case visitCase(J.Case case_, P p) {
             if (scope.isScope(case_)) {
                 List<Statement> statements = case_.getStatements();
@@ -181,11 +188,21 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                     }
                     return true;
                 }
+                if (s instanceof J.Switch) {
+                    // Arrow-style switches used as statements don't prevent fall-through
+                    J.Switch sw = (J.Switch) s;
+                    List<Statement> cases = sw.getCases().getStatements();
+                    for (Statement cs : cases) {
+                        if (cs instanceof J.Case && ((J.Case) cs).getType() == J.Case.Type.Rule) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
                 return s instanceof J.Return ||
                         s instanceof J.Break ||
                         s instanceof J.Continue ||
-                        s instanceof J.Throw ||
-                        s instanceof J.Switch;
+                        s instanceof J.Throw;
             }
 
             @Override

--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -32,10 +32,7 @@ import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.csharp.CSharpFileChecker;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -162,20 +159,45 @@ public class MinimumSwitchCases extends Recipe {
 
                         // move first case to "if"
                         List<Statement> thenStatements = getStatements(cases[0]);
+                        List<Statement> filteredThen = removeBreaksPreservingComments(thenStatements);
 
-                        generatedIf = generatedIf.withThenPart(((J.Block) generatedIf.getThenPart()).withStatements(ListUtils.map(thenStatements,
-                                s -> s instanceof J.Break ? null : s)));
+                        generatedIf = generatedIf.withThenPart(((J.Block) generatedIf.getThenPart()).withStatements(filteredThen));
+
+                        // Collect variable declarations from first case for redeclaration in else block
+                        Map<String, J.VariableDeclarations> declaredVars = collectDeclaredVariables(filteredThen);
 
                         // move second case to "else"
                         if (cases[1] != null) {
                             assert generatedIf.getElsePart() != null;
+                            List<Statement> elseStatements = removeBreaksPreservingComments(getStatements(cases[1]));
+                            // Transfer comments from the switch block's end space to the else block
+                            Space switchEnd = sortedSwitch.getCases().getEnd();
+                            if (!switchEnd.getComments().isEmpty()) {
+                                if (elseStatements.isEmpty()) {
+                                    // Create a placeholder empty statement to carry the comments
+                                    J.Block elseBlock = (J.Block) (isDefault(cases[1]) ?
+                                            generatedIf.getElsePart().getBody() :
+                                            ((J.If) generatedIf.getElsePart().getBody()).getThenPart());
+                                    elseBlock = elseBlock.withEnd(elseBlock.getEnd().withComments(
+                                            ListUtils.concatAll(switchEnd.getComments(), elseBlock.getEnd().getComments())));
+                                    if (isDefault(cases[1])) {
+                                        generatedIf = generatedIf.withElsePart(generatedIf.getElsePart().withBody(elseBlock));
+                                    } else {
+                                        generatedIf = generatedIf.withElsePart(generatedIf.getElsePart().withBody(
+                                                ((J.If) generatedIf.getElsePart().getBody()).withThenPart(elseBlock)));
+                                    }
+                                } else {
+                                    Statement first = elseStatements.get(0);
+                                    elseStatements.set(0, first.withPrefix(first.getPrefix().withComments(
+                                            ListUtils.concatAll(switchEnd.getComments(), first.getPrefix().getComments()))));
+                                }
+                            }
+                            elseStatements = redeclareAssignments(elseStatements, declaredVars);
                             if (isDefault(cases[1])) {
-                                generatedIf = generatedIf.withElsePart(generatedIf.getElsePart().withBody(((J.Block) generatedIf.getElsePart().getBody()).withStatements(ListUtils.map(getStatements(cases[1]),
-                                        s -> s instanceof J.Break ? null : s))));
+                                generatedIf = generatedIf.withElsePart(generatedIf.getElsePart().withBody(((J.Block) generatedIf.getElsePart().getBody()).withStatements(elseStatements)));
                             } else {
                                 J.If elseIf = (J.If) generatedIf.getElsePart().getBody();
-                                generatedIf = generatedIf.withElsePart(generatedIf.getElsePart().withBody(elseIf.withThenPart(((J.Block) elseIf.getThenPart()).withStatements(ListUtils.map(getStatements(cases[1]),
-                                        s -> s instanceof J.Break ? null : s)))));
+                                generatedIf = generatedIf.withElsePart(generatedIf.getElsePart().withBody(elseIf.withThenPart(((J.Block) elseIf.getThenPart()).withStatements(elseStatements))));
                             }
                         }
 
@@ -232,6 +254,66 @@ public class MinimumSwitchCases extends Recipe {
                     }
                 }
                 return statements;
+            }
+
+            private List<Statement> removeBreaksPreservingComments(List<Statement> statements) {
+                return ListUtils.map(statements, (i, s) -> {
+                    if (s instanceof J.Break) {
+                        return null;
+                    }
+                    // Collect comments from any following break statement
+                    if (i + 1 < statements.size() && statements.get(i + 1) instanceof J.Break) {
+                        List<Comment> breakComments = statements.get(i + 1).getComments();
+                        if (!breakComments.isEmpty()) {
+                            return s.withPrefix(s.getPrefix().withComments(
+                                    ListUtils.concatAll(s.getPrefix().getComments(), breakComments)));
+                        }
+                    }
+                    return s;
+                });
+            }
+
+            private Map<String, J.VariableDeclarations> collectDeclaredVariables(List<Statement> statements) {
+                Map<String, J.VariableDeclarations> vars = new LinkedHashMap<>();
+                for (Statement s : statements) {
+                    if (s instanceof J.VariableDeclarations) {
+                        J.VariableDeclarations vd = (J.VariableDeclarations) s;
+                        for (J.VariableDeclarations.NamedVariable v : vd.getVariables()) {
+                            vars.put(v.getSimpleName(), vd);
+                        }
+                    }
+                }
+                return vars;
+            }
+
+            private List<Statement> redeclareAssignments(List<Statement> statements, Map<String, J.VariableDeclarations> declaredVars) {
+                if (declaredVars.isEmpty()) {
+                    return statements;
+                }
+                List<Statement> result = new ArrayList<>();
+                for (Statement s : statements) {
+                    if (s instanceof J.Assignment) {
+                        J.Assignment assignment = (J.Assignment) s;
+                        if (assignment.getVariable() instanceof J.Identifier) {
+                            String name = ((J.Identifier) assignment.getVariable()).getSimpleName();
+                            J.VariableDeclarations originalDecl = declaredVars.get(name);
+                            if (originalDecl != null) {
+                                J.VariableDeclarations.NamedVariable newVar = originalDecl.getVariables().get(0)
+                                        .withName(((J.Identifier) assignment.getVariable()).withPrefix(Space.EMPTY))
+                                        .withInitializer(assignment.getAssignment())
+                                        .withId(randomId());
+                                J.VariableDeclarations newDecl = originalDecl
+                                        .withVariables(singletonList(newVar))
+                                        .withPrefix(s.getPrefix())
+                                        .withId(randomId());
+                                result.add(newDecl);
+                                continue;
+                            }
+                        }
+                    }
+                    result.add(s);
+                }
+                return result;
             }
 
             private boolean isDefault(J.Case case_) {

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -102,6 +102,61 @@ class FallThroughTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/14")
+    @Test
+    void switchExpressionInsideSwitchStatement() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void statement() {
+                  }
+
+                  void test() {
+                      switch (2) {
+                          case 0:
+                              switch (3) {
+                                  case 1 -> statement();
+                                  case 3 -> {
+                                      statement();
+                                      statement();
+                                  }
+                              }
+                          case 2:
+                              statement();
+                              break;
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void statement() {
+                  }
+
+                  void test() {
+                      switch (2) {
+                          case 0:
+                              switch (3) {
+                                  case 1 -> statement();
+                                  case 3 -> {
+                                      statement();
+                                      statement();
+                                  }
+                              }
+                              break;
+                          case 2:
+                              statement();
+                              break;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void switchExpressions() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InlineVariableTest.java
@@ -253,6 +253,32 @@ class InlineVariableTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/9")
+    @Test
+    void preserveEnumArray() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              enum ImportType {
+                  TIMETABLE, DUTIES
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Test {
+                  static ImportType[] getList() {
+                      ImportType[] list = {ImportType.TIMETABLE, ImportType.DUTIES};
+                      return list;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void inlineAssignmentReturn() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -1044,6 +1044,93 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/6")
+    @Test
+    void preserveDefaultCaseComments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  int variable;
+                  void test() {
+                      switch (variable) {
+                          case 0:
+                              doSomething();
+                              break;
+                          default:
+                              // Pass other keys to children
+                      }
+                  }
+                  void doSomething() {}
+              }
+              """,
+            """
+              class Test {
+                  int variable;
+                  void test() {
+                      if (variable == 0) {
+                          doSomething();
+                      } else {
+                          // Pass other keys to children
+                      }
+                  }
+                  void doSomething() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/687")
+    @Test
+    void variableRedeclaredInElseBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              @SuppressWarnings("ConstantConditions")
+              class Test {
+                  int variable;
+                  void test() {
+                      switch (variable) {
+                          case 1:
+                              String data = getSomeString();
+                              doThingWith(data);
+                              break;
+                          case 2:
+                              data = getSomeOtherString();
+                              doThingWith(data);
+                              break;
+                      }
+                  }
+                  String getSomeString() { return ""; }
+                  String getSomeOtherString() { return ""; }
+                  void doThingWith(String s) {}
+              }
+              """,
+            """
+              @SuppressWarnings("ConstantConditions")
+              class Test {
+                  int variable;
+                  void test() {
+                      if (variable == 1) {
+                          String data = getSomeString();
+                          doThingWith(data);
+                      } else if (variable == 2) {
+                          String data = getSomeOtherString();
+                          doThingWith(data);
+                      }
+                  }
+                  String getSomeString() { return ""; }
+                  String getSomeOtherString() { return ""; }
+                  void doThingWith(String s) {}
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/moderneinc/customer-requests/issues/1536")
     @Test
     void skipsTransformationWhenTypeInfoMissing() {


### PR DESCRIPTION
## Summary
- **FallThrough (#14):** Fix incorrect break insertion inside nested switch expressions by preventing `AddBreak` from descending into nested switches, and treating arrow-style switches as non-terminating in the `breaks()` analysis.
- **MinimumSwitchCases (#6):** Preserve comments from `default:` case labels when converting switch to if/else, by transferring comments from the switch block's end space to the generated else block.
- **MinimumSwitchCases (#687):** Redeclare variables in else blocks when they were originally declared in the first case, converting bare assignments back into variable declarations to maintain correct scoping.
- **InlineVariable (#9):** Added test confirming enum arrays are already correctly excluded from inlining by the existing `JavaType.Array` guard.

## Test plan
- [x] `FallThroughTest.switchExpressionInsideSwitchStatement` — verifies break added only at outer case level
- [x] `MinimumSwitchCasesTest.preserveDefaultCaseComments` — verifies comment preserved in else block
- [x] `MinimumSwitchCasesTest.variableRedeclaredInElseBlock` — verifies variable re-declared in else-if block
- [x] `InlineVariableTest.preserveEnumArray` — verifies enum array not inlined
- [x] All existing tests for FallThrough, MinimumSwitchCases, InlineVariable pass

## Closes
- closes #14 
- closes #6 
- closes #687 
- closes #9 