### PR TITLE
Fix InstanceOfPatternMatch duplicate pattern variable names with flow scoping

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -72,12 +72,20 @@ public class InstanceOfPatternMatch extends Recipe {
         );
 
         return Preconditions.check(preconditions, new JavaVisitor<ExecutionContext>() {
+            final Set<String> introducedPatternVarNames = new HashSet<>();
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                introducedPatternVarNames.clear();
+                return (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+            }
+
             @Override
             public @Nullable J postVisit(J tree, ExecutionContext ctx) {
                 J result = super.postVisit(tree, ctx);
                 InstanceOfPatternReplacements original = getCursor().getMessage("flowTypeScope");
                 if (original != null && !original.isEmpty()) {
-                    return UseInstanceOfPatternMatching.refactor(result, original, getCursor().getParentOrThrow());
+                    return UseInstanceOfPatternMatching.refactor(result, original, getCursor().getParentOrThrow(), introducedPatternVarNames);
                 }
                 return result;
             }
@@ -476,9 +484,10 @@ public class InstanceOfPatternMatch extends Recipe {
     private static class UseInstanceOfPatternMatching extends JavaVisitor<Integer> {
 
         private final InstanceOfPatternReplacements replacements;
+        private final Set<String> introducedNames;
 
-        static @Nullable J refactor(@Nullable J tree, InstanceOfPatternReplacements replacements, Cursor cursor) {
-            return new UseInstanceOfPatternMatching(replacements).visit(tree, 0, cursor);
+        static @Nullable J refactor(@Nullable J tree, InstanceOfPatternReplacements replacements, Cursor cursor, Set<String> introducedNames) {
+            return new UseInstanceOfPatternMatching(replacements, introducedNames).visit(tree, 0, cursor);
         }
 
         @Override
@@ -489,7 +498,7 @@ public class InstanceOfPatternMatch extends Recipe {
                 Cursor widenedCursor = updateCursor(b);
 
                 // Collect names from the left side if it's an instanceof with a pattern
-                Set<String> usedNames = new HashSet<>();
+                Set<String> usedNames = new HashSet<>(introducedNames);
                 if (b.getLeft() instanceof J.InstanceOf) {
                     J.InstanceOf leftInstanceOf = (J.InstanceOf) b.getLeft();
                     if (leftInstanceOf.getPattern() != null) {
@@ -499,11 +508,19 @@ public class InstanceOfPatternMatch extends Recipe {
 
                 Expression newRight;
                 if (binary.getRight() instanceof J.InstanceOf) {
-                    newRight = replacements.processInstanceOf((J.InstanceOf) binary.getRight(), widenedCursor, usedNames);
+                    J.InstanceOf rightResult = replacements.processInstanceOf((J.InstanceOf) binary.getRight(), widenedCursor, usedNames);
+                    if (rightResult.getPattern() != null && ((J.InstanceOf) binary.getRight()).getPattern() == null) {
+                        introducedNames.add(((J.Identifier) rightResult.getPattern()).getSimpleName());
+                    }
+                    newRight = rightResult;
                 } else if (binary.getRight() instanceof J.Parentheses &&
                         ((J.Parentheses<?>) binary.getRight()).getTree() instanceof J.InstanceOf) {
                     @SuppressWarnings("unchecked") J.Parentheses<J.InstanceOf> originalRight = (J.Parentheses<J.InstanceOf>) binary.getRight();
-                    newRight = originalRight.withTree(replacements.processInstanceOf(originalRight.getTree(), widenedCursor, usedNames));
+                    J.InstanceOf rightResult = replacements.processInstanceOf(originalRight.getTree(), widenedCursor, usedNames);
+                    if (rightResult.getPattern() != null && originalRight.getTree().getPattern() == null) {
+                        introducedNames.add(((J.Identifier) rightResult.getPattern()).getSimpleName());
+                    }
+                    newRight = originalRight.withTree(rightResult);
                 } else {
                     newRight = (Expression) visitNonNull(binary.getRight(), p, widenedCursor);
                 }
@@ -516,7 +533,11 @@ public class InstanceOfPatternMatch extends Recipe {
         @Override
         public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, Integer p) {
             instanceOf = (J.InstanceOf) super.visitInstanceOf(instanceOf, p);
-            return replacements.processInstanceOf(instanceOf, getCursor(), new HashSet<>());
+            J.InstanceOf result = replacements.processInstanceOf(instanceOf, getCursor(), new HashSet<>(introducedNames));
+            if (result.getPattern() != null && instanceOf.getPattern() == null) {
+                introducedNames.add(((J.Identifier) result.getPattern()).getSimpleName());
+            }
+            return result;
         }
 
         @Override

--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -72,20 +72,16 @@ public class InstanceOfPatternMatch extends Recipe {
         );
 
         return Preconditions.check(preconditions, new JavaVisitor<ExecutionContext>() {
-            final Set<String> introducedPatternVarNames = new HashSet<>();
-
-            @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                introducedPatternVarNames.clear();
-                return (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
-            }
-
             @Override
             public @Nullable J postVisit(J tree, ExecutionContext ctx) {
                 J result = super.postVisit(tree, ctx);
                 InstanceOfPatternReplacements original = getCursor().getMessage("flowTypeScope");
                 if (original != null && !original.isEmpty()) {
-                    return UseInstanceOfPatternMatching.refactor(result, original, getCursor().getParentOrThrow(), introducedPatternVarNames);
+                    Cursor methodCursor = getCursor().dropParentUntil(
+                            v -> v instanceof J.MethodDeclaration || v instanceof J.ClassDeclaration);
+                    Set<String> introducedNames = methodCursor.computeMessageIfAbsent(
+                            "introducedPatternVarNames", k -> new HashSet<>());
+                    return UseInstanceOfPatternMatching.refactor(result, original, getCursor().getParentOrThrow(), introducedNames);
                 }
                 return result;
             }

--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -78,7 +78,7 @@ public class InstanceOfPatternMatch extends Recipe {
                 InstanceOfPatternReplacements original = getCursor().getMessage("flowTypeScope");
                 if (original != null && !original.isEmpty()) {
                     Cursor methodCursor = getCursor().dropParentUntil(
-                            v -> v instanceof J.MethodDeclaration || v instanceof J.ClassDeclaration);
+                            v -> v instanceof J.MethodDeclaration || v instanceof J.ClassDeclaration || v == Cursor.ROOT_VALUE);
                     Set<String> introducedNames = methodCursor.computeMessageIfAbsent(
                             "introducedPatternVarNames", k -> new HashSet<>());
                     return UseInstanceOfPatternMatching.refactor(result, original, getCursor().getParentOrThrow(), introducedNames);
@@ -505,17 +505,13 @@ public class InstanceOfPatternMatch extends Recipe {
                 Expression newRight;
                 if (binary.getRight() instanceof J.InstanceOf) {
                     J.InstanceOf rightResult = replacements.processInstanceOf((J.InstanceOf) binary.getRight(), widenedCursor, usedNames);
-                    if (rightResult.getPattern() != null && ((J.InstanceOf) binary.getRight()).getPattern() == null) {
-                        introducedNames.add(((J.Identifier) rightResult.getPattern()).getSimpleName());
-                    }
+                    trackIntroducedName((J.InstanceOf) binary.getRight(), rightResult);
                     newRight = rightResult;
                 } else if (binary.getRight() instanceof J.Parentheses &&
                         ((J.Parentheses<?>) binary.getRight()).getTree() instanceof J.InstanceOf) {
                     @SuppressWarnings("unchecked") J.Parentheses<J.InstanceOf> originalRight = (J.Parentheses<J.InstanceOf>) binary.getRight();
                     J.InstanceOf rightResult = replacements.processInstanceOf(originalRight.getTree(), widenedCursor, usedNames);
-                    if (rightResult.getPattern() != null && originalRight.getTree().getPattern() == null) {
-                        introducedNames.add(((J.Identifier) rightResult.getPattern()).getSimpleName());
-                    }
+                    trackIntroducedName(originalRight.getTree(), rightResult);
                     newRight = originalRight.withTree(rightResult);
                 } else {
                     newRight = (Expression) visitNonNull(binary.getRight(), p, widenedCursor);
@@ -530,10 +526,14 @@ public class InstanceOfPatternMatch extends Recipe {
         public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, Integer p) {
             instanceOf = (J.InstanceOf) super.visitInstanceOf(instanceOf, p);
             J.InstanceOf result = replacements.processInstanceOf(instanceOf, getCursor(), new HashSet<>(introducedNames));
-            if (result.getPattern() != null && instanceOf.getPattern() == null) {
+            trackIntroducedName(instanceOf, result);
+            return result;
+        }
+
+        private void trackIntroducedName(J.InstanceOf original, J.InstanceOf result) {
+            if (result.getPattern() != null && original.getPattern() == null) {
                 introducedNames.add(((J.Identifier) result.getPattern()).getSimpleName());
             }
-            return result;
         }
 
         @Override

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -1989,4 +1989,48 @@ class InstanceOfPatternMatchTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2202")
+    @Test
+    void flowScopedPatternVariableConflictWithElseReturn() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void test(Object objNotOnOrAfter, Object objNotBefore) {
+                      String strNotOnOrAfter = "";
+                      if (objNotOnOrAfter != null && objNotOnOrAfter instanceof String) {
+                          strNotOnOrAfter = (String) objNotOnOrAfter;
+                      } else {
+                          return;
+                      }
+
+                      String strNotBefore = "";
+                      if (objNotBefore != null && objNotBefore instanceof String) {
+                          strNotBefore = (String) objNotBefore;
+                      }
+                  }
+              }
+              """,
+            """
+              class A {
+                  void test(Object objNotOnOrAfter, Object objNotBefore) {
+                      String strNotOnOrAfter = "";
+                      if (objNotOnOrAfter != null && objNotOnOrAfter instanceof String string) {
+                          strNotOnOrAfter = string;
+                      } else {
+                          return;
+                      }
+
+                      String strNotBefore = "";
+                      if (objNotBefore != null && objNotBefore instanceof String string1) {
+                          strNotBefore = string1;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes duplicate pattern variable names when `InstanceOfPatternMatch` transforms multiple `instanceof` checks in sequence and the first `if-else` has an abruptly completing `else` branch (e.g., `return`, `throw`). Java's flow scoping keeps the pattern variable in scope, so the second `instanceof` must use a different name.
- Tracks introduced pattern variable names across statements within a method and includes them in the used-names set during name generation.
- Adds a regression test matching the exact scenario from the issue.

- Fixes https://github.com/moderneinc/customer-requests/issues/2202

## Test plan
- [x] New test `flowScopedPatternVariableConflictWithElseReturn` passes
- [x] All existing `InstanceOfPatternMatchTest` tests pass