### PR TITLE
Fix RenameExceptionInEmptyCatch crash on Kotlin/Groovy files

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RenameExceptionInEmptyCatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RenameExceptionInEmptyCatch.java
@@ -155,7 +155,7 @@ public class RenameExceptionInEmptyCatch extends Recipe {
             // Sets structure for cursor positions to aggregate namespaces.
             private Cursor getCursorToParentScope() {
                 return getCursor().dropParentUntil(is ->
-                        is instanceof J.CompilationUnit ||
+                        is instanceof JavaSourceFile ||
                         is instanceof J.ClassDeclaration ||
                         is instanceof J.Block ||
                         is instanceof J.MethodDeclaration ||

--- a/src/test/java/org/openrewrite/staticanalysis/RenameExceptionInEmptyCatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RenameExceptionInEmptyCatchTest.java
@@ -17,10 +17,13 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings({"EmptyTryBlock", "CatchMayIgnoreException"})
 class RenameExceptionInEmptyCatchTest implements RewriteTest {
@@ -146,6 +149,32 @@ class RenameExceptionInEmptyCatchTest implements RewriteTest {
                       }
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/701")
+    @Test
+    void kotlinImportOnly() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import nebula.plugin.contacts.Contact
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/701")
+    @Test
+    void groovyTopLevelStatement() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+            """
+              def file = new File("test")
               """
           )
         );


### PR DESCRIPTION
## Summary
- Fixes #701. `RenameExceptionInEmptyCatch` threw `IllegalStateException` when processing Kotlin or Groovy files because `getCursorToParentScope()` used `J.CompilationUnit` as the top-level fallback in `dropParentUntil`, which doesn't match Kotlin/Groovy compilation unit types. Changed to `JavaSourceFile` which covers all language variants. Added regression tests for both Kotlin and Groovy.

## Test plan
- [x] Existing tests pass
- [x] New Kotlin import-only test passes (previously crashed)
- [x] New Groovy top-level statement test passes (previously crashed)