### PR TITLE
Fix UnnecessaryExplicitTypeArguments within lambda return statements

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -90,7 +90,38 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                             inferredType = methodDeclaration.getReturnTypeExpression().getType();
                         }
                     } else if (e instanceof J.Lambda) {
-                        inferredType = ((J.Lambda) e).getType();
+                        JavaType.Parameterized parameterized = TypeUtils.asParameterized(((J.Lambda) e).getType());
+                        if (parameterized != null) {
+                            JavaType.Method sam = null;
+                            for (JavaType.Method candidate : parameterized.getMethods()) {
+                                if (candidate.hasFlags(Flag.Default) || candidate.hasFlags(Flag.Static)) {
+                                    continue;
+                                }
+                                if (sam != null) {
+                                    sam = null;
+                                    break;
+                                }
+                                sam = candidate;
+                            }
+                            if (sam != null) {
+                                JavaType samReturn = sam.getReturnType();
+                                if (samReturn instanceof JavaType.GenericTypeVariable) {
+                                    String name = ((JavaType.GenericTypeVariable) samReturn).getName();
+                                    List<JavaType> formalParams = parameterized.getType().getTypeParameters();
+                                    List<JavaType> actualParams = parameterized.getTypeParameters();
+                                    for (int i = 0; i < formalParams.size() && i < actualParams.size(); i++) {
+                                        JavaType formal = formalParams.get(i);
+                                        if (formal instanceof JavaType.GenericTypeVariable &&
+                                                name.equals(((JavaType.GenericTypeVariable) formal).getName())) {
+                                            inferredType = actualParams.get(i);
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    inferredType = samReturn;
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -21,6 +21,8 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,38 +92,7 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                             inferredType = methodDeclaration.getReturnTypeExpression().getType();
                         }
                     } else if (e instanceof J.Lambda) {
-                        JavaType.Parameterized parameterized = TypeUtils.asParameterized(((J.Lambda) e).getType());
-                        if (parameterized != null) {
-                            JavaType.Method sam = null;
-                            for (JavaType.Method candidate : parameterized.getMethods()) {
-                                if (candidate.hasFlags(Flag.Default) || candidate.hasFlags(Flag.Static)) {
-                                    continue;
-                                }
-                                if (sam != null) {
-                                    sam = null;
-                                    break;
-                                }
-                                sam = candidate;
-                            }
-                            if (sam != null) {
-                                JavaType samReturn = sam.getReturnType();
-                                if (samReturn instanceof JavaType.GenericTypeVariable) {
-                                    String name = ((JavaType.GenericTypeVariable) samReturn).getName();
-                                    List<JavaType> formalParams = parameterized.getType().getTypeParameters();
-                                    List<JavaType> actualParams = parameterized.getTypeParameters();
-                                    for (int i = 0; i < formalParams.size() && i < actualParams.size(); i++) {
-                                        JavaType formal = formalParams.get(i);
-                                        if (formal instanceof JavaType.GenericTypeVariable &&
-                                                name.equals(((JavaType.GenericTypeVariable) formal).getName())) {
-                                            inferredType = actualParams.get(i);
-                                            break;
-                                        }
-                                    }
-                                } else {
-                                    inferredType = samReturn;
-                                }
-                            }
-                        }
+                        inferredType = getLambdaReturnType(((J.Lambda) e).getType());
                     }
                 }
 
@@ -130,6 +101,46 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                 }
 
                 return m;
+            }
+
+            private JavaType.@Nullable Method findMethodIfUnambiguous(JavaType.FullyQualified type) {
+                JavaType.Method sam = null;
+                for (JavaType.Method candidate : type.getMethods()) {
+                    if (candidate.hasFlags(Flag.Default) || candidate.hasFlags(Flag.Static)) {
+                        continue;
+                    }
+                    if (sam != null) {
+                        return null;
+                    }
+                    sam = candidate;
+                }
+                return sam;
+            }
+
+            private @Nullable JavaType getLambdaReturnType(@Nullable JavaType lambdaType) {
+                JavaType.Parameterized parameterized = TypeUtils.asParameterized(lambdaType);
+                if (parameterized == null) {
+                    return null;
+                }
+                JavaType.Method sam = findMethodIfUnambiguous(parameterized);
+                if (sam == null) {
+                    return null;
+                }
+                JavaType samReturn = sam.getReturnType();
+                if (samReturn instanceof JavaType.GenericTypeVariable) {
+                    String name = ((JavaType.GenericTypeVariable) samReturn).getName();
+                    List<JavaType> formalParams = parameterized.getType().getTypeParameters();
+                    List<JavaType> actualParams = parameterized.getTypeParameters();
+                    for (int i = 0; i < formalParams.size() && i < actualParams.size(); i++) {
+                        JavaType formal = formalParams.get(i);
+                        if (formal instanceof JavaType.GenericTypeVariable &&
+                                name.equals(((JavaType.GenericTypeVariable) formal).getName())) {
+                            return actualParams.get(i);
+                        }
+                    }
+                    return null;
+                }
+                return samReturn;
             }
 
             private boolean shouldRetainOnStaticMethod(JavaType.Method methodType) {

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -71,7 +71,7 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
-    @ExpectedToFail("Not implemented yet")
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/670")
     @Test
     void withinLambda() {
         rewriteRun(


### PR DESCRIPTION
- Closes #670

## Summary
- Fix `UnnecessaryExplicitTypeArguments` to properly remove unnecessary explicit type arguments inside lambda return statements
- The previous code used the lambda's functional interface type directly instead of resolving the SAM method's return type against the parameterized type
- Now correctly finds the Single Abstract Method, resolves generic type variables to actual type parameters, and compares against the method invocation's return type

## Test plan
- [x] Existing `withinLambda()` test now passes (previously `@ExpectedToFail`)
- [x] All other `UnnecessaryExplicitTypeArgumentsTest` tests still pass