### PR TITLE
NeedBraces: add test for if-else, fix do-while

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NeedBraces.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NeedBraces.java
@@ -22,7 +22,9 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.style.Checkstyle;
 import org.openrewrite.java.style.NeedBracesStyle;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JLeftPadded;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
@@ -229,7 +231,18 @@ public class NeedBraces extends Recipe {
                 J.Block b = buildBlock(elem.getBody());
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             } else if (!needBracesStyle.getAllowSingleLineStatement() && !hasAllowableBodyType) {
-                J.Block b = buildBlock(elem.getBody());
+                // The trailing comment between the body and the `while` keyword lives in the
+                // `before` space of the `whileCondition`. When wrapping the body in a block,
+                // move a same-line trailing comment into the new block's end so it stays with
+                // the body statement rather than drifting onto the closing brace.
+                JLeftPadded<J.ControlParentheses<Expression>> whileCondition = elem.getPadding().getWhileCondition();
+                Space whileBefore = whileCondition.getBefore();
+                Space end = Space.EMPTY;
+                if (!whileBefore.getComments().isEmpty() && !whileBefore.getWhitespace().contains("\n")) {
+                    end = whileBefore;
+                    elem = elem.getPadding().withWhileCondition(whileCondition.withBefore(Space.SINGLE_SPACE));
+                }
+                J.Block b = buildBlock(elem.getBody()).withEnd(end);
                 elem = maybeAutoFormat(elem, elem.withBody(b), ctx);
             }
             return elem;

--- a/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NeedBracesTest.java
@@ -519,6 +519,67 @@ class NeedBracesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/611")
+    @Test
+    void trailingCommentPreservedOnDoWhileBody() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void method(Object obj) {
+                      do
+                          obj.notify(); // notify
+                      while (true);
+                      System.out.println("done");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method(Object obj) {
+                      do {
+                          obj.notify(); // notify
+                      } while (true);
+                      System.out.println("done");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/611")
+    @Test
+    void trailingCommentPreservedOnIfBodyBeforeElse() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  boolean method(boolean nullable, String columnName) {
+                      if (nullable)
+                          return false; // skip
+                      else
+                          throw new IllegalArgumentException("cannot write non-nullable column with null value: " + columnName);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  boolean method(boolean nullable, String columnName) {
+                      if (nullable) {
+                          return false; // skip
+                      } else {
+                          throw new IllegalArgumentException("cannot write non-nullable column with null value: " + columnName);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/315")
     @Test
     void trailingCommentsElseBlock() {


### PR DESCRIPTION
## What's changed?
Fixing how comments are handled in `NeedBraces`:
- for `do-while` loops apply the same kind of fix we have elsewhere

Also add a test to ensure the exact case as mentioned in #611 is covered.

## What's your motivation?

- fixes #611 

