### PR TITLE
Fix UnnecessaryCatch for nested try-with-resources close()

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
@@ -111,6 +111,23 @@ public class UnnecessaryCatch extends Recipe {
                         }
                         return super.visitThrow(thrown, integer);
                     }
+
+                    @Override
+                    public J.Try visitTry(J.Try nestedTry, Integer integer) {
+                        if (nestedTry.getResources() != null) {
+                            for (J.Try.Resource resource : nestedTry.getResources()) {
+                                JavaType resourceType = resource.getVariableDeclarations().getType();
+                                if (resourceType instanceof JavaType.FullyQualified) {
+                                    for (JavaType.Method method : ((JavaType.FullyQualified) resourceType).getMethods()) {
+                                        if ("close".equals(method.getName()) && method.getParameterTypes().isEmpty()) {
+                                            thrownExceptions.addAll(method.getThrownExceptions());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        return super.visitTry(nestedTry, integer);
+                    }
                 }.visit(t.getBody(), 0);
 
                 Set<JavaType> unnecessaryTypes = getUnnecessaryTypes(t, thrownExceptions);

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -392,6 +393,63 @@ class UnnecessaryCatchTest implements RewriteTest {
                       try (StringWriter sw = new StringWriter()) {
                       } catch (IOException e) {
                           // Caught on .close()
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/677")
+    @Test
+    void doNotRemoveCatchForCloseOnNestedTryWithResources() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.ByteArrayOutputStream;
+              import java.io.IOException;
+
+              class Scratch {
+                  void method() {
+                      try {
+                          try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                              os.write(1);
+                          }
+                      } catch (IOException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/677")
+    @Test
+    void doNotRemoveMultiCatchForCloseOnNestedTryWithResources() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import javax.xml.transform.Transformer;
+              import javax.xml.transform.TransformerException;
+              import javax.xml.transform.stream.StreamResult;
+              import javax.xml.transform.stream.StreamSource;
+              import java.io.ByteArrayOutputStream;
+              import java.io.IOException;
+
+              class Scratch {
+                  static String transform(Transformer transformer, StreamSource text) {
+                      try {
+                          try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                              transformer.transform(text, new StreamResult(os));
+                              return os.toString();
+                          }
+                      } catch (IOException | TransformerException e) {
+                          throw new RuntimeException(e);
                       }
                   }
               }


### PR DESCRIPTION
## Summary
- Reproduces and fixes #677 where `UnnecessaryCatch` removed `IOException` from an outer catch that was actually handling the `close()` exception of a nested try-with-resources
- The visitor that collects thrown exceptions from the outer try body now also visits nested `J.Try` and, for each of its resources, adds the checked exceptions thrown by the resource type's `close()` method
- Adds two regression tests mirroring the `XsltTransformationVisitor` pattern (single and multi-catch)

## Test plan
- [x] `./gradlew test --tests UnnecessaryCatchTest`