### PR TITLE
Regression test for `ReplaceStackWithDeque` crash on `this` argument

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -76,6 +77,44 @@ class ReplaceStackWithDequeTest implements RewriteTest {
                       stack.add(1);
                       stack.add(2);
                       return stack;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-analysis/pull/95")
+    @Test
+    void thisAsArgumentInMethodInvocation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Stack;
+
+              class Test {
+                  void test(java.util.List<Test> result) {
+                      Stack<Integer> stack = new Stack<>();
+                      stack.add(1);
+                      if (stack.isEmpty()) {
+                          result.add(this);
+                      }
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayDeque;
+              import java.util.Deque;
+              import java.util.Stack;
+
+              class Test {
+                  void test(java.util.List<Test> result) {
+                      Deque<Integer> stack = new ArrayDeque<>();
+                      stack.add(1);
+                      if (stack.isEmpty()) {
+                          result.add(this);
+                      }
                   }
               }
               """


### PR DESCRIPTION
## Motivation

The flagship Java best practices recipe run failed on `finos/messageml-utils` and `finos/tracdap` today with:

```
java.lang.RuntimeException: Unable to create DataFlowNode for Cursor{Identifier->MethodInvocation->...}
  org.openrewrite.analysis.dataflow.DataFlowNode.ofOrThrow(DataFlowNode.java:76)
  org.openrewrite.analysis.dataflow.analysis.ForwardFlow.computeVariableAssignment(ForwardFlow.java:466)
  org.openrewrite.analysis.dataflow.analysis.ForwardFlow$Analysis.visitIdentifier(ForwardFlow.java:302)
```

Both files used `this` as an argument to a method invocation (`result.add(this)`, `validator.apply(target, arg, this)`) in code that `ReplaceStackWithDeque` traced dataflow through. Root cause was a one-character typo in `rewrite-analysis` where `ThisAccess.Factory.viewOf` checked for `"super"` instead of `"this"`, so `DataFlowNode.of` returned `none` for every `this` identifier.

- Fixed upstream in openrewrite/rewrite-analysis#95. This PR adds a regression test so the recipe cannot silently regress if the upstream behavior changes again.

## Summary

- Add `ReplaceStackWithDequeTest.thisAsArgumentInMethodInvocation` — a minimal reproducer of the production crash: a `Stack` variable in the same method as `result.add(this)`

## Test plan

- [x] Test fails with the old `rewrite-analysis` (same stack trace as production)
- [x] Test passes with rewrite-analysis#95 merged (verified locally against a Maven Local snapshot)
- [x] `./gradlew test --tests ReplaceStackWithDequeTest` passes

> Note: CI needs the rewrite-analysis snapshot that includes the fix. Rerun CI once the next rewrite-analysis SNAPSHOT is published.