### PR TITLE
bugfix:  false positive in AnnotateNullableParameters when parameter …

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableParameters.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableParameters.java
@@ -318,14 +318,15 @@ public class AnnotateNullableParameters extends Recipe {
         }
 
         private void handleMethodInvocation(J.MethodInvocation mi, Set<J.Identifier> nullCheckedParams) {
-            if (isKnownNullMethodChecker(mi) && !mi.getArguments().isEmpty()) {
+            if (isKnownNullMethodChecker(mi)) {
                 // Only consider the parameter as null-checked if it's passed directly,
                 // not if it's dereferenced first (e.g., map.get("key"))
-                Expression firstArg = mi.getArguments().get(0);
-                if (firstArg instanceof J.Identifier) {
-                    J.Identifier identifier = (J.Identifier) firstArg;
-                    if (containsIdentifierByName(identifiers, identifier)) {
-                        nullCheckedParams.add(identifier);
+                for (Expression arg : mi.getArguments()) {
+                    if (arg instanceof J.Identifier) {
+                        J.Identifier identifier = (J.Identifier) arg;
+                        if (containsIdentifierByName(identifiers, identifier)) {
+                            nullCheckedParams.add(identifier);
+                        }
                     }
                 }
             }

--- a/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableParameters.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AnnotateNullableParameters.java
@@ -318,16 +318,16 @@ public class AnnotateNullableParameters extends Recipe {
         }
 
         private void handleMethodInvocation(J.MethodInvocation mi, Set<J.Identifier> nullCheckedParams) {
-            if (isKnownNullMethodChecker(mi)) {
-                new JavaIsoVisitor<Set<J.Identifier>>() {
-                    @Override
-                    public J.Identifier visitIdentifier(J.Identifier identifier, Set<J.Identifier> set) {
-                        if (containsIdentifierByName(identifiers, identifier)) {
-                            set.add(identifier);
-                        }
-                        return identifier;
+            if (isKnownNullMethodChecker(mi) && !mi.getArguments().isEmpty()) {
+                // Only consider the parameter as null-checked if it's passed directly,
+                // not if it's dereferenced first (e.g., map.get("key"))
+                Expression firstArg = mi.getArguments().get(0);
+                if (firstArg instanceof J.Identifier) {
+                    J.Identifier identifier = (J.Identifier) firstArg;
+                    if (containsIdentifierByName(identifiers, identifier)) {
+                        nullCheckedParams.add(identifier);
                     }
-                }.visit(mi.getArguments(), nullCheckedParams);
+                }
             }
         }
 

--- a/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableParametersTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AnnotateNullableParametersTest.java
@@ -909,4 +909,30 @@ class AnnotateNullableParametersTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void unchangedWhenParameterDereferencedBeforeNullCheckingMethod() {
+        List<String> additionalNullCheckingMethods = List.of("org.my.util.Text isEmptyOrNull(java.lang.String)");
+        rewriteRun(
+          spec -> spec.recipe(new AnnotateNullableParameters(null, additionalNullCheckingMethods)),
+          //language=java
+          java(
+            """
+              import java.util.Map;
+              import org.my.util.Text;
+
+              public class PersonBuilder {
+                  private String name = "Unknown";
+
+                  public PersonBuilder setInfo(Map<String, String> infoMap) {
+                      if (!Text.isEmptyOrNull(infoMap.get("name"))) {
+                          this.name = infoMap.get("name");
+                      }
+                      return this;
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION

## Fix false positive in AnnotateNullableParameters when parameter is dereferenced before null check

### Problem

The `AnnotateNullableParameters` recipe was incorrectly annotating parameters as `@Nullable` when they were dereferenced before being passed to **additional** null-checking methods. 

For example, in this code:
```java
public void setInfo(Map<String, String> infoMap) {
    if (!Text.isEmptyOrNull(infoMap.get("name"))) {
        this.name = infoMap.get("name");
    }
}
```

The recipe would incorrectly annotate `infoMap` as `@Nullable` because it detected `Text.isEmptyOrNull()` being called. However, `infoMap` itself is being dereferenced (via `.get()`), which means it cannot be null at that point. The null check is for the **return value** of `get()`, not for `infoMap` itself.

### Solution

Modified the `handleMethodInvocation` method to only consider a parameter as null-checked when it's passed **directly** as an identifier to the null-checking method, not when it's dereferenced first.

**Before**: Used a visitor to traverse all identifiers within the method arguments, capturing any that matched parameter names.

**After**: Only checks if the first argument is a direct `J.Identifier` matching a parameter name.

### Changes

- **`AnnotateNullableParameters.java`**: Simplified `handleMethodInvocation` to prevent false positives from dereferenced parameters
- **`AnnotateNullableParametersTest.java`**: Added regression test `unchangedWhenParameterDereferencedBeforeNullCheckingMethod` to verify the fix

### Requested Reviewer
@timtebeek 
