### PR TITLE
Preserve statement order in `UseTryWithResources`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseTryWithResources.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseTryWithResources.java
@@ -306,9 +306,17 @@ public class UseTryWithResources extends Recipe {
     }
 
     private static boolean finallyContainsClose(J.Block finallyBlock, String varName) {
+        // The target close must be reachable without any non-close statements before it.
+        // Try-with-resources closes the resource before the finally block runs, so any
+        // statement that originally ran before the close in the finally would otherwise
+        // run after it. Other close statements (for variables that will also be merged
+        // into the try-with-resources) are tolerated.
         for (Statement stmt : finallyBlock.getStatements()) {
             if (isCloseStatement(stmt, varName)) {
                 return true;
+            }
+            if (extractVarNameFromCloseStatement(stmt) == null) {
+                return false;
             }
         }
         return false;

--- a/src/test/java/org/openrewrite/staticanalysis/UseTryWithResourcesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseTryWithResourcesTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -343,7 +344,45 @@ class UseTryWithResourcesTest implements RewriteTest {
     }
 
     @Test
-    void finallyWithExtraLogicKeepsRemainingStatements() {
+    void finallyWithExtraLogicAfterCloseKeepsRemainingStatements() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.*;
+
+              class Test {
+                  void method() throws IOException {
+                      InputStream in = new FileInputStream("file.txt");
+                      try {
+                          int data = in.read();
+                      } finally {
+                          in.close();
+                          System.out.println("closed");
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.*;
+
+              class Test {
+                  void method() throws IOException {
+                      try (InputStream in = new FileInputStream("file.txt")) {
+                          int data = in.read();
+                      } finally {
+                          System.out.println("closed");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/moderneinc/rewrite-java-application-server/issues/19")
+    void doNotChangeWhenStatementsBeforeClose() {
         rewriteRun(
           //language=java
           java(
@@ -361,16 +400,32 @@ class UseTryWithResourcesTest implements RewriteTest {
                       }
                   }
               }
-              """,
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/moderneinc/rewrite-java-application-server/issues/19")
+    void doNotChangeWhenCleanupBeforeClose() {
+        rewriteRun(
+          //language=java
+          java(
             """
               import java.io.*;
 
               class Test {
-                  void method() throws IOException {
-                      try (InputStream in = new FileInputStream("file.txt")) {
+                  interface CancellationTokenSource {
+                      void cancel();
+                  }
+
+                  void method(CancellationTokenSource cancellation) throws IOException {
+                      InputStream in = new FileInputStream("file.txt");
+                      try {
                           int data = in.read();
                       } finally {
-                          System.out.println("closing");
+                          cancellation.cancel();
+                          in.close();
                       }
                   }
               }


### PR DESCRIPTION
## Summary
- Fix `UseTryWithResources` reordering finally-block statements when merging a `close()` into try-with-resources. Try-with-resources auto-closes before the finally runs, so any non-close statement that originally preceded the close would move to after it.
- The recipe now refuses to transform when a non-close statement appears before the target `close()` in the finally; other close statements (which will themselves be merged into the try-with-resources) are still tolerated.
- Updated the existing `finallyWithExtraLogic…` test to use the safe ordering and added two regression tests for [moderneinc/rewrite-java-application-server#19](https://github.com/moderneinc/rewrite-java-application-server/issues/19).

## Test plan
- [x] `./gradlew test --tests UseTryWithResourcesTest`