### PR TITLE
Skip meta-annotated `@Configuration` in `FinalClass` and `HideUtilityClassConstructor`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalClassVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalClassVisitor.java
@@ -35,7 +35,7 @@ import static org.openrewrite.staticanalysis.ModifierOrder.sortModifiers;
 
 public class FinalClassVisitor extends JavaIsoVisitor<ExecutionContext> {
 
-    private static final AnnotationMatcher CONFIGURATION_ANNOTATION = new AnnotationMatcher("@org.springframework.context.annotation.Configuration");
+    private static final AnnotationMatcher CONFIGURATION_ANNOTATION = new AnnotationMatcher("@org.springframework.context.annotation.Configuration", true);
 
     Tree visitRoot;
 
@@ -75,7 +75,7 @@ public class FinalClassVisitor extends JavaIsoVisitor<ExecutionContext> {
             return cd;
         }
 
-        // Spring @Configuration classes are proxied at runtime and must not be final
+        // Spring @Configuration classes (including meta-annotated ones like @TestConfiguration / @SpringBootApplication) are proxied at runtime and must not be final
         if (cd.getLeadingAnnotations().stream().anyMatch(a -> CONFIGURATION_ANNOTATION.matches(a))) {
             return cd;
         }

--- a/src/main/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorVisitor.java
@@ -168,7 +168,7 @@ public class HideUtilityClassConstructorVisitor<P> extends JavaIsoVisitor<P> {
      * Until then, however, we'll keep this private and unexposed.
      */
     private final class UtilityClassMatcher {
-        private final AnnotationMatcher configurationAnnotation = new AnnotationMatcher("@org.springframework.context.annotation.Configuration");
+        private final AnnotationMatcher configurationAnnotation = new AnnotationMatcher("@org.springframework.context.annotation.Configuration", true);
         private final Collection<AnnotationMatcher> ignorableAnnotations;
 
         private UtilityClassMatcher(Collection<String> ignorableAnnotations) {

--- a/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
@@ -215,6 +215,40 @@ class FinalClassTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/729")
+    @Test
+    void doNotFinalizeSpringTestConfigurationClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.springframework.context.annotation;
+              public @interface Configuration {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package org.springframework.boot.test.context;
+              import org.springframework.context.annotation.Configuration;
+              @Configuration
+              public @interface TestConfiguration {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.context.TestConfiguration;
+
+              @TestConfiguration
+              class MyTestConfig {
+                  private MyTestConfig() {}
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/372")
     @Test
     void doNotFinalizeClassWithNestedStaticFinalSubclass() {

--- a/src/test/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/HideUtilityClassConstructorTest.java
@@ -566,6 +566,42 @@ class HideUtilityClassConstructorTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/729")
+    @Test
+    void doNotChangeSpringTestConfigurationClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package org.springframework.context.annotation;
+              public @interface Configuration {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package org.springframework.boot.test.context;
+              import org.springframework.context.annotation.Configuration;
+              @Configuration
+              public @interface TestConfiguration {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              import org.springframework.boot.test.context.TestConfiguration;
+
+              @TestConfiguration
+              class MyTestConfig {
+                  public static String someBean() {
+                      return "bean";
+                  }
+              }
+              """
+          )
+        );
+    }
+
     private static Consumer<RecipeSpec> hideUtilityClassConstructor(String... ignoreIfAnnotatedBy) {
         return spec -> spec.parser(JavaParser.fromJavaVersion().styles(
           singletonList(


### PR DESCRIPTION
## Summary

- Flip the `AnnotationMatcher` for `@org.springframework.context.annotation.Configuration` to `matchesMetaAnnotations=true` in both `FinalClassVisitor` and `HideUtilityClassConstructorVisitor`, so classes annotated with `@TestConfiguration`, `@SpringBootApplication`, or any other stereotype layered on top of `@Configuration` are skipped for the same proxy/CGLIB reasons.
- Add regression tests covering `@TestConfiguration` for both recipes.

- Addresses https://github.com/openrewrite/rewrite-static-analysis/issues/729#issuecomment-4332205496.

## Test plan
- [x] `./gradlew test --tests FinalClassTest --tests HideUtilityClassConstructorTest`