### PR TITLE
Revert to using rewrite-java-21 for test runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 
     testImplementation("com.google.code.gson:gson:latest.release")
 
-    testRuntimeOnly("org.openrewrite:rewrite-java-25")
+    testRuntimeOnly("org.openrewrite:rewrite-java-21")
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
 }
 


### PR DESCRIPTION
## Summary
- Downgrade `testRuntimeOnly` dependency from `rewrite-java-25` to `rewrite-java-21`.
- As we saw failures with using Gradle 8.12 (old default), 8.14.3 (new default), 8.14.4 (breaks on Kotlin val), and 9.x

## Test plan
- [ ] `./gradlew check`