### PR TITLE
Preserve casts pinning generic-method return type in lambdas

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -131,6 +131,23 @@ public class RemoveRedundantTypeCast extends Recipe {
                     }
                 }
 
+                // A cast inside a lambda body may pin the inferred return type of a generic method call
+                // so outer inference (e.g. Optional.map -> ifPresent) doesn't lose it to the type bound.
+                if (parentValue instanceof J.Lambda && typeCast.getExpression() instanceof J.MethodInvocation) {
+                    JavaType.Method invokedMethod = ((J.MethodInvocation) typeCast.getExpression()).getMethodType();
+                    if (invokedMethod != null && invokedMethod.getDeclaringType() != null) {
+                        for (JavaType.Method declared : invokedMethod.getDeclaringType().getMethods()) {
+                            if (declared.getName().equals(invokedMethod.getName()) &&
+                                    declared.getParameterTypes().size() == invokedMethod.getParameterTypes().size() &&
+                                    declared.getReturnType() instanceof JavaType.GenericTypeVariable &&
+                                    declared.getDeclaredFormalTypeNames().contains(
+                                            ((JavaType.GenericTypeVariable) declared.getReturnType()).getName())) {
+                                return visitedTypeCast;
+                            }
+                        }
+                    }
+                }
+
                 if (!(targetType instanceof JavaType.Array) && TypeUtils.isOfClassType(targetType, "java.lang.Object") ||
                     TypeUtils.isOfType(targetType, expressionType) ||
                     TypeUtils.isAssignableTo(targetType, expressionType)) {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -612,6 +612,33 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/871")
+    @Test
+    void doNotRemoveCastNeededForGenericMethodInferenceInLambda() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.nio.file.Path;
+              import java.util.List;
+              import java.util.Optional;
+
+              interface SourceFile {
+                  <T extends SourceFile> T withSourcePath(Path path);
+              }
+
+              class Test {
+                  void foo(Optional<? extends SourceFile> opt, Path targetPath, List<SourceFile> generated) {
+                      opt
+                          .map(sourceFile -> (SourceFile) sourceFile.withSourcePath(targetPath))
+                          .ifPresent(generated::add);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/221")
     @Test
     void doNotRemoveCharacterCastInGenericContext() {


### PR DESCRIPTION
## Summary
- `RemoveRedundantTypeCast` was stripping casts like `(SourceFile) sourceFile.withSourcePath(targetPath)` inside lambda bodies, breaking compilation when the invoked method's return type is a method-level type variable (`<T extends SourceFile> T withSourcePath(Path)`).
- Without the cast, outer inference (e.g. `Optional.map(...).ifPresent(generated::add)`) loses `T` to its bound, producing an "incompatible types" error.
- Added a guard: when the cast sits in a lambda body and wraps a method invocation whose declared return type is a generic type variable from the method's own formal type parameters, keep the cast. The lookup goes through the declaring type's methods because the call-site `JavaType.Method` already substitutes `T` with its bound.

- Fixes #871

## Test plan
- [x] New test `doNotRemoveCastNeededForGenericMethodInferenceInLambda` reproduces the scenario from the issue.
- [x] Full `RemoveRedundantTypeCastTest` suite passes.
- [x] Full `./gradlew test` passes.