### PR TITLE
Skip `Objects::nonNull`/`isNull` when lambda parameter does not match

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -145,8 +145,17 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
             if (body instanceof J.Binary) {
                 J.Binary binary = (J.Binary) body;
                 if ((binary.getOperator() == J.Binary.Type.Equal || binary.getOperator() == J.Binary.Type.NotEqual) &&
-                        isNullCheck(binary.getLeft(), binary.getRight()) ||
-                        isNullCheck(binary.getRight(), binary.getLeft())) {
+                        (isNullCheck(binary.getLeft(), binary.getRight()) ||
+                                isNullCheck(binary.getRight(), binary.getLeft()))) {
+                    List<J.VariableDeclarations.NamedVariable> lambdaParameters = getLambdaParameters(lambda);
+                    if (lambdaParameters.size() != 1) {
+                        return l;
+                    }
+                    Expression nonNullSide = isNullCheck(binary.getLeft(), binary.getRight()) ? binary.getLeft() : binary.getRight();
+                    if (!(nonNullSide instanceof J.Identifier) ||
+                            ((J.Identifier) nonNullSide).getFieldType() != lambdaParameters.get(0).getVariableType()) {
+                        return l;
+                    }
                     code = J.Binary.Type.Equal == binary.getOperator() ? "java.util.Objects::isNull" :
                             "java.util.Objects::nonNull";
                     J updated = JavaTemplate.builder(code)

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -790,6 +790,31 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/873")
+    @Test
+    void zeroArgNullCheckLambdaCannotBecomeObjectsNonNull() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.Callable;
+
+              public class Main {
+                  private Object importerSource;
+
+                  void awaitReady(final ConditionFactory await) {
+                      await.until(() -> importerSource != null);
+                  }
+
+                  interface ConditionFactory {
+                      void until(Callable<Boolean> condition);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings("Convert2MethodRef")
     @Test
     void isEqualToNull() {


### PR DESCRIPTION
## Summary
- Fixes #873. `ReplaceLambdaWithMethodReference` was rewriting `() -> field != null` to `Objects::nonNull` even when the lambda had no parameters (or when the null check referred to a captured field rather than the lambda parameter), producing code that no longer compiled against zero-arg functional interfaces like `Callable<Boolean>`.

The recipe now only transforms binary null checks when the lambda has exactly one parameter and the non-null side of the comparison is an identifier referencing that parameter. Also fixed a precedence bug in the surrounding boolean condition.

## Test plan
- [x] Added `zeroArgNullCheckLambdaCannotBecomeObjectsNonNull` reproducing the issue
- [x] `./gradlew test --tests ReplaceLambdaWithMethodReferenceTest` passes