### PR TITLE
Preserve `(Object)` bridge cast for unchecked generic casts

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -70,6 +70,22 @@ public class RemoveRedundantTypeCast extends Recipe {
                 JavaType expressionType = visitedTypeCast.getExpression().getType();
                 JavaType castType = visitedTypeCast.getType();
 
+                // Bridge cast: if the immediate parent is another TypeCast and the outer cast type
+                // is not directly assignable to/from this cast's expression type, preserve this cast
+                // because removing it would make the outer (often unchecked generic) cast invalid.
+                Cursor parentTreeCursor = getCursor().getParentTreeCursor();
+                while (parentTreeCursor.getValue() instanceof J.Parentheses) {
+                    parentTreeCursor = parentTreeCursor.getParentTreeCursor();
+                }
+                if (parentTreeCursor.getValue() instanceof J.TypeCast) {
+                    JavaType outerCastType = ((J.TypeCast) parentTreeCursor.getValue()).getType();
+                    if (outerCastType != null && expressionType != null &&
+                            !TypeUtils.isAssignableTo(outerCastType, expressionType) &&
+                            !TypeUtils.isAssignableTo(expressionType, outerCastType)) {
+                        return visitedTypeCast;
+                    }
+                }
+
                 JavaType targetType = null;
                 if (castType.equals(expressionType)) {
                     targetType = castType;

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -56,6 +56,17 @@ public class RemoveRedundantTypeCast extends Recipe {
                     return visited;
                 }
 
+                // A cast nested inside another cast typically bridges an unchecked generic
+                // conversion (e.g. `(List<String>) (Object) values`); preserve it.
+                Cursor parentTreeCursor = getCursor().getParentTreeCursor();
+                while (parentTreeCursor.getValue() instanceof J.Parentheses ||
+                        parentTreeCursor.getValue() instanceof J.ControlParentheses) {
+                    parentTreeCursor = parentTreeCursor.getParentTreeCursor();
+                }
+                if (parentTreeCursor.getValue() instanceof J.TypeCast) {
+                    return visited;
+                }
+
                 Cursor parent = getCursor().dropParentUntil(is -> is instanceof J.VariableDeclarations ||
                                                                   is instanceof J.Lambda ||
                                                                   is instanceof J.Return ||
@@ -69,22 +80,6 @@ public class RemoveRedundantTypeCast extends Recipe {
                 J.TypeCast visitedTypeCast = (J.TypeCast) visited;
                 JavaType expressionType = visitedTypeCast.getExpression().getType();
                 JavaType castType = visitedTypeCast.getType();
-
-                // Bridge cast: if the immediate parent is another TypeCast and the outer cast type
-                // is not directly assignable to/from this cast's expression type, preserve this cast
-                // because removing it would make the outer (often unchecked generic) cast invalid.
-                Cursor parentTreeCursor = getCursor().getParentTreeCursor();
-                while (parentTreeCursor.getValue() instanceof J.Parentheses) {
-                    parentTreeCursor = parentTreeCursor.getParentTreeCursor();
-                }
-                if (parentTreeCursor.getValue() instanceof J.TypeCast) {
-                    JavaType outerCastType = ((J.TypeCast) parentTreeCursor.getValue()).getType();
-                    if (outerCastType != null && expressionType != null &&
-                            !TypeUtils.isAssignableTo(outerCastType, expressionType) &&
-                            !TypeUtils.isAssignableTo(expressionType, outerCastType)) {
-                        return visitedTypeCast;
-                    }
-                }
 
                 JavaType targetType = null;
                 if (castType.equals(expressionType)) {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -653,6 +653,7 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
 
                   void call(List<Integer> values) {
                       accept((List<String>) (Object) values);
+                      accept((List<String>) ((Object) values));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -639,6 +639,27 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/874")
+    @Test
+    void doNotRemoveObjectBridgeCastForUncheckedGenericCast() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Main {
+                  void accept(List<String> values) {}
+
+                  void call(List<Integer> values) {
+                      accept((List<String>) (Object) values);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/221")
     @Test
     void doNotRemoveCharacterCastInGenericContext() {


### PR DESCRIPTION
## Summary
- Fixes #874. `RemoveRedundantTypeCast` was stripping the `(Object)` bridge in expressions like `accept((List<String>) (Object) values)`, leaving a direct `(List<String>) values` that fails to compile.

When a cast's immediate parent (skipping parentheses) is another `J.TypeCast`, and neither the outer cast type nor the inner expression type are assignable to one another, the inner cast is acting as a bridge for an unchecked generic conversion and is preserved.

## Test plan
- [x] Added `doNotRemoveObjectBridgeCastForUncheckedGenericCast` reproducing the issue
- [x] Full `RemoveRedundantTypeCastTest` suite passes