### PR TITLE
Regression tests for ReplaceStackWithDeque ControlFlow crashes

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class ReplaceStackWithDequeTest implements RewriteTest {
     @Override
@@ -79,6 +80,92 @@ class ReplaceStackWithDequeTest implements RewriteTest {
                       return stack;
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotFailOnAnonymousClassWithMultipleReturningMethods() {
+        // Regression: ControlFlow used to throw "No current node!" while analyzing the
+        // outer method's data flow because it descended into the anonymous class body
+        // and treated each nested method declaration as part of the enclosing flow.
+        // After the fix, dataflow correctly detects that `result` is returned, so the
+        // Stack is not rewritten; the recipe completes without throwing.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Stack;
+
+              class Test {
+                  Stack<String> rows() {
+                      Stack<String> result = new Stack<>();
+                      Object visitor = new Object() {
+                          @Override
+                          public boolean equals(Object obj) {
+                              return obj == this;
+                          }
+
+                          @Override
+                          public String toString() {
+                              return "v";
+                          }
+                      };
+                      result.add(visitor.toString());
+                      return result;
+                  }
+              }
+              """,
+            """
+              import java.util.Stack;
+
+              class Test {
+                  Stack<String> rows() {
+                      Stack<String> result = new Stack<>();
+                      Object visitor = new Object() {
+                          @Override
+                          public boolean equals(Object obj) {
+                              return obj == this;
+                          }
+
+                          @Override
+                          public String toString() {
+                              return "v";
+                          }
+                      };
+                      result.add(visitor.toString());
+                      return result;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotFailOnKotlinExpressionBodyWithBooleanOr() {
+        // Regression: ControlFlow used to throw "Condition Node is not a guard!" while
+        // analyzing a Kotlin expression-body function whose `||` operand was a binary
+        // equality expression or a method invocation returning `kotlin.Boolean` — the
+        // operand cursor wasn't recognized as a Guard because `kotlin.Boolean` isn't
+        // assignable to the JVM `boolean` primitive in OpenRewrite's type system.
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import java.util.Stack
+
+              fun isImperative(name: String?, stack: Stack<String> = Stack()): Boolean =
+                  name == "Recipe" || (!stack.contains(name) && isImperative(name, stack.apply { push(name) }))
+              """,
+            """
+              import java.util.ArrayDeque
+              import java.util.Deque
+              import java.util.Stack
+
+              fun isImperative(name: String?, stack: Deque<String> = ArrayDeque()): Boolean =
+                  name == "Recipe" || (!stack.contains(name) && isImperative(name, stack.apply { push(name) }))
               """
           )
         );


### PR DESCRIPTION
## Motivation

`ReplaceStackWithDeque` was throwing `ControlFlowIllegalStateException`s on flagship runs of the "OpenRewrite recipe best practices" recipe (2026-05-05 and 2026-05-06) against:

- `moderneinc/moderne-intellij-plugin` (Kotlin) — \`Condition Node is not a guard!\`
- `moderneinc/rewrite-sql` (Java) — \`No current node!\`
- `openrewrite/rewrite-templating` (Java) — \`No current node!\`

- The crashes originated in `org.openrewrite.analysis.controlflow.ControlFlow` (used here via `FindLocalFlowPaths.noneMatch`). The analyzer fix lives in https://github.com/openrewrite/rewrite-analysis/pull/96. This PR adds two minimized regression tests that reproduce the failures from the static-analysis side so we catch any future regressions through the recipe entry point.

## Summary

- `doNotFailOnAnonymousClassWithMultipleReturningMethods` — Java reproducer for \`No current node!\`. An anonymous class body with two methods whose bodies both `return`. After the analyzer fix, dataflow correctly detects that `result` is returned, so the Stack stays.
- `doNotFailOnKotlinExpressionBodyWithBooleanOr` — Kotlin reproducer for \`Condition Node is not a guard!\`. A `Boolean`-returning expression-body function combining `==` and `||`. The function returns a `Boolean`, not the stack, so the Stack→Deque replacement is correct here; the test asserts the recipe runs to completion.

## Test plan

- [x] Both new tests fail without the analyzer fix and pass with it (verified locally against \`org.openrewrite.meta:rewrite-analysis 2.33.0-SNAPSHOT\` from the linked PR).
- [x] Existing `ReplaceStackWithDequeTest` cases still pass.
- [x] Full \`./gradlew test\` passes.