### PR TITLE
Skip `SimplifyConsecutiveAssignments` when initializer would self-reference

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyConsecutiveAssignments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyConsecutiveAssignments.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class SimplifyConsecutiveAssignments extends Recipe {
@@ -65,7 +66,8 @@ public class SimplifyConsecutiveAssignments extends Recipe {
                             Expression acc = numericVariableAccumulation(nextStatement, name);
                             String op = numericVariableOperator(nextStatement, name);
 
-                            if (acc != null && op != null) {
+                            if (acc != null && op != null &&
+                                    !(stat instanceof J.VariableDeclarations && referencesVariable(acc, name))) {
                                 skip.set(i + 1);
                                 // combine this statement with the following statement into one binary expression
                                 return combine(new Cursor(getCursor(), stat), op, acc);
@@ -162,6 +164,18 @@ public class SimplifyConsecutiveAssignments extends Recipe {
                     }
                 }
                 return null;
+            }
+
+            private boolean referencesVariable(Expression expression, String name) {
+                return new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
+                        if (name.equals(identifier.getSimpleName()) && identifier.getFieldType() != null) {
+                            found.set(true);
+                        }
+                        return identifier;
+                    }
+                }.reduce(expression, new AtomicBoolean()).get();
             }
 
             private @Nullable String singleVariableName(Expression e) {

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyConsecutiveAssignmentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyConsecutiveAssignmentsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -89,6 +90,25 @@ class SimplifyConsecutiveAssignmentsTest implements RewriteTest {
                           x = 2;
                       }
                       return x;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/881")
+    void doNotInlineWhenInitializerWouldBeSelfReferential() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Main {
+                  int swizzle(int state) {
+                      int result = state;
+                      result ^= result >>> 1;
+                      return result;
                   }
               }
               """


### PR DESCRIPTION
## Summary
- Fixes #881: `SimplifyConsecutiveAssignments` was folding a follow-up compound assignment into a variable declaration's initializer even when the right-hand side referenced the variable being declared, producing code like `int result = state ^ result >>> 1;` that fails to compile.
- The visitor now skips combining when the original statement is a `J.VariableDeclarations` and the accumulated expression references the same variable.
- Added a regression test mirroring the issue's reproducer.

## Test plan
- [x] `./gradlew test --tests SimplifyConsecutiveAssignmentsTest`