### PR TITLE
Document identity-semantics caveat on PrimitiveWrapperClassConstructorToValueOf

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
@@ -40,7 +40,10 @@ public class PrimitiveWrapperClassConstructorToValueOf extends Recipe {
     @Getter
     final String description = "The constructor of all primitive types has been deprecated in favor of using the static " +
             "factory method `valueOf` available for each of the primitive type wrappers. " +
-            "Using `valueOf` enables object caching for frequently used values, reducing unnecessary heap allocations.";
+            "Using `valueOf` enables object caching for frequently used values, reducing unnecessary heap allocations. " +
+            "Note that this changes identity semantics: `valueOf` may return cached instances (such as `Boolean.TRUE` or " +
+            "`Integer` values in `[-128, 127]`), so code that compares boxed values with `==`/`!=`, relies on " +
+            "`System.identityHashCode`, or synchronizes on the boxed value may behave differently after this change.";
 
     @Getter
     final Set<String> tags = singleton("RSPEC-S2129");


### PR DESCRIPTION
## Summary
- Append a note to the `PrimitiveWrapperClassConstructorToValueOf` description explaining that replacing `new Boolean(..)`/`new Integer(..)`/etc. with `Boolean.valueOf(..)`/`Integer.valueOf(..)`/etc. changes identity semantics, since `valueOf` may return cached instances (e.g. `Boolean.TRUE`, the `Integer` cache for `[-128, 127]`).
- Docs-only; visitor logic is unchanged.

- Closes #880

## Test plan
- [x] No behavior change; existing tests still pass via compilation