### PR TITLE
Skip `FinalClass` when class has anonymous inner subclasses

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalClassVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalClassVisitor.java
@@ -102,6 +102,19 @@ public class FinalClassVisitor extends JavaIsoVisitor<ExecutionContext> {
         return cd;
     }
 
+    @Override
+    public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+        J.NewClass nc = super.visitNewClass(newClass, ctx);
+        // Anonymous classes extend their declared type; that supertype must not be made final
+        if (nc.getBody() != null && nc.getClazz() != null) {
+            JavaType.FullyQualified type = TypeUtils.asFullyQualified(nc.getClazz().getType());
+            if (type != null) {
+                typesToNotFinalize.add(type.getFullyQualifiedName());
+            }
+        }
+        return nc;
+    }
+
     private void excludeSupertypes(JavaType.FullyQualified type) {
         if (type.getSupertype() != null &&
                 typesToNotFinalize.add(type.getSupertype().getFullyQualifiedName())) {

--- a/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalClassTest.java
@@ -267,6 +267,25 @@ class FinalClassTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/885")
+    @Test
+    void doNotFinalizeClassWithAnonymousSubclass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Factory {
+                  private Factory() {}
+
+                  static Factory create() {
+                      return new Factory() {};
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/372")
     @Test
     void doNotFinalizeClassWithNestedStaticSubclass() {


### PR DESCRIPTION
## Summary
- `FinalClass` was incorrectly adding `final` to classes whose private constructors are used from anonymous inner subclasses defined within the class body, producing uncompilable code.
- The visitor now records the supertype of any anonymous class as a type that must not be finalized, mirroring how named subclass supertypes are already excluded.

- Fixes #885

## Test plan
- [x] `./gradlew test --tests FinalClassTest` (new `doNotFinalizeClassWithAnonymousSubclass` plus existing scenarios)