### PR TITLE
Skip `ReplaceLambdaWithMethodReference` for parameterized types with multiple constructors

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -172,11 +172,13 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                     if (nc.getBody() != null) {
                         return l;
                     }
-                    if (isAMethodInvocationArgument(l, getCursor()) && nc.getType() instanceof JavaType.Class) {
-                        JavaType.Class clazz = (JavaType.Class) nc.getType();
-                        boolean hasMultipleConstructors = clazz.getMethods().stream().filter(JavaType.Method::isConstructor).count() > 1;
-                        if (hasMultipleConstructors) {
-                            return l;
+                    if (isAMethodInvocationArgument(l, getCursor())) {
+                        JavaType.FullyQualified clazz = TypeUtils.asFullyQualified(nc.getType());
+                        if (clazz != null) {
+                            boolean hasMultipleConstructors = clazz.getMethods().stream().filter(JavaType.Method::isConstructor).count() > 1;
+                            if (hasMultipleConstructors) {
+                                return l;
+                            }
                         }
                     }
                 } else if (method instanceof J.MemberReference) {

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -1090,6 +1090,37 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Test
+    void multipleConstructorsOnGenericTypeWithDiamond() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class B<T> {
+                  B() {}
+                  B(boolean flag) {}
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+              import java.util.function.Supplier;
+
+              class A {
+                  void method(Supplier<B<?>> supplier) {}
+                  void method(Function<A, B<?>> function) {}
+
+                  void test() {
+                      method(() -> new B<>());
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2949")
     @Test
     void anotherMultipleConstructorsCaseEasyUnderstanding() {


### PR DESCRIPTION
## Summary

- The multi-constructor guard in `ReplaceLambdaWithMethodReference` only checked `JavaType.Class`, so `() -> new Visitor<>()` (with a diamond) slipped through and was rewritten to `Visitor::new`.
- When the visitor had multiple constructors and the surrounding method was overloaded (e.g. `toRecipe(Supplier)` vs `toRecipe(Function)`), the resulting `::new` reference became ambiguous and failed to compile.
- Switched the check to `TypeUtils.asFullyQualified(nc.getType())` so it covers both raw and parameterized constructor calls, and added a regression test.

## Test plan
- [x] `./gradlew test --tests ReplaceLambdaWithMethodReferenceTest`