### PR TITLE
Preserve `null` cast at varargs position in `RemoveRedundantTypeCast`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -97,6 +97,14 @@ public class RemoveRedundantTypeCast extends Recipe {
                         for (int i = 0; i < arguments.size(); i++) {
                             Expression arg = arguments.get(i);
                             if (arg == typeCast) {
+                                // A `null` literal cast at the last position of a (potential) varargs call
+                                // disambiguates between passing `null` as the array vs. a single null element.
+                                if (J.Literal.isLiteralValue(typeCast.getExpression(), null) &&
+                                        i == methodType.getParameterTypes().size() - 1 &&
+                                        i == arguments.size() - 1 &&
+                                        methodType.getParameterTypes().get(i) instanceof JavaType.Array) {
+                                    return visited;
+                                }
                                 targetType = getParameterType(methodType, i);
                                 break;
                             }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -307,6 +307,29 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doNotRemoveNullCastInVarargsPosition() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.lang.reflect.Method;
+
+              class Test {
+                  void invoke(Method method, Object resolver) throws Exception {
+                      method.invoke(resolver, (String) null);
+                  }
+                  void m(String... s) {
+                  }
+                  void foo() {
+                      m((String) null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1647")
     @Test
     void downCast() {


### PR DESCRIPTION
## Summary

A cast like `(String) null` passed as the last argument to a varargs method (e.g. `Method.invoke(Object, Object...)`) is required to disambiguate between passing `null` as the entire array and passing a single null element. The recipe was stripping it, changing runtime behavior. Skip removal when the cast expression is a `null` literal at the last argument position whose corresponding parameter is an array.

## Test plan

- [x] New `doNotRemoveNullCastInVarargsPosition` test covers `Method.invoke` and a plain `String...` method
- [x] Existing `varargsCall` test (non-null arg in varargs position) still passes