### PR TITLE
Retain explicit type arguments on no-arg static methods in `UnnecessaryExplicitTypeArguments`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -146,6 +146,11 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                 if (!methodType.hasFlags(Flag.Static)) {
                     return false;
                 }
+                // Without arguments, the type parameter cannot be inferred from call-site parameters.
+                // Removing the explicit type arguments can break overload resolution in the enclosing call.
+                if (methodType.getParameterTypes().isEmpty()) {
+                    return true;
+                }
                 List<String> formalTypeNames = new ArrayList<>(methodType.getDeclaredFormalTypeNames());
                 methodType.getParameterTypes().stream()
                         .filter(p -> p instanceof JavaType.Parameterized)

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -262,6 +262,33 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
             );
         }
 
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2370")
+        @Test
+        void retainsExplicitTypeOnStaticMethodWithoutTypeBoundParameters() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import java.util.List;
+
+                  interface RowMapper<T> {}
+
+                  class ArgumentMatchers {
+                      public static <T> T any() { return null; }
+                  }
+
+                  class Test {
+                      <R> List<R> query(String sql, RowMapper<R> rowMapper) { return null; }
+
+                      void test() {
+                          List<String> result = query("sql", ArgumentMatchers.<RowMapper<String>>any());
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
         @Test
         void staticMethodInvocationWithoutTypeArguments() {
             //language=java


### PR DESCRIPTION
## Summary
- When a static method declares a type parameter but takes no arguments (e.g. `ArgumentMatchers.<T>any()`), the type parameter cannot be inferred from call-site arguments, so removing the explicit type arguments can break overload/inference in the enclosing call (as reported in [customer-requests#2370](https://github.com/moderneinc/customer-requests/issues/2370)).
- The existing `shouldRetainOnStaticMethod` guard relied on `JavaType.Method.getDeclaredFormalTypeNames()`, which the parser does not always populate (it returned empty for `any()`), causing the guard to incorrectly allow removal.
- Added an early-return: if the static method has no parameters, retain the explicit type arguments.

## Test plan
- [x] Added `retainsExplicitTypeOnStaticMethodWithoutTypeBoundParameters` reproducing the customer's pattern; fails on `main` and passes with the fix.
- [x] All existing `UnnecessaryExplicitTypeArgumentsTest` tests still pass.