### PR TITLE
Detect overloads on parameterized receiver in `hasMethodOverloading`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/LambdaBlockToExpression.java
@@ -96,9 +96,7 @@ public class LambdaBlockToExpression extends Recipe {
         int numberOfParameters = methodType.getParameterNames().size();
         return Optional.of(methodType)
                 .map(JavaType.Method::getDeclaringType)
-                .filter(JavaType.Class.class::isInstance)
-                .map(JavaType.Class.class::cast)
-                .map(JavaType.Class::getMethods)
+                .map(JavaType.FullyQualified::getMethods)
                 .map(methods -> {
                     int overloadingCount = 0;
                     for (JavaType.Method dm : methods) {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -308,6 +308,28 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
     }
 
     @Test
+    void doNotRemoveNullCastWithAmbiguousOverloads() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              interface Provider<T> {
+              }
+              interface Property<T> extends Provider<T> {
+                  void set(T value);
+                  void set(Provider<? extends T> provider);
+              }
+              class Test {
+                  void foo(Property<Integer> property) {
+                      property.set((Integer) null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotRemoveNullCastInVarargsPosition() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary
- `RemoveRedundantTypeCast` was stripping `(Integer) null` from `property.set((Integer) null)` on a Gradle `Property<Integer>`, breaking compilation because `Property<T>` declares both `set(T)` and `set(Provider<? extends T>)` — `set(null)` is ambiguous.
- The `hasMethodOverloading` guard missed this: when the receiver is parameterized, `getDeclaringType()` returns a `JavaType.Parameterized`, which the `JavaType.Class` filter dropped. Widening to `JavaType.FullyQualified` lets methods on parameterized receivers be inspected.

## Test plan
- [x] New regression test `RemoveRedundantTypeCastTest.doNotRemoveNullCastWithAmbiguousOverloads` covering the `Property<T>.set` shape.
- [x] `./gradlew test --tests RemoveRedundantTypeCastTest --tests LambdaBlockToExpressionTest` passes.