### PR TITLE
Preserve cast on generic method invocation in overloaded outer call

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -81,6 +81,27 @@ public class RemoveRedundantTypeCast extends Recipe {
                 JavaType expressionType = visitedTypeCast.getExpression().getType();
                 JavaType castType = visitedTypeCast.getType();
 
+                // A cast on a generic method invocation pins the inferred return type so
+                // an overloaded outer call (e.g. `StringBuilder.append`) resolves unambiguously.
+                if (parentValue instanceof MethodCall && typeCast.getExpression() instanceof J.MethodInvocation) {
+                    JavaType.Method invokedMethod = ((J.MethodInvocation) typeCast.getExpression()).getMethodType();
+                    if (invokedMethod != null && invokedMethod.getDeclaringType() != null) {
+                        for (JavaType.Method declared : invokedMethod.getDeclaringType().getMethods()) {
+                            if (declared.getName().equals(invokedMethod.getName()) &&
+                                    declared.getParameterTypes().size() == invokedMethod.getParameterTypes().size() &&
+                                    declared.getReturnType() instanceof JavaType.GenericTypeVariable &&
+                                    declared.getDeclaredFormalTypeNames().contains(
+                                            ((JavaType.GenericTypeVariable) declared.getReturnType()).getName())) {
+                                JavaType.Method parentMethodType = ((MethodCall) parentValue).getMethodType();
+                                if (parentMethodType == null || hasMethodOverloading(parentMethodType)) {
+                                    return visited;
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+
                 JavaType targetType = null;
                 if (castType.equals(expressionType)) {
                     targetType = castType;

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -83,22 +83,11 @@ public class RemoveRedundantTypeCast extends Recipe {
 
                 // A cast on a generic method invocation pins the inferred return type so
                 // an overloaded outer call (e.g. `StringBuilder.append`) resolves unambiguously.
-                if (parentValue instanceof MethodCall && typeCast.getExpression() instanceof J.MethodInvocation) {
-                    JavaType.Method invokedMethod = ((J.MethodInvocation) typeCast.getExpression()).getMethodType();
-                    if (invokedMethod != null && invokedMethod.getDeclaringType() != null) {
-                        for (JavaType.Method declared : invokedMethod.getDeclaringType().getMethods()) {
-                            if (declared.getName().equals(invokedMethod.getName()) &&
-                                    declared.getParameterTypes().size() == invokedMethod.getParameterTypes().size() &&
-                                    declared.getReturnType() instanceof JavaType.GenericTypeVariable &&
-                                    declared.getDeclaredFormalTypeNames().contains(
-                                            ((JavaType.GenericTypeVariable) declared.getReturnType()).getName())) {
-                                JavaType.Method parentMethodType = ((MethodCall) parentValue).getMethodType();
-                                if (parentMethodType == null || hasMethodOverloading(parentMethodType)) {
-                                    return visited;
-                                }
-                                break;
-                            }
-                        }
+                if (parentValue instanceof MethodCall) {
+                    JavaType.Method parentMethodType = ((MethodCall) parentValue).getMethodType();
+                    if ((parentMethodType == null || hasMethodOverloading(parentMethodType)) &&
+                            returnsDeclaredTypeParameter(typeCast.getExpression())) {
+                        return visited;
                     }
                 }
 
@@ -173,19 +162,8 @@ public class RemoveRedundantTypeCast extends Recipe {
 
                 // A cast inside a lambda body may pin the inferred return type of a generic method call
                 // so outer inference (e.g. Optional.map -> ifPresent) doesn't lose it to the type bound.
-                if (parentValue instanceof J.Lambda && typeCast.getExpression() instanceof J.MethodInvocation) {
-                    JavaType.Method invokedMethod = ((J.MethodInvocation) typeCast.getExpression()).getMethodType();
-                    if (invokedMethod != null && invokedMethod.getDeclaringType() != null) {
-                        for (JavaType.Method declared : invokedMethod.getDeclaringType().getMethods()) {
-                            if (declared.getName().equals(invokedMethod.getName()) &&
-                                    declared.getParameterTypes().size() == invokedMethod.getParameterTypes().size() &&
-                                    declared.getReturnType() instanceof JavaType.GenericTypeVariable &&
-                                    declared.getDeclaredFormalTypeNames().contains(
-                                            ((JavaType.GenericTypeVariable) declared.getReturnType()).getName())) {
-                                return visitedTypeCast;
-                            }
-                        }
-                    }
+                if (parentValue instanceof J.Lambda && returnsDeclaredTypeParameter(typeCast.getExpression())) {
+                    return visitedTypeCast;
                 }
 
                 if (!(targetType instanceof JavaType.Array) && TypeUtils.isOfClassType(targetType, "java.lang.Object") ||
@@ -211,6 +189,26 @@ public class RemoveRedundantTypeCast extends Recipe {
                     return parentheses.getTree().withPrefix(parentheses.getPrefix());
                 }
                 return parentheses;
+            }
+
+            private boolean returnsDeclaredTypeParameter(Expression expression) {
+                if (!(expression instanceof J.MethodInvocation)) {
+                    return false;
+                }
+                JavaType.Method invokedMethod = ((J.MethodInvocation) expression).getMethodType();
+                if (invokedMethod == null || invokedMethod.getDeclaringType() == null) {
+                    return false;
+                }
+                for (JavaType.Method declared : invokedMethod.getDeclaringType().getMethods()) {
+                    if (declared.getName().equals(invokedMethod.getName()) &&
+                            declared.getParameterTypes().size() == invokedMethod.getParameterTypes().size() &&
+                            declared.getReturnType() instanceof JavaType.GenericTypeVariable &&
+                            declared.getDeclaredFormalTypeNames().contains(
+                                    ((JavaType.GenericTypeVariable) declared.getReturnType()).getName())) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             private JavaType getParameterType(JavaType.Method method, int arg) {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -703,4 +703,28 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotRemoveObjectCastOnGenericMethodCallWithOverloads() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Holder {
+                  <T> T getValue() {
+                      return null;
+                  }
+              }
+
+              class Test {
+                  String render(Holder h) {
+                      StringBuilder sb = new StringBuilder();
+                      sb.append((Object) h.getValue());
+                      return sb.toString();
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `RemoveRedundantTypeCast` stripped `(Object)` from `sb.append((Object) cursor.getValue())` where `Cursor.getValue()` is `<T> T getValue()`, breaking compilation because `StringBuilder.append` has many single-arg overloads and the free generic return makes resolution ambiguous.
- The LST resolves the invocation's return to its bound (`Object`), so the existing `castType.equals(expressionType)` shortcut took over and the `hasMethodOverloading` check on the parent call never ran.
- Distinct from #890 (which widens `hasMethodOverloading` for parameterized receivers and `null` operands) — here the receiver is `StringBuilder` (already a `JavaType.Class`) and the operand is a generic method call.

## Test plan
- [x] New regression test `RemoveRedundantTypeCastTest.doNotRemoveObjectCastOnGenericMethodCallWithOverloads` modeled on the failing `rewrite-analysis` shape.
- [x] `./gradlew test --tests RemoveRedundantTypeCastTest --tests LambdaBlockToExpressionTest` passes.