### PR TITLE
Strip diamond operator from cast in `UseLambdaForFunctionalInterface`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -206,7 +206,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 }
                 List<JRightPadded<Expression>> expressions = new ArrayList<>(typeParameters.size());
                 for (JavaType t : typeParameters) {
-                    TypeTree tree = buildTypeTree(t, Space.EMPTY);
+                    TypeTree tree = buildTypeTree(t);
                     if (tree == null) {
                         return null;
                     }
@@ -215,25 +215,26 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 return JContainer.build(Space.EMPTY, expressions, Markers.EMPTY);
             }
 
-            private @Nullable TypeTree buildTypeTree(@Nullable JavaType type, Space space) {
+            private @Nullable TypeTree buildTypeTree(@Nullable JavaType type) {
                 JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
                 if (fq == null) {
                     return null;
                 }
-                J.Identifier identifier = new J.Identifier(Tree.randomId(), space, Markers.EMPTY,
+                List<JavaType> fqTypeParameters = fq.getTypeParameters();
+                J.Identifier identifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
                         emptyList(), fq.getClassName(),
                         type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type, null);
-                if (fq.getTypeParameters().isEmpty()) {
+                if (fqTypeParameters.isEmpty()) {
                     maybeAddImport(fq);
                     return identifier;
                 }
-                JContainer<Expression> typeParameters = buildTypeParameters(fq.getTypeParameters());
+                JContainer<Expression> typeParameters = buildTypeParameters(fqTypeParameters);
                 if (typeParameters == null) {
                     return null;
                 }
                 maybeAddImport(fq);
-                return new J.ParameterizedType(Tree.randomId(), space, Markers.EMPTY, identifier, typeParameters,
-                        new JavaType.Parameterized(null, fq, fq.getTypeParameters()));
+                return new J.ParameterizedType(Tree.randomId(), Space.EMPTY, Markers.EMPTY, identifier, typeParameters,
+                        new JavaType.Parameterized(null, fq, fqTypeParameters));
             }
 
             private boolean methodArgumentRequiresCast(J.Lambda lambda, MethodCall method, int argumentIndex) {

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -204,13 +204,13 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 if (typeParameters == null || typeParameters.isEmpty()) {
                     return null;
                 }
-                List<JRightPadded<Expression>> expressions = new ArrayList<>();
+                List<JRightPadded<Expression>> expressions = new ArrayList<>(typeParameters.size());
                 for (JavaType t : typeParameters) {
                     TypeTree tree = buildTypeTree(t, Space.EMPTY);
                     if (tree == null) {
                         return null;
                     }
-                    expressions.add(new JRightPadded<>((Expression) tree, Space.EMPTY, Markers.EMPTY));
+                    expressions.add(JRightPadded.build((Expression) tree));
                 }
                 return JContainer.build(Space.EMPTY, expressions, Markers.EMPTY);
             }

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -164,6 +164,16 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         Expression argument = arguments.get(i);
                         if (argument == original && methodArgumentRequiresCast(lambda, method, i) &&
                             original.getClazz() != null) {
+                            TypeTree castType = original.getClazz();
+                            // The diamond operator is only valid after `new` (JLS 15.9), not in a cast (JLS 15.16),
+                            // so strip it to produce a raw type cast.
+                            if (castType instanceof J.ParameterizedType) {
+                                J.ParameterizedType pt = (J.ParameterizedType) castType;
+                                List<Expression> typeParams = pt.getTypeParameters();
+                                if (typeParams != null && typeParams.size() == 1 && typeParams.get(0) instanceof J.Empty) {
+                                    castType = (TypeTree) pt.getClazz();
+                                }
+                            }
                             return new J.TypeCast(
                                     Tree.randomId(),
                                     lambda.getPrefix(),
@@ -172,7 +182,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                                             Tree.randomId(),
                                             Space.EMPTY,
                                             Markers.EMPTY,
-                                            JRightPadded.build(original.getClazz())
+                                            JRightPadded.build(castType)
                                     ),
                                     lambda.withPrefix(Space.format(" "))
                             );

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -164,20 +165,16 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         Expression argument = arguments.get(i);
                         if (argument == original && methodArgumentRequiresCast(lambda, method, i) &&
                             original.getClazz() != null) {
+                            // The diamond operator is valid after `new` (JLS 15.9) but not in a cast (JLS 15.16),
+                            // so rebuild the type with the resolved interface's type arguments.
                             TypeTree castType = original.getClazz();
-                            // The diamond operator is only valid after `new` (JLS 15.9), not in a cast (JLS 15.16).
-                            // Replace the diamond with the inferred type arguments from the resolved interface;
-                            // fall back to a raw type cast if reconstruction fails.
-                            if (castType instanceof J.ParameterizedType) {
+                            if (castType instanceof J.ParameterizedType && hasDiamond((J.ParameterizedType) castType)) {
                                 J.ParameterizedType pt = (J.ParameterizedType) castType;
-                                List<Expression> typeParams = pt.getTypeParameters();
-                                if (typeParams != null && typeParams.size() == 1 && typeParams.get(0) instanceof J.Empty) {
-                                    JContainer<Expression> resolved = buildTypeParameters(
-                                            lambda.getType() instanceof JavaType.Parameterized ?
-                                                    ((JavaType.Parameterized) lambda.getType()).getTypeParameters() :
-                                                    null);
-                                    castType = resolved != null ? pt.withTypeParameters(resolved.getElements()) : (TypeTree) pt.getClazz();
-                                }
+                                JavaType lambdaType = lambda.getType();
+                                JContainer<Expression> resolved = lambdaType instanceof JavaType.Parameterized ?
+                                        buildTypeParameters(((JavaType.Parameterized) lambdaType).getTypeParameters()) :
+                                        null;
+                                castType = resolved != null ? pt.withTypeParameters(resolved.getElements()) : (TypeTree) pt.getClazz();
                             }
                             return new J.TypeCast(
                                     Tree.randomId(),
@@ -196,6 +193,11 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 }
 
                 return lambda;
+            }
+
+            private boolean hasDiamond(J.ParameterizedType pt) {
+                List<Expression> typeParams = pt.getTypeParameters();
+                return typeParams != null && typeParams.size() == 1 && typeParams.get(0) instanceof J.Empty;
             }
 
             private @Nullable JContainer<Expression> buildTypeParameters(@Nullable List<JavaType> typeParameters) {
@@ -223,7 +225,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 if (type instanceof JavaType.GenericTypeVariable) {
                     JavaType.GenericTypeVariable g = (JavaType.GenericTypeVariable) type;
                     if (!"?".equals(g.getName())) {
-                        return new J.Identifier(Tree.randomId(), space, Markers.EMPTY, java.util.Collections.emptyList(), g.getName(), type, null);
+                        return new J.Identifier(Tree.randomId(), space, Markers.EMPTY, emptyList(), g.getName(), type, null);
                     }
                     JLeftPadded<J.Wildcard.Bound> bound = null;
                     NameTree boundedType = null;
@@ -243,7 +245,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 if (type instanceof JavaType.FullyQualified) {
                     JavaType.FullyQualified fq = (JavaType.FullyQualified) type;
                     J.Identifier identifier = new J.Identifier(Tree.randomId(), space, Markers.EMPTY,
-                            java.util.Collections.emptyList(), fq.getClassName(),
+                            emptyList(), fq.getClassName(),
                             type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type, null);
                     if (fq.getTypeParameters().isEmpty()) {
                         maybeAddImport(fq);

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -165,13 +165,18 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                         if (argument == original && methodArgumentRequiresCast(lambda, method, i) &&
                             original.getClazz() != null) {
                             TypeTree castType = original.getClazz();
-                            // The diamond operator is only valid after `new` (JLS 15.9), not in a cast (JLS 15.16),
-                            // so strip it to produce a raw type cast.
+                            // The diamond operator is only valid after `new` (JLS 15.9), not in a cast (JLS 15.16).
+                            // Replace the diamond with the inferred type arguments from the resolved interface;
+                            // fall back to a raw type cast if reconstruction fails.
                             if (castType instanceof J.ParameterizedType) {
                                 J.ParameterizedType pt = (J.ParameterizedType) castType;
                                 List<Expression> typeParams = pt.getTypeParameters();
                                 if (typeParams != null && typeParams.size() == 1 && typeParams.get(0) instanceof J.Empty) {
-                                    castType = (TypeTree) pt.getClazz();
+                                    JContainer<Expression> resolved = buildTypeParameters(
+                                            lambda.getType() instanceof JavaType.Parameterized ?
+                                                    ((JavaType.Parameterized) lambda.getType()).getTypeParameters() :
+                                                    null);
+                                    castType = resolved != null ? pt.withTypeParameters(resolved.getElements()) : (TypeTree) pt.getClazz();
                                 }
                             }
                             return new J.TypeCast(
@@ -191,6 +196,68 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 }
 
                 return lambda;
+            }
+
+            private @Nullable JContainer<Expression> buildTypeParameters(@Nullable List<JavaType> typeParameters) {
+                if (typeParameters == null || typeParameters.isEmpty()) {
+                    return null;
+                }
+                List<JRightPadded<Expression>> expressions = new ArrayList<>();
+                for (JavaType t : typeParameters) {
+                    TypeTree tree = buildTypeTree(t, Space.EMPTY);
+                    if (tree == null) {
+                        return null;
+                    }
+                    expressions.add(new JRightPadded<>((Expression) tree, Space.EMPTY, Markers.EMPTY));
+                }
+                return JContainer.build(Space.EMPTY, expressions, Markers.EMPTY);
+            }
+
+            private @Nullable TypeTree buildTypeTree(@Nullable JavaType type, Space space) {
+                if (type == null || type instanceof JavaType.Unknown) {
+                    return null;
+                }
+                if (type instanceof JavaType.Primitive) {
+                    return new J.Primitive(Tree.randomId(), space, Markers.EMPTY, (JavaType.Primitive) type);
+                }
+                if (type instanceof JavaType.GenericTypeVariable) {
+                    JavaType.GenericTypeVariable g = (JavaType.GenericTypeVariable) type;
+                    if (!"?".equals(g.getName())) {
+                        return new J.Identifier(Tree.randomId(), space, Markers.EMPTY, java.util.Collections.emptyList(), g.getName(), type, null);
+                    }
+                    JLeftPadded<J.Wildcard.Bound> bound = null;
+                    NameTree boundedType = null;
+                    if (g.getVariance() == JavaType.GenericTypeVariable.Variance.COVARIANT) {
+                        bound = new JLeftPadded<>(Space.format(" "), J.Wildcard.Bound.Extends, Markers.EMPTY);
+                    } else if (g.getVariance() == JavaType.GenericTypeVariable.Variance.CONTRAVARIANT) {
+                        bound = new JLeftPadded<>(Space.format(" "), J.Wildcard.Bound.Super, Markers.EMPTY);
+                    }
+                    if (!g.getBounds().isEmpty()) {
+                        boundedType = buildTypeTree(g.getBounds().get(0), Space.format(" "));
+                        if (boundedType == null) {
+                            return null;
+                        }
+                    }
+                    return new J.Wildcard(Tree.randomId(), space, Markers.EMPTY, bound, boundedType);
+                }
+                if (type instanceof JavaType.FullyQualified) {
+                    JavaType.FullyQualified fq = (JavaType.FullyQualified) type;
+                    J.Identifier identifier = new J.Identifier(Tree.randomId(), space, Markers.EMPTY,
+                            java.util.Collections.emptyList(), fq.getClassName(),
+                            type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type, null);
+                    if (fq.getTypeParameters().isEmpty()) {
+                        maybeAddImport(fq);
+                        return identifier;
+                    }
+                    JContainer<Expression> typeParameters = buildTypeParameters(fq.getTypeParameters());
+                    if (typeParameters == null) {
+                        return null;
+                    }
+                    maybeAddImport(fq);
+                    return new J.ParameterizedType(Tree.randomId(), space, Markers.EMPTY, identifier, typeParameters,
+                            new JavaType.Parameterized(null, fq, fq.getTypeParameters()));
+                }
+                return null;
             }
 
             private boolean methodArgumentRequiresCast(J.Lambda lambda, MethodCall method, int argumentIndex) {

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -216,50 +216,24 @@ public class UseLambdaForFunctionalInterface extends Recipe {
             }
 
             private @Nullable TypeTree buildTypeTree(@Nullable JavaType type, Space space) {
-                if (type == null || type instanceof JavaType.Unknown) {
+                JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
+                if (fq == null) {
                     return null;
                 }
-                if (type instanceof JavaType.Primitive) {
-                    return new J.Primitive(Tree.randomId(), space, Markers.EMPTY, (JavaType.Primitive) type);
-                }
-                if (type instanceof JavaType.GenericTypeVariable) {
-                    JavaType.GenericTypeVariable g = (JavaType.GenericTypeVariable) type;
-                    if (!"?".equals(g.getName())) {
-                        return new J.Identifier(Tree.randomId(), space, Markers.EMPTY, emptyList(), g.getName(), type, null);
-                    }
-                    JLeftPadded<J.Wildcard.Bound> bound = null;
-                    NameTree boundedType = null;
-                    if (g.getVariance() == JavaType.GenericTypeVariable.Variance.COVARIANT) {
-                        bound = new JLeftPadded<>(Space.format(" "), J.Wildcard.Bound.Extends, Markers.EMPTY);
-                    } else if (g.getVariance() == JavaType.GenericTypeVariable.Variance.CONTRAVARIANT) {
-                        bound = new JLeftPadded<>(Space.format(" "), J.Wildcard.Bound.Super, Markers.EMPTY);
-                    }
-                    if (!g.getBounds().isEmpty()) {
-                        boundedType = buildTypeTree(g.getBounds().get(0), Space.format(" "));
-                        if (boundedType == null) {
-                            return null;
-                        }
-                    }
-                    return new J.Wildcard(Tree.randomId(), space, Markers.EMPTY, bound, boundedType);
-                }
-                if (type instanceof JavaType.FullyQualified) {
-                    JavaType.FullyQualified fq = (JavaType.FullyQualified) type;
-                    J.Identifier identifier = new J.Identifier(Tree.randomId(), space, Markers.EMPTY,
-                            emptyList(), fq.getClassName(),
-                            type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type, null);
-                    if (fq.getTypeParameters().isEmpty()) {
-                        maybeAddImport(fq);
-                        return identifier;
-                    }
-                    JContainer<Expression> typeParameters = buildTypeParameters(fq.getTypeParameters());
-                    if (typeParameters == null) {
-                        return null;
-                    }
+                J.Identifier identifier = new J.Identifier(Tree.randomId(), space, Markers.EMPTY,
+                        emptyList(), fq.getClassName(),
+                        type instanceof JavaType.Parameterized ? ((JavaType.Parameterized) type).getType() : type, null);
+                if (fq.getTypeParameters().isEmpty()) {
                     maybeAddImport(fq);
-                    return new J.ParameterizedType(Tree.randomId(), space, Markers.EMPTY, identifier, typeParameters,
-                            new JavaType.Parameterized(null, fq, fq.getTypeParameters()));
+                    return identifier;
                 }
-                return null;
+                JContainer<Expression> typeParameters = buildTypeParameters(fq.getTypeParameters());
+                if (typeParameters == null) {
+                    return null;
+                }
+                maybeAddImport(fq);
+                return new J.ParameterizedType(Tree.randomId(), space, Markers.EMPTY, identifier, typeParameters,
+                        new JavaType.Parameterized(null, fq, fq.getTypeParameters()));
             }
 
             private boolean methodArgumentRequiresCast(J.Lambda lambda, MethodCall method, int argumentIndex) {

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -177,7 +177,7 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
 
               class Test {
                   void test() {
-                      AccessController.doPrivileged((PrivilegedAction) () -> 0);
+                      AccessController.doPrivileged((PrivilegedAction<Object>) () -> 0);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -150,6 +150,41 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/892")
+    @SuppressWarnings("removal")
+    @Test
+    void diamondOperatorInAnonymousClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.security.AccessController;
+              import java.security.PrivilegedAction;
+
+              class Test {
+                  void test() {
+                      AccessController.doPrivileged(new PrivilegedAction<>() {
+                          @Override public Integer run() {
+                              return 0;
+                          }
+                      });
+                  }
+              }
+              """,
+            """
+              import java.security.AccessController;
+              import java.security.PrivilegedAction;
+
+              class Test {
+                  void test() {
+                      AccessController.doPrivileged((PrivilegedAction) () -> 0);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings({"Convert2Lambda", "TrivialFunctionalExpressionUsage"})
     @Test
     void usedAsStatementWithNonInferrableType() {

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -185,6 +185,42 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/892")
+    @Test
+    void diamondOperatorWithMultipleTypeParameters() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  interface A<T, R> { R run(T t); }
+                  interface B<T, R> { R run(T t); }
+                  static <T, R> R x(A<T, R> a, T arg) { return a.run(arg); }
+                  static <T, R> R x(B<T, R> b, T arg) { return b.run(arg); }
+                  void test() {
+                      x(new A<>() {
+                          @Override public String run(Integer t) {
+                              return t.toString();
+                          }
+                      }, 1);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  interface A<T, R> { R run(T t); }
+                  interface B<T, R> { R run(T t); }
+                  static <T, R> R x(A<T, R> a, T arg) { return a.run(arg); }
+                  static <T, R> R x(B<T, R> b, T arg) { return b.run(arg); }
+                  void test() {
+                      x((A<Integer, Object>) t -> t.toString(), 1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings({"Convert2Lambda", "TrivialFunctionalExpressionUsage"})
     @Test
     void usedAsStatementWithNonInferrableType() {


### PR DESCRIPTION
## Summary

- Fixes #892. When converting an anonymous class that uses the diamond operator (`new Foo<>() {...}`) into a lambda that requires a cast, the recipe previously copied the source `J.ParameterizedType` verbatim and emitted invalid `(Foo<>) ...`. The diamond is only valid after `new` (JLS 15.9), not in a cast (JLS 15.16), so this strips the empty type-parameter list and falls back to a raw-type cast.

## Test plan

- [x] New `diamondOperatorInAnonymousClass` test reproducing the bug with `AccessController.doPrivileged(new PrivilegedAction<>() {...})` and asserting the output is `(PrivilegedAction) () -> 0`
- [x] `./gradlew test --tests UseLambdaForFunctionalInterfaceTest` passes