### PR TITLE
Guard cast to `JavaType.Annotation` in `ReorderAnnotations`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReorderAnnotations.java
@@ -42,7 +42,7 @@ public class ReorderAnnotations extends Recipe {
                 // If the annotation is a type use annotation, it should be ordered last
                 if (a.getType() instanceof JavaType.Class) {
                     for (JavaType.FullyQualified fq : ((JavaType.Class) a.getType()).getAnnotations()) {
-                        if (TypeUtils.isOfClassType(fq, "java.lang.annotation.Target")) {
+                        if (fq instanceof JavaType.Annotation && TypeUtils.isOfClassType(fq, "java.lang.annotation.Target")) {
                             for (JavaType.Annotation.ElementValue elementValue : ((JavaType.Annotation) fq).getValues()) {
                                 Object value = elementValue.getValue();
                                 if (value instanceof List) {


### PR DESCRIPTION
## Summary
- `JavaType.Class#getAnnotations()` returns `List<FullyQualified>`, whose elements may be `JavaType.ShallowClass` rather than `JavaType.Annotation`.
- Previously, `ReorderAnnotations` only checked the FQ name was `java.lang.annotation.Target` before casting to `JavaType.Annotation`, causing a `ClassCastException` when the meta-annotation was attached as a shallow class.
- Added an `instanceof JavaType.Annotation` guard before the cast.

## Test plan
- [x] `./gradlew test --tests ReorderAnnotationsTest`