### PR TITLE
Replace `var` with interface type in `UseLambdaForFunctionalInterface`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -67,32 +67,22 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 // needs an explicit target type (JLS 14.4.1, 15.27.1). If we are about to convert the
                 // initializer to a lambda, replace `var` with the anonymous class's interface type.
                 TypeTree replacementType = null;
-                if (isVarType(multiVariable)) {
-                    Expression initializer = multiVariable.getVariables().get(0).getInitializer();
-                    if (initializer instanceof J.NewClass && ((J.NewClass) initializer).getClazz() != null) {
-                        replacementType = ((J.NewClass) initializer).getClazz();
+                TypeTree typeExpression = multiVariable.getTypeExpression();
+                if (typeExpression != null && typeExpression.getMarkers().findFirst(JavaVarKeyword.class).isPresent() &&
+                    multiVariable.getVariables().size() == 1 &&
+                    multiVariable.getVariables().get(0).getInitializer() instanceof J.NewClass) {
+                    J.NewClass nc = (J.NewClass) multiVariable.getVariables().get(0).getInitializer();
+                    if (nc.getClazz() != null) {
+                        replacementType = nc.getClazz();
                     }
                 }
                 J.VariableDeclarations result = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
-                if (replacementType != null && result.getVariables().get(0).getInitializer() instanceof J.Lambda) {
-                    J.Lambda lambda = (J.Lambda) result.getVariables().get(0).getInitializer();
-                    if (replacementType instanceof J.ParameterizedType && hasDiamond((J.ParameterizedType) replacementType)) {
-                        J.ParameterizedType pt = (J.ParameterizedType) replacementType;
-                        JavaType lambdaType = lambda.getType();
-                        JContainer<Expression> resolved = lambdaType instanceof JavaType.Parameterized ?
-                                buildTypeParameters(((JavaType.Parameterized) lambdaType).getTypeParameters()) :
-                                null;
-                        replacementType = resolved != null ? pt.withTypeParameters(resolved.getElements()) : (TypeTree) pt.getClazz();
-                    }
-                    result = result.withTypeExpression(replacementType.withPrefix(multiVariable.getTypeExpression().getPrefix()));
+                Expression newInitializer = result.getVariables().get(0).getInitializer();
+                if (replacementType != null && newInitializer instanceof J.Lambda) {
+                    replacementType = resolveDiamond(replacementType, (J.Lambda) newInitializer);
+                    result = result.withTypeExpression(replacementType.withPrefix(typeExpression.getPrefix()));
                 }
                 return result;
-            }
-
-            private boolean isVarType(J.VariableDeclarations multiVariable) {
-                return multiVariable.getTypeExpression() instanceof J.Identifier &&
-                        "var".equals(((J.Identifier) multiVariable.getTypeExpression()).getSimpleName()) &&
-                        multiVariable.getVariables().size() == 1;
             }
 
             @Override
@@ -201,15 +191,7 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                             original.getClazz() != null) {
                             // The diamond operator is valid after `new` (JLS 15.9) but not in a cast (JLS 15.16),
                             // so rebuild the type with the resolved interface's type arguments.
-                            TypeTree castType = original.getClazz();
-                            if (castType instanceof J.ParameterizedType && hasDiamond((J.ParameterizedType) castType)) {
-                                J.ParameterizedType pt = (J.ParameterizedType) castType;
-                                JavaType lambdaType = lambda.getType();
-                                JContainer<Expression> resolved = lambdaType instanceof JavaType.Parameterized ?
-                                        buildTypeParameters(((JavaType.Parameterized) lambdaType).getTypeParameters()) :
-                                        null;
-                                castType = resolved != null ? pt.withTypeParameters(resolved.getElements()) : (TypeTree) pt.getClazz();
-                            }
+                            TypeTree castType = resolveDiamond(original.getClazz(), lambda);
                             return new J.TypeCast(
                                     Tree.randomId(),
                                     lambda.getPrefix(),
@@ -227,6 +209,18 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 }
 
                 return lambda;
+            }
+
+            private TypeTree resolveDiamond(TypeTree type, J.Lambda lambda) {
+                if (!(type instanceof J.ParameterizedType) || !hasDiamond((J.ParameterizedType) type)) {
+                    return type;
+                }
+                J.ParameterizedType pt = (J.ParameterizedType) type;
+                JavaType lambdaType = lambda.getType();
+                JContainer<Expression> resolved = lambdaType instanceof JavaType.Parameterized ?
+                        buildTypeParameters(((JavaType.Parameterized) lambdaType).getTypeParameters()) :
+                        null;
+                return resolved != null ? pt.withTypeParameters(resolved.getElements()) : (TypeTree) pt.getClazz();
             }
 
             private boolean hasDiamond(J.ParameterizedType pt) {

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -62,6 +62,40 @@ public class UseLambdaForFunctionalInterface extends Recipe {
             }
 
             @Override
+            public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                // `var` borrows its type from the right-hand side, but a lambda is a poly expression that
+                // needs an explicit target type (JLS 14.4.1, 15.27.1). If we are about to convert the
+                // initializer to a lambda, replace `var` with the anonymous class's interface type.
+                TypeTree replacementType = null;
+                if (isVarType(multiVariable)) {
+                    Expression initializer = multiVariable.getVariables().get(0).getInitializer();
+                    if (initializer instanceof J.NewClass && ((J.NewClass) initializer).getClazz() != null) {
+                        replacementType = ((J.NewClass) initializer).getClazz();
+                    }
+                }
+                J.VariableDeclarations result = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
+                if (replacementType != null && result.getVariables().get(0).getInitializer() instanceof J.Lambda) {
+                    J.Lambda lambda = (J.Lambda) result.getVariables().get(0).getInitializer();
+                    if (replacementType instanceof J.ParameterizedType && hasDiamond((J.ParameterizedType) replacementType)) {
+                        J.ParameterizedType pt = (J.ParameterizedType) replacementType;
+                        JavaType lambdaType = lambda.getType();
+                        JContainer<Expression> resolved = lambdaType instanceof JavaType.Parameterized ?
+                                buildTypeParameters(((JavaType.Parameterized) lambdaType).getTypeParameters()) :
+                                null;
+                        replacementType = resolved != null ? pt.withTypeParameters(resolved.getElements()) : (TypeTree) pt.getClazz();
+                    }
+                    result = result.withTypeExpression(replacementType.withPrefix(multiVariable.getTypeExpression().getPrefix()));
+                }
+                return result;
+            }
+
+            private boolean isVarType(J.VariableDeclarations multiVariable) {
+                return multiVariable.getTypeExpression() instanceof J.Identifier &&
+                        "var".equals(((J.Identifier) multiVariable.getTypeExpression()).getSimpleName()) &&
+                        multiVariable.getVariables().size() == 1;
+            }
+
+            @Override
             public J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
                 // Check if this anonymous class should be converted to a lambda.
                 // We must determine this BEFORE calling super.visitNewClass() to avoid

--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -79,8 +79,8 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 J.VariableDeclarations result = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
                 Expression newInitializer = result.getVariables().get(0).getInitializer();
                 if (replacementType != null && newInitializer instanceof J.Lambda) {
-                    replacementType = resolveDiamond(replacementType, (J.Lambda) newInitializer);
-                    result = result.withTypeExpression(replacementType.withPrefix(typeExpression.getPrefix()));
+                    TypeTree resolved = resolveDiamond(replacementType, (J.Lambda) newInitializer);
+                    return result.withTypeExpression(resolved.withPrefix(typeExpression.getPrefix()));
                 }
                 return result;
             }

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -221,6 +221,80 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/895")
+    @Test
+    void varLocalVariableReplacedWithInterfaceType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  interface Action {
+                      String run(String input);
+                  }
+
+                  void execute() {
+                      final var action = new Action() {
+                          @Override
+                          public String run(String input) {
+                              return input.toUpperCase();
+                          }
+                      };
+                      action.run("hello");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  interface Action {
+                      String run(String input);
+                  }
+
+                  void execute() {
+                      final Action action = input -> input.toUpperCase();
+                      action.run("hello");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/895")
+    @Test
+    void varLocalVariableWithDiamondReplacedWithResolvedType() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class Test {
+                  void execute() {
+                      var f = new Function<String, Integer>() {
+                          @Override
+                          public Integer apply(String s) {
+                              return s.length();
+                          }
+                      };
+                      f.apply("hello");
+                  }
+              }
+              """,
+            """
+              import java.util.function.Function;
+
+              class Test {
+                  void execute() {
+                      Function<String, Integer> f = s -> s.length();
+                      f.apply("hello");
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings({"Convert2Lambda", "TrivialFunctionalExpressionUsage"})
     @Test
     void usedAsStatementWithNonInferrableType() {


### PR DESCRIPTION
## Summary

A lambda is a poly expression that needs an explicit target type from the declaration (JLS 14.4.1, 15.27.1), but `var` borrows its type from the right-hand side. Converting `var x = new Foo() {...}` to a lambda while keeping `var` produced code that no longer compiles:

```
error: cannot infer type for local variable action
```

This change replaces `var` with the anonymous class's interface type whenever the initializer is converted to a lambda. Diamonds on the right-hand side (`new Foo<>() {...}`) are expanded from the resolved lambda type so the emitted declaration compiles without unchecked warnings.

- Fixes #895.

## Test plan

- [x] `./gradlew test --tests "UseLambdaForFunctionalInterfaceTest"` — full class passes
- [x] New `varLocalVariableReplacedWithInterfaceType` covers the issue's exact reproducer
- [x] New `varLocalVariableWithDiamondReplacedWithResolvedType` covers a parameterized interface on the RHS