### PR TITLE
Guard `instanceof` to `Class::isInstance` conversion on lambda arity

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -122,8 +122,8 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
             if (body instanceof J.TypeCast && l.getParameters().getParameters().size() == 1) {
                 J.TypeCast cast = (J.TypeCast) body;
                 J param = l.getParameters().getParameters().get(0);
-                if (cast.getExpression() instanceof J.Identifier && param instanceof J.VariableDeclarations &&
-                        ((J.Identifier) cast.getExpression()).getSimpleName().equals(((J.VariableDeclarations) param).getVariables().get(0).getSimpleName())) {
+                if (param instanceof J.VariableDeclarations &&
+                        SemanticallyEqual.areEqual(cast.getExpression(), ((J.VariableDeclarations) param).getVariables().get(0).getName())) {
                     J.ControlParentheses<TypeTree> j = cast.getClazz();
                     J tree = j.getTree();
                     if ((tree instanceof J.Identifier || tree instanceof J.FieldAccess) &&
@@ -157,8 +157,7 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                         return l;
                     }
                     Expression nonNullSide = isNullCheck(binary.getLeft(), binary.getRight()) ? binary.getLeft() : binary.getRight();
-                    if (!(nonNullSide instanceof J.Identifier) ||
-                            ((J.Identifier) nonNullSide).getFieldType() != lambdaParameters.get(0).getVariableType()) {
+                    if (!SemanticallyEqual.areEqual(nonNullSide, lambdaParameters.get(0).getName())) {
                         return l;
                     }
                     code = J.Binary.Type.Equal == binary.getOperator() ? "java.util.Objects::isNull" :

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -20,6 +20,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinVisitor;
@@ -100,8 +101,7 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                 }
                 J j = instanceOf.getClazz();
                 if ((j instanceof J.Identifier || j instanceof J.FieldAccess) &&
-                        instanceOf.getExpression() instanceof J.Identifier &&
-                        ((J.Identifier) instanceOf.getExpression()).getFieldType() == lambdaParameters.get(0).getVariableType()) {
+                        SemanticallyEqual.areEqual(instanceOf.getExpression(), lambdaParameters.get(0).getName())) {
                     // Create the class literal directly from the original expression
                     JavaType originalType = ((TypeTree) j).getType();
                     JavaType.Class classType = getClassType(originalType);

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -94,9 +94,14 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
 
             if (body instanceof J.InstanceOf) {
                 J.InstanceOf instanceOf = (J.InstanceOf) body;
+                List<J.VariableDeclarations.NamedVariable> lambdaParameters = getLambdaParameters(lambda);
+                if (lambdaParameters.size() != 1) {
+                    return l;
+                }
                 J j = instanceOf.getClazz();
                 if ((j instanceof J.Identifier || j instanceof J.FieldAccess) &&
-                        instanceOf.getExpression() instanceof J.Identifier) {
+                        instanceOf.getExpression() instanceof J.Identifier &&
+                        ((J.Identifier) instanceOf.getExpression()).getFieldType() == lambdaParameters.get(0).getVariableType()) {
                     // Create the class literal directly from the original expression
                     JavaType originalType = ((TypeTree) j).getType();
                     JavaType.Class classType = getClassType(originalType);

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -397,6 +397,41 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/900")
+    @Test
+    void doNotChangeBiPredicateInstanceOf() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.BiPredicate;
+
+              class Test {
+                  BiPredicate<String, Throwable> pred = (r, t) -> t instanceof IllegalArgumentException;
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/900")
+    @Test
+    void doNotChangeInstanceOfOnCapturedVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Predicate;
+
+              class Test {
+                  Object field;
+                  Predicate<String> pred = s -> field instanceof String;
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void nonStaticMethods() {
         rewriteRun(


### PR DESCRIPTION
## Summary
- Adds a one-parameter arity guard and parameter-identity check to the `instanceof` branch of `ReplaceLambdaWithMethodReference`, mirroring the existing guards in the sibling `J.TypeCast` and null-check branches.
- Previously, `BiPredicate<String, Throwable> p = (r, t) -> t instanceof IllegalArgumentException;` was rewritten to `IllegalArgumentException.class::isInstance` — a unary `Predicate`, not assignable to the binary `BiPredicate` target type, so downstream compilation failed.
- Also closes the analogous latent bug where a single-parameter lambda referencing a *captured* variable (`s -> field instanceof Foo`) would be converted into a method reference that no longer references the captured state.

- Fixes #900

## Test plan
- [x] `./gradlew test --tests "ReplaceLambdaWithMethodReferenceTest"` passes locally
- [x] New `doNotChangeBiPredicateInstanceOf` test verifies the reported case is left unchanged
- [x] New `doNotChangeInstanceOfOnCapturedVariable` test verifies captured-variable case is left unchanged
- [x] Existing `instanceOf`, `qualifiedInstanceOf`, `instanceOfLeftHandIsNotLambdaParameter`, `insideIfConditionAfterInstanceOfPatternVariable`, `localRecordWithInstanceOfCheck` tests still pass