### PR TITLE
Preserve cast on argument to overloaded method in `RemoveRedundantTypeCast`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -91,6 +91,17 @@ public class RemoveRedundantTypeCast extends Recipe {
                     }
                 }
 
+                // When the cast is an argument to an overloaded method, removing it can
+                // make resolution ambiguous (e.g. `log(String, Object...)` vs
+                // `log(String, Throwable)` selected by `(Object) value`). Bail out before
+                // any other branch decides the cast is redundant.
+                if (parentValue instanceof MethodCall) {
+                    JavaType.Method methodType = ((MethodCall) parentValue).getMethodType();
+                    if (methodType == null || hasMethodOverloading(methodType)) {
+                        return visited;
+                    }
+                }
+
                 JavaType targetType = null;
                 if (castType.equals(expressionType)) {
                     targetType = castType;
@@ -99,9 +110,6 @@ public class RemoveRedundantTypeCast extends Recipe {
                 } else if (parentValue instanceof MethodCall) {
                     MethodCall methodCall = (MethodCall) parentValue;
                     JavaType.Method methodType = methodCall.getMethodType();
-                    if (methodType == null || hasMethodOverloading(methodType)) {
-                        return visited;
-                    }
                     if (!methodType.getParameterTypes().isEmpty()) {
                         List<Expression> arguments = methodCall.getArguments();
                         for (int i = 0; i < arguments.size(); i++) {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -280,6 +280,26 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/899")
+    @Test
+    void keepObjectCastDisambiguatingVarargsFromThrowableOverload() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void log(String format, Object... args) {}
+                  void log(String format, Throwable t) {}
+
+                  void run(Object value) {
+                      log("value: {}", (Object) value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void varargsCall() {
         rewriteRun(


### PR DESCRIPTION
## Summary

- Fixes #899. `RemoveRedundantTypeCast` was stripping `(Object) value` in calls like `log("msg: {}", (Object) value)`, leaving SLF4J-shaped overloads (`log(String, Object...)` vs `log(String, Throwable)`) ambiguous and uncompilable.

The recipe already had a `hasMethodOverloading` guard, but it only ran inside the `else if` branch reached when `castType != expressionType`. When the expression was already an `Object` cast to `Object`, the earlier `castType.equals(expressionType)` short-circuit set `targetType = castType` and the guard never fired. The fix hoists the overload check above that branch so it runs for any cast that is a direct argument to a `MethodCall`.

## Test plan

- [x] `./gradlew test --tests RemoveRedundantTypeCastTest` passes, including the new `keepObjectCastDisambiguatingVarargsFromThrowableOverload` regression mirroring the issue's reproducer.