### PR TITLE
Preserve raw cast on parameterized expression in `RemoveRedundantTypeCast`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -102,6 +102,16 @@ public class RemoveRedundantTypeCast extends Recipe {
                     }
                 }
 
+                // A raw cast on a parameterized expression (e.g. `(B) b` where `b` is `B<T>`)
+                // is an intentional unchecked conversion; removing it changes overload and
+                // type-inference behavior on parameterized receivers.
+                JavaType.Parameterized exprParameterized = TypeUtils.asParameterized(expressionType);
+                if (parentValue instanceof MethodCall && exprParameterized != null &&
+                        TypeUtils.asParameterized(castType) == null &&
+                        TypeUtils.isOfClassType(castType, exprParameterized.getType().getFullyQualifiedName())) {
+                    return visited;
+                }
+
                 JavaType targetType = null;
                 if (castType.equals(expressionType)) {
                     targetType = castType;

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -746,6 +746,29 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/901")
+    @Test
+    void doNotRemoveRawCastBridgingWildcardCapture() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              interface I<T> {
+                  void method(B<T> param);
+              }
+
+              class B<T> {}
+
+              class A<T> {
+                  void test(I<? extends T> i, B<T> b) {
+                      i.method((B) b);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void doNotRemoveObjectCastOnGenericMethodCallWithOverloads() {
         rewriteRun(


### PR DESCRIPTION
## Summary
- Preserve a raw cast like `(B) b` when `b` is `B<T>` and the cast is a method-call argument
- Removing such a cast changes overload and type-inference behavior when the receiver is itself parameterized (e.g. `I<? extends T>`), breaking compilation

- Fixes #901

## Test plan
- [x] New test `doNotRemoveRawCastBridgingWildcardCapture` reproducing the issue
- [x] Existing `RemoveRedundantTypeCastTest` suite still passes
- [x] Full `./gradlew test` passes