### PR TITLE
Skip Python sources in `CombineSemanticallyEqualCatchBlocks`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     provided("org.openrewrite:rewrite-javascript:${rewriteVersion}")
     provided("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
     provided("org.openrewrite:rewrite-csharp:${rewriteVersion}")
+    provided("org.openrewrite:rewrite-python:${rewriteVersion}")
 
     annotationProcessor("org.openrewrite:rewrite-templating:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-templating:${rewriteVersion}")

--- a/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
+++ b/src/main/java/org/openrewrite/staticanalysis/CombineSemanticallyEqualCatchBlocks.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.staticanalysis.python.PythonFileChecker;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,7 +51,7 @@ public class CombineSemanticallyEqualCatchBlocks extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new CombineSemanticallyEqualCatchBlocksVisitor();
+        return Preconditions.check(Preconditions.not(new PythonFileChecker<>()), new CombineSemanticallyEqualCatchBlocksVisitor());
     }
 
     private static class CombineSemanticallyEqualCatchBlocksVisitor extends JavaVisitor<ExecutionContext> {

--- a/src/main/java/org/openrewrite/staticanalysis/python/PythonFileChecker.java
+++ b/src/main/java/org/openrewrite/staticanalysis/python/PythonFileChecker.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.python;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ReflectionUtils;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.python.tree.Py;
+
+/**
+ * Add a search marker if visiting a Python file
+ */
+public class PythonFileChecker<P> extends TreeVisitor<Tree, P> {
+    private static final boolean IS_PYTHON_AVAILABLE = ReflectionUtils.isClassAvailable("org.openrewrite.python.tree.Py");
+
+    @Override
+    public @Nullable Tree visit(@Nullable Tree tree, P p) {
+        if (IS_PYTHON_AVAILABLE && tree instanceof Py.CompilationUnit) {
+            return SearchResult.found(tree);
+        }
+        return tree;
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #907. `CombineSemanticallyEqualCatchBlocks` crashed in `TreeVisitorAdapter` when the recipe's inner `CommentVisitor` (a `JavaIsoVisitor`) was adapted to Python `Py.CompilationUnit` sources. Added a new `PythonFileChecker` mirroring the existing `KotlinFileChecker`/`GroovyFileChecker` pattern, and used it as a precondition (`Preconditions.not(new PythonFileChecker<>())`) so the recipe still runs on Java, Kotlin, and Groovy files but skips Python. Also added `rewrite-python` as a `provided` dependency to support the checker.

## Test plan

- [x] `./gradlew test --tests CombineSemanticallyEqualCatchBlocksTest`