### PR TITLE
Use receiver type for unbound instance method reference in `ReplaceLambdaWithMethodReference`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -211,7 +211,14 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                         if (isLambdaInGenericAndOverloadedContext()) {
                             return l;
                         }
-                        J.MemberReference updated = newStaticMethodReference(methodType, true, lambda.getType()).withPrefix(lambda.getPrefix());
+                        JavaType.FullyQualified containingType = methodType.getDeclaringType();
+                        if (!methodType.hasFlags(Flag.Static) && select != null) {
+                            JavaType.FullyQualified selectType = TypeUtils.asFullyQualified(select.getType());
+                            if (selectType != null) {
+                                containingType = selectType;
+                            }
+                        }
+                        J.MemberReference updated = newInstanceMethodReference(className(containingType, true), methodType, lambda.getType()).withPrefix(lambda.getPrefix());
                         doAfterVisit(service(ImportService.class).shortenFullyQualifiedTypeReferencesIn(updated));
                         return updated;
                     }

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -1878,6 +1878,62 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/906")
+    @Test
+    void useReceiverTypeWhenDeclaringTypeIsPackagePrivate() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.helloworld.internal;
+
+              import java.util.Optional;
+
+              abstract class Base {
+                  public Optional<String> getValue() {
+                      return Optional.empty();
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.helloworld.internal;
+
+              public class Child extends Base {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.helloworld;
+
+              import com.helloworld.internal.Child;
+              import java.util.Optional;
+
+              public class Main {
+                  String get(final Optional<Child> opt) {
+                      return opt.flatMap(s -> s.getValue()).orElse("");
+                  }
+              }
+              """,
+            """
+              package com.helloworld;
+
+              import com.helloworld.internal.Child;
+              import java.util.Optional;
+
+              public class Main {
+                  String get(final Optional<Child> opt) {
+                      return opt.flatMap(Child::getValue).orElse("");
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/20")
     @Test
     void castToTypeParameterInLambda() {


### PR DESCRIPTION
- Fixes #906.

When `ReplaceLambdaWithMethodReference` converted an unbound instance reference like `s -> s.method()`, it built the class name from the method's declaring type. If that type was package-private and the receiver was a public subclass in another package, the result (e.g. `Base::getValue`) failed to compile because the declaring class could not be imported.

This change uses the receiver/select type to construct the class name for unbound instance method references, falling back to the declaring type only when the select type is not a fully-qualified type. Static method references continue to use the declaring type unchanged.

Added a regression test reproducing the three-file scenario from the issue.