### PR TITLE
Retain load-bearing type witness in select position in `UnnecessaryExplicitTypeArguments`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -53,24 +53,35 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
 
                 JavaType inferredType = null;
                 if (enclosing instanceof J.MethodInvocation) {
-                    if (shouldRetainOnStaticMethod(methodType)) {
-                        return m;
-                    }
-                    // Cannot remove type parameters if it would introduce ambiguity about which method should be called
                     J.MethodInvocation enclosingMethod = (J.MethodInvocation) enclosing;
-                    if (enclosingMethod.getMethodType() == null) {
-                        return m;
-                    }
-                    if (!(enclosingMethod.getMethodType().getDeclaringType() instanceof JavaType.Class)) {
-                        return m;
-                    }
-                    JavaType.Class declaringClass = (JavaType.Class) enclosingMethod.getMethodType().getDeclaringType();
-                    // If there's another method on the class with the same name, skip removing type parameters
-                    // More nuanced detection of ambiguity introduction is possible
-                    if (declaringClass.getMethods().stream()
-                            .filter(it -> it.getName().equals(enclosingMethod.getSimpleName()))
-                            .count() > 1) {
-                        return m;
+                    if (enclosingMethod.getSelect() == method) {
+                        // This invocation is the select (receiver) of the enclosing invocation, so the
+                        // enclosing call provides no target type to drive inference of this call's type
+                        // variables. Retain the witness unless those type variables can be inferred from
+                        // this call's own arguments.
+                        if (!canInferTypeArgumentsFromArguments(methodType)) {
+                            return m;
+                        }
+                    } else {
+                        // This invocation is an argument of the enclosing invocation.
+                        if (shouldRetainOnStaticMethod(methodType)) {
+                            return m;
+                        }
+                        // Cannot remove type parameters if it would introduce ambiguity about which method should be called
+                        if (enclosingMethod.getMethodType() == null) {
+                            return m;
+                        }
+                        if (!(enclosingMethod.getMethodType().getDeclaringType() instanceof JavaType.Class)) {
+                            return m;
+                        }
+                        JavaType.Class declaringClass = (JavaType.Class) enclosingMethod.getMethodType().getDeclaringType();
+                        // If there's another method on the class with the same name, skip removing type parameters
+                        // More nuanced detection of ambiguity introduction is possible
+                        if (declaringClass.getMethods().stream()
+                                .filter(it -> it.getName().equals(enclosingMethod.getSimpleName()))
+                                .count() > 1) {
+                            return m;
+                        }
                     }
                     inferredType = methodType.getReturnType();
                 } else if (enclosing instanceof Expression) {
@@ -143,13 +154,16 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
             }
 
             private boolean shouldRetainOnStaticMethod(JavaType.Method methodType) {
-                if (!methodType.hasFlags(Flag.Static)) {
-                    return false;
-                }
-                // Without arguments, the type parameter cannot be inferred from call-site parameters.
-                // Removing the explicit type arguments can break overload resolution in the enclosing call.
+                // Without a target type, removing the explicit type arguments of a static method can break
+                // overload resolution in the enclosing call when the type variables are not inferable from
+                // the call's own arguments.
+                return methodType.hasFlags(Flag.Static) && !canInferTypeArgumentsFromArguments(methodType);
+            }
+
+            private boolean canInferTypeArgumentsFromArguments(JavaType.Method methodType) {
+                // Without arguments, the type parameters cannot be inferred from call-site arguments.
                 if (methodType.getParameterTypes().isEmpty()) {
-                    return true;
+                    return false;
                 }
                 List<String> formalTypeNames = new ArrayList<>(methodType.getDeclaredFormalTypeNames());
                 methodType.getParameterTypes().stream()
@@ -157,7 +171,7 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                         .flatMap(p -> ((JavaType.Parameterized) p).getTypeParameters().stream())
                         .filter(t -> t instanceof JavaType.GenericTypeVariable)
                         .forEach(it -> formalTypeNames.remove(((JavaType.GenericTypeVariable) it).getName()));
-                return !formalTypeNames.isEmpty();
+                return formalTypeNames.isEmpty();
             }
         });
     }

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -216,6 +216,36 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void retainsWitnessWhenResultIsSelectOfMethodInvocation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class VarDec {
+                  List<String> getVariables() {
+                      return null;
+                  }
+              }
+
+              class Cursor {
+                  <T> T getValue() {
+                      return null;
+                  }
+              }
+
+              class Test {
+                  String test(Cursor c) {
+                      return c.<VarDec>getValue().getVariables().get(0);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class StaticMethods {
         static final SourceSpecs GENERIC_CLASS_SOURCE = java(


### PR DESCRIPTION
## Motivation

`UnnecessaryExplicitTypeArguments` removes an explicit type witness from a generic method invocation even when that witness is load-bearing — specifically when the invocation is the **select (receiver)** of another method invocation. In that position there is no target type to drive type inference, so the witness is required, and removing it produces non-compiling code.

Observed in the wild on `rewrite-spring`'s `ImplicitWebAnnotationNames`:

```java
// before — compiles
J.VariableDeclarations.NamedVariable namedVariable =
        varDecsCursor.<J.VariableDeclarations>getValue().getVariables().get(0);

// after recipe — does NOT compile
J.VariableDeclarations.NamedVariable namedVariable =
        varDecsCursor.getValue().getVariables().get(0);
```

`Cursor#getValue()` is declared `<T> T getValue()`. With the `<J.VariableDeclarations>` witness removed and the result immediately chained into `.getVariables()`, there is no target type, so `T` infers to `Object`, and `Object` has no `getVariables()` method.

## Summary

- Split the `enclosing instanceof J.MethodInvocation` handling into **select** vs. **argument** positions (`enclosingMethod.getSelect() == method`).
- In **select** position the enclosing call provides no target type, so the witness is retained unless the type variables are inferable from the call's own arguments.
- Extracted that inference check into `canInferTypeArgumentsFromArguments(...)`, reused by `shouldRetainOnStaticMethod` so existing static-method and argument-position behavior is unchanged.

## Test plan

- [x] Added `retainsWitnessWhenResultIsSelectOfMethodInvocation` reproducing the chained-call case (recipe makes no change).
- [x] Full `UnnecessaryExplicitTypeArgumentsTest` suite passes, including the pre-existing select-position case `GenericClass.<T>typedBuilderWithClass(clazz).build()` where the witness is still correctly removed (type variable inferable from the `Class<T>` argument).