### PR TITLE
Fix `ArrayIndexOutOfBoundsException` in `UseDiamondOperator` on flagless varargs

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseDiamondOperator.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseDiamondOperator.java
@@ -178,10 +178,15 @@ public class UseDiamondOperator extends Recipe {
         }
 
         private JavaType getMethodParamType(JavaType.Method methodType, int paramIndex) {
-            if (methodType.hasFlags(Flag.Varargs) && paramIndex >= methodType.getParameterTypes().size() - 1) {
-                return ((JavaType.Array) methodType.getParameterTypes().get(methodType.getParameterTypes().size() - 1)).getElemType();
+            List<JavaType> paramTypes = methodType.getParameterTypes();
+            // Treat an out-of-range index as the (vararg-like) last parameter, even when `Flag.Varargs` is
+            // absent. Methods attributed from the classpath / type-table can lack the flag despite the call
+            // passing more arguments than declared parameters, which would otherwise throw an AIOOBE here.
+            if (paramIndex >= paramTypes.size() - 1) {
+                JavaType last = paramTypes.get(paramTypes.size() - 1);
+                return last instanceof JavaType.Array ? ((JavaType.Array) last).getElemType() : last;
             }
-            return methodType.getParameterTypes().get(paramIndex);
+            return paramTypes.get(paramIndex);
         }
 
         @Override

--- a/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
@@ -19,9 +19,16 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
@@ -100,6 +107,53 @@ class UseDiamondOperatorTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void varArgWithoutVarargsFlag() {
+        // Some methods attributed from the classpath / type-table during platform ingestion carry a
+        // `JavaType.Method` whose `Flag.Varargs` is absent even though the call passes more arguments than
+        // declared parameters. The standard in-memory parser never produces this, so we strip the flag in
+        // `mapBeforeRecipe` to reproduce the `ArrayIndexOutOfBoundsException` that this regression guards against.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              class Foo {
+                  void something(String first, List<Integer>... lists) {}
+                  void doSomething() {
+                      something("a", new ArrayList<Integer>(), new ArrayList<Integer>());
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+
+              class Foo {
+                  void something(String first, List<Integer>... lists) {}
+                  void doSomething() {
+                      something("a", new ArrayList<>(), new ArrayList<>());
+                  }
+              }
+              """,
+            spec -> spec.mapBeforeRecipe(cu -> (J.CompilationUnit) new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                    J.MethodInvocation mi = super.visitMethodInvocation(method, p);
+                    JavaType.Method mt = mi.getMethodType();
+                    if (mt != null && mt.hasFlags(Flag.Varargs)) {
+                        Set<Flag> flags = new HashSet<>(mt.getFlags());
+                        flags.remove(Flag.Varargs);
+                        JavaType.Method without = mt.withFlags(flags);
+                        mi = mi.withMethodType(without).withName(mi.getName().withType(without));
+                    }
+                    return mi;
+                }
+            }.visit(cu, 0))
           )
         );
     }


### PR DESCRIPTION
## Motivation

A Moderne flagship recipe run ("Common static analysis issues" and "Java best practices", app environment, 2026-06-12) failed on two Spring repositories with an `ArrayIndexOutOfBoundsException` thrown by `UseDiamondOperator`:

```
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
  java.base/java.util.Arrays$ArrayList.get(Arrays.java:4165)
  org.openrewrite.staticanalysis.UseDiamondOperator$UseDiamondOperatorVisitor.getMethodParamType(UseDiamondOperator.java:184)
  org.openrewrite.staticanalysis.UseDiamondOperator$UseDiamondOperatorVisitor.lambda$visitMethodInvocation$1(UseDiamondOperator.java:147)
  org.openrewrite.internal.ListUtils.map(ListUtils.java:206)
  org.openrewrite.staticanalysis.UseDiamondOperator$UseDiamondOperatorVisitor.visitMethodInvocation(UseDiamondOperator.java:128)
```

Affected source files (both test sources):
- `spring-framework`: `spring-jdbc/src/test/java/org/springframework/jdbc/core/JdbcTemplateTests.java`
- `spring-data`: `src/test/java/org/springframework/data/repository/aot/RepositoryRegistrationAotContributionAssert.java`

## Root cause

In `visitMethodInvocation`, the guard intentionally allows more arguments than declared parameter types to handle varargs calls:

```java
methodType.getParameterTypes().size() <= mi.getArguments().size()
```

Arguments are then mapped by index `i`, and `getMethodParamType(methodType, i)` is called for each `J.NewClass` argument. But `getMethodParamType` only handled the out-of-range index when `Flag.Varargs` was set:

```java
if (methodType.hasFlags(Flag.Varargs) && paramIndex >= methodType.getParameterTypes().size() - 1) {
    return ((JavaType.Array) ...).getElemType();
}
return methodType.getParameterTypes().get(paramIndex); // AIOOBE when paramIndex >= size and Varargs flag absent
```

When a varargs method's `JavaType.Method` lacks `Flag.Varargs` — observed with methods attributed from the classpath / type-table during platform ingestion — `paramIndex` reaches `size()` and the final `.get(paramIndex)` throws.

## Summary

- `getMethodParamType` is now bounds-safe: an out-of-range index is treated as the (vararg-like) last parameter regardless of the `Flag.Varargs` flag, unwrapping the array element type when the last parameter is an array.
- Added a regression test (`varArgWithoutVarargsFlag`).

## Reproduction limitation

The crash could **not** be reproduced with the standard in-memory `JavaParser`: valid, fully-attributed varargs calls always carry `Flag.Varargs`, so the safe branch is taken. The crash requires a `JavaType.Method` where the varargs flag is absent despite `args > params`, which the parser does not produce.

To get a test that fails before / passes after the fix, the regression test parses a normal varargs call and then strips `Flag.Varargs` from the method type via `mapBeforeRecipe` (keeping `MethodInvocation#name#type` consistent). This reproduces the exact `Index 2 out of bounds for length 2` before the fix and applies the diamond operator after it.

## Test plan

- [x] New test `varArgWithoutVarargsFlag` reproduces the `ArrayIndexOutOfBoundsException` against the unmodified recipe and passes after the fix.
- [x] `./gradlew test --tests "UseDiamondOperatorTest"` — full suite green, including the existing flagged-varargs test `varArgIsParameterizedNewClass` (no over-application of the diamond operator).
