### PR TITLE
Preserve space when InstanceOfPatternMatch replaces a cast after a keyword

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -459,7 +459,7 @@ public class InstanceOfPatternMatch extends Recipe {
                 JavaType.Variable fieldType = new JavaType.Variable(null, Flag.Default.getBitMask(), name, owner.getType(), typeCast.getType(), emptyList());
                 return new J.Identifier(
                         randomId(),
-                        typeCast.getPrefix(),
+                        keywordSafePrefix(typeCast.getPrefix(), cursor),
                         Markers.EMPTY,
                         emptyList(),
                         name,
@@ -467,6 +467,22 @@ public class InstanceOfPatternMatch extends Recipe {
                         fieldType);
             }
             return null;
+        }
+
+        /**
+         * A cast like {@code throw(Foo)e} starts with {@code (}, so it needs no whitespace separation
+         * from a preceding keyword. Replacing it with an identifier (e.g. {@code exception}) would fuse
+         * the tokens into {@code throwexception}, so ensure a separating space when the replaced
+         * expression directly follows a keyword (such as {@code throw}, {@code return} or {@code yield}).
+         */
+        private Space keywordSafePrefix(Space prefix, Cursor cursor) {
+            if (prefix.getWhitespace().isEmpty() && prefix.getComments().isEmpty()) {
+                Object parent = cursor.getParentTreeCursor().getValue();
+                if (parent instanceof J.Return || parent instanceof J.Throw || parent instanceof J.Yield) {
+                    return Space.SINGLE_SPACE;
+                }
+            }
+            return prefix;
         }
 
         public @Nullable J processVariableDeclarations(J.VariableDeclarations multiVariable) {
@@ -541,7 +557,7 @@ public class InstanceOfPatternMatch extends Recipe {
             if (parens.getTree() instanceof J.TypeCast) {
                 J replacement = replacements.processTypeCast((J.TypeCast) parens.getTree(), getCursor());
                 if (replacement != null) {
-                    return replacement.withPrefix(parens.getPrefix());
+                    return replacement.withPrefix(replacements.keywordSafePrefix(parens.getPrefix(), getCursor()));
                 }
             }
             return super.visitParentheses(parens, p);

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -2033,4 +2033,56 @@ class InstanceOfPatternMatchTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-apache/issues/135")
+    @Test
+    void castDirectlyAfterThrowKeywordWithoutSpace() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class BasisException extends RuntimeException {}
+              class A {
+                  void test(Exception e) {
+                      if (e instanceof BasisException)throw(BasisException)e;
+                  }
+              }
+              """,
+            """
+              class BasisException extends RuntimeException {}
+              class A {
+                  void test(Exception e) {
+                      if (e instanceof BasisException exception)throw exception;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-apache/issues/135")
+    @Test
+    void castDirectlyAfterReturnKeywordWithoutSpace() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  String test(Object o) {
+                      if (o instanceof String)return(String)o;
+                      return "";
+                  }
+              }
+              """,
+            """
+              class A {
+                  String test(Object o) {
+                      if (o instanceof String string)return string;
+                      return "";
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

`InstanceOfPatternMatch` could produce uncompilable code when a type cast directly followed a keyword without intervening whitespace. Given:

```java
if (e instanceof BasisException)throw(BasisException)e;
```

the recipe replaced the cast `(BasisException)e` with the new pattern variable identifier `exception`. Because the cast had an empty prefix (no space after `throw`), the tokens fused into `throwexception`:

```java
if (e instanceof BasisException exception)throwexception;   // not a statement
```

A cast begins with `(`, so it needs no separation from a preceding keyword; an identifier does. This change inserts a single separating space when the replaced expression directly follows `throw`, `return` or `yield` and had no existing prefix. Both the direct cast path (`throw(Foo)e`) and the parenthesized path (`throw((Foo)e)`) are handled.

## Anything in particular you'd like reviewers to focus on?

The keyword list (`throw`/`return`/`yield`). These are the statement keywords that can be immediately followed by a parenthesized expression with no whitespace.

## Checklist

- [x] I've added unit tests to cover the changes (`castDirectlyAfterThrowKeywordWithoutSpace`, `castDirectlyAfterReturnKeywordWithoutSpace`)

- Fixes https://github.com/openrewrite/rewrite-migrate-java/issues/1131