### PR TITLE
Preserve raw supertype cast on parameterized argument in `RemoveRedundantTypeCast`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -102,13 +102,15 @@ public class RemoveRedundantTypeCast extends Recipe {
                     }
                 }
 
-                // A raw cast on a parameterized expression (e.g. `(B) b` where `b` is `B<T>`)
-                // is an intentional unchecked conversion; removing it changes overload and
-                // type-inference behavior on parameterized receivers.
+                // A raw cast on a parameterized expression (e.g. `(B) b` where `b` is `B<T>`,
+                // or `(Collection) set` where `set` is `Set<? extends G>`) is an intentional
+                // unchecked conversion; removing it changes overload and type-inference behavior
+                // on parameterized arguments, which can break compilation.
                 JavaType.Parameterized exprParameterized = TypeUtils.asParameterized(expressionType);
                 if (parentValue instanceof MethodCall && exprParameterized != null &&
+                        TypeUtils.asFullyQualified(castType) != null &&
                         TypeUtils.asParameterized(castType) == null &&
-                        TypeUtils.isOfClassType(castType, exprParameterized.getType().getFullyQualifiedName())) {
+                        TypeUtils.isAssignableTo(castType, expressionType)) {
                     return visited;
                 }
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -769,6 +769,34 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/914")
+    @Test
+    void doNotRemoveRawSupertypeCastBridgingWildcardCapture() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Collection;
+              import java.util.HashSet;
+              import java.util.Set;
+
+              class G<T extends Number> {}
+
+              interface I {
+                  Set<? extends G> doSomething();
+              }
+
+              class A {
+                  void test(I i) {
+                      Set<? extends G> s = new HashSet<>();
+                      s.addAll((Collection) i.doSomething());
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void doNotRemoveObjectCastOnGenericMethodCallWithOverloads() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?

`RemoveRedundantTypeCast` removed a necessary raw cast when a parameterized expression is cast to a raw **supertype** and passed as a method argument:

```java
Set<? extends G> s = new HashSet<>();
s.addAll((Collection) i.doSomething()); // i.doSomething() returns Set<? extends G>
```

The `(Collection)` cast is an intentional unchecked conversion that bridges the wildcard capture; removing it breaks compilation.

- The existing guard added in #905 (for #901) only preserved raw casts targeting the *same class* as the parameterized expression (`isOfClassType`). This broadens it to preserve raw casts to any assignable (supertype) class type, covering both cases.

## Anything in particular you'd like reviewers to focus on?

The condition now keys on `castType` being a non-parameterized `FullyQualified` that the parameterized expression is assignable to, rather than an exact class match.

- Fixes #914