### PR TITLE
`InstanceOfPatternMatch` not to remove double primitive cast

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InstanceOfPatternMatch.java
@@ -453,9 +453,25 @@ public class InstanceOfPatternMatch extends Recipe {
         public @Nullable J processTypeCast(J.TypeCast typeCast, Cursor cursor) {
             J.InstanceOf instanceOf = replacements.get(typeCast);
             if (instanceOf != null && instanceOf.getPattern() != null) {
-                String name = ((J.Identifier) instanceOf.getPattern()).getSimpleName();
+                J.Identifier pattern = (J.Identifier) instanceOf.getPattern();
+                String name = pattern.getSimpleName();
                 TypedTree owner = cursor.firstEnclosing(J.MethodDeclaration.class);
                 owner = owner != null ? owner : cursor.firstEnclosingOrThrow(J.ClassDeclaration.class);
+                // A primitive (unboxing) cast nested inside another cast is load-bearing: in `(int) (long) o`
+                // the `(long)` cast cannot be dropped, since `(int) o` on the boxed pattern variable does not
+                // compile. Keep the cast and replace only its expression with the pattern variable.
+                if (typeCast.getType() instanceof JavaType.Primitive &&
+                        cursor.getParentTreeCursor().getValue() instanceof J.TypeCast) {
+                    JavaType.Variable innerType = new JavaType.Variable(null, Flag.Default.getBitMask(), name, owner.getType(), pattern.getType(), emptyList());
+                    return typeCast.withExpression(new J.Identifier(
+                            randomId(),
+                            typeCast.getExpression().getPrefix(),
+                            Markers.EMPTY,
+                            emptyList(),
+                            name,
+                            pattern.getType(),
+                            innerType));
+                }
                 JavaType.Variable fieldType = new JavaType.Variable(null, Flag.Default.getBitMask(), name, owner.getType(), typeCast.getType(), emptyList());
                 return new J.Identifier(
                         randomId(),

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -2085,4 +2085,47 @@ class InstanceOfPatternMatchTest implements RewriteTest {
           )
         );
     }
+
+    @DocumentExample
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/916")
+    @Test
+    void doubleCastUnboxingIssueWithInstanceOf() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class DoubleCastUnboxingSample {
+
+                  public Integer foo(Class clazz, Object data) {
+                      Integer result;
+                      if (Integer.class == clazz && data instanceof Integer) {
+                          result = (int) data;
+                      } else if (Integer.class == clazz && data instanceof Long) {
+                          result = (int) (long) data;
+                      } else {
+                          result = null;
+                      }
+                      return result;
+                  }
+              }
+              """,
+            """
+              public class DoubleCastUnboxingSample {
+
+                  public Integer foo(Class clazz, Object data) {
+                      Integer result;
+                      if (Integer.class == clazz && data instanceof Integer integer) {
+                          result = integer;
+                      } else if (Integer.class == clazz && data instanceof Long long1) {
+                          result = (int) (long) long1;
+                      } else {
+                          result = null;
+                      }
+                      return result;
+                  }
+              }
+              """
+          )
+        );
+    }    
 }

--- a/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InstanceOfPatternMatchTest.java
@@ -2086,7 +2086,6 @@ class InstanceOfPatternMatchTest implements RewriteTest {
         );
     }
 
-    @DocumentExample
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/916")
     @Test
     void doubleCastUnboxingIssueWithInstanceOf() {
@@ -2127,5 +2126,5 @@ class InstanceOfPatternMatchTest implements RewriteTest {
               """
           )
         );
-    }    
+    }
 }


### PR DESCRIPTION
## What's changed?

An amendment to `InstanceOfPatternMatch` recipe.
Make it not remove the double cast from `long` to `int`.

## What's your motivation?

- Otherwise it produces invalid code.
- Closes #916 
- Closes #917 
