### PR TITLE
Fix `UseTryWithResources` moving resource out of scope for catch block

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseTryWithResources.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseTryWithResources.java
@@ -157,9 +157,11 @@ public class UseTryWithResources extends Recipe {
             return false;
         }
 
-        // Variable must not be closed in catch blocks
+        // Variable must not be referenced in catch blocks. The scope of a resource declared in
+        // the resource specification is the try block only (JLS 14.20.3), so any reference from a
+        // catch clause would become out of scope once the declaration moves into the header.
         for (J.Try.Catch aCatch : tryStmt.getCatches()) {
-            if (containsClose(varName, aCatch.getBody())) {
+            if (isReferenced(varName, aCatch.getBody())) {
                 return false;
             }
         }
@@ -457,14 +459,14 @@ public class UseTryWithResources extends Recipe {
         }.reduce(tree, new AtomicBoolean()).get();
     }
 
-    private static boolean containsClose(String varName, J tree) {
+    private static boolean isReferenced(String varName, J tree) {
         return new JavaIsoVisitor<AtomicBoolean>() {
             @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, AtomicBoolean f) {
-                if (isCloseInvocation(mi, varName)) {
+            public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean f) {
+                if (identifier.getSimpleName().equals(varName)) {
                     f.set(true);
                 }
-                return super.visitMethodInvocation(mi, f);
+                return super.visitIdentifier(identifier, f);
             }
         }.reduce(tree, new AtomicBoolean()).get();
     }

--- a/src/test/java/org/openrewrite/staticanalysis/UseTryWithResourcesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseTryWithResourcesTest.java
@@ -343,6 +343,32 @@ class UseTryWithResourcesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/920")
+    @Test
+    void doNotChangeResourceReferencedInCatch() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.*;
+
+              class Test {
+                  void method() throws IOException {
+                      InputStream in = new FileInputStream("file.txt");
+                      try {
+                          int data = in.read();
+                      } catch (RuntimeException e) {
+                          in.reset();
+                      } finally {
+                          in.close();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void finallyWithExtraLogicAfterCloseKeepsRemainingStatements() {
         rewriteRun(


### PR DESCRIPTION
## What's changed

`UseTryWithResources` moved a resource declaration into the try-with-resources header even when the resource was referenced from a `catch` clause. Since a resource's scope is the `try` block only (JLS 14.20.3), the resulting source failed to compile with `cannot find symbol`.

`canTransform` previously only rejected resources that were *closed* in a catch block; it now rejects any resource *referenced* in a catch block.

## Anything you'd like reviewers to focus on?

- Fixes #920