### PR TITLE
Fix `MinimumSwitchCases` crash on Java 21 sealed-interface pattern switch

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -215,6 +215,17 @@ public class MinimumSwitchCases extends Recipe {
                 if (switch_.getCases().getStatements().size() > 2) {
                     return false;
                 }
+                // Don't transform switches that use Java 21 pattern matching (e.g. `case Foo.Bar b ->`),
+                // as those case labels are not simple expressions and cannot be converted to `==`/`equals` checks
+                for (Statement statement : switch_.getCases().getStatements()) {
+                    if (statement instanceof J.Case) {
+                        for (J label : ((J.Case) statement).getCaseLabels()) {
+                            if (!(label instanceof Expression)) {
+                                return false;
+                            }
+                        }
+                    }
+                }
                 // Don't transform if any case has an identifier pattern without type info
                 // (we can't properly qualify it in the if statement)
                 if (hasUnresolvableIdentifierCasePattern(switch_)) {

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -1160,4 +1160,31 @@ class MinimumSwitchCasesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite/issues/8039")
+    void sealedInterfacePatternSwitch() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              sealed interface LifecycleCommand permits LifecycleCommand.Sequential, LifecycleCommand.Parallel {
+                  record Sequential(List<String> args) implements LifecycleCommand {}
+                  record Parallel(List<String> steps) implements LifecycleCommand {}
+              }
+
+              class Test {
+                  void test(LifecycleCommand command) {
+                      switch (command) {
+                          case LifecycleCommand.Sequential s -> System.out.println(s.args());
+                          case LifecycleCommand.Parallel p -> System.out.println(p.steps());
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed

`MinimumSwitchCases` (part of `CommonStaticAnalysis`) threw an `IndexOutOfBoundsException` when visiting a `switch` whose `case` arms use Java 21 type-pattern matching (e.g. `case Foo.Bar b ->`).

Such case labels are not `Expression` instances, so `getExpressions()` returns an empty list and `J.Case.getPattern()` (which does `getExpressions().get(0)`) crashes inside `isDefault`.

These switches can't be converted to `==`/`equals` comparisons anyway, so `doRewrite` now bails out when any case label is not a simple expression.

## Reproducer

```java
switch (command) {
    case LifecycleCommand.Sequential s -> System.out.println(s.args());
    case LifecycleCommand.Parallel p -> System.out.println(p.steps());
}
```

Added a regression test `sealedInterfacePatternSwitch`.

- Fixes https://github.com/openrewrite/rewrite/issues/8039