### PR TITLE
Fix `RemoveRedundantTypeCast` removing cast that gives a `var` lambda its target type

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -160,8 +160,16 @@ public class RemoveRedundantTypeCast extends Recipe {
                 if ((targetType instanceof JavaType.Primitive || castType instanceof JavaType.Primitive) && castType != expressionType) {
                     return visitedTypeCast;
                 }
-                if (typeCast.getExpression() instanceof J.Lambda || typeCast.getExpression() instanceof J.MemberReference) {
+                J castExpression = typeCast.getExpression();
+                while (castExpression instanceof J.Parentheses || castExpression instanceof J.ControlParentheses) {
+                    castExpression = castExpression instanceof J.Parentheses ?
+                            ((J.Parentheses<?>) castExpression).getTree() :
+                            ((J.ControlParentheses<?>) castExpression).getTree();
+                }
+                if (castExpression instanceof J.Lambda || castExpression instanceof J.MemberReference) {
                     // Not currently supported, this will be more accurate with dataflow analysis.
+                    // The cast supplies the target type for the lambda or method reference; removing it
+                    // can break compilation, e.g. when assigned to a `var` local.
                     return visitedTypeCast;
                 }
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
 
 @SuppressWarnings("ALL")
 class RemoveRedundantTypeCastTest implements RewriteTest {
@@ -485,6 +486,50 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/924")
+    void keepCastForLambdaAssignedToVar() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class Example {
+                  void run() {
+                      var converter = (Function<Integer, String>) (i -> Integer.toString(i));
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(25))
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/924")
+    void keepCastForMethodReferenceAssignedToVar() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Supplier;
+
+              class Example {
+                  static String make() {
+                      return "";
+                  }
+
+                  void run() {
+                      var supplier = (Supplier<String>) Example::make;
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(25))
           )
         );
     }


### PR DESCRIPTION
- Fixes #924

`RemoveRedundantTypeCast` already guards against removing a cast whose operand is a lambda or method reference, but the check only matched when the operand was the *direct* cast expression. When the lambda is wrapped in parentheses — `var converter = (Function<Integer, String>) (i -> Integer.toString(i));` — the operand is a `J.ControlParentheses`/`J.Parentheses` node, so the guard missed it and removed the cast.

For a `var` local the cast is the only thing supplying the lambda's target type, so removing it produces code that does not compile (`cannot infer type for local variable`).

This unwraps parentheses before the lambda / method-reference check. The analogous method-reference form was already preserved (its operand isn't parenthesized); a regression test is added for it too.