### PR TITLE
Fix UseStringCaseInsensitiveOrder lambda matching

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseStringCaseInsensitiveOrder.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseStringCaseInsensitiveOrder.java
@@ -37,7 +37,7 @@ public class UseStringCaseInsensitiveOrder {
     public static class FromLambda {
         @BeforeTemplate
         Comparator<String> before() {
-            return String::compareToIgnoreCase;
+            return (a, b) -> a.compareToIgnoreCase(b);
         }
 
         @AfterTemplate


### PR DESCRIPTION
The `OpenRewrite recipe best practices` commit (1b83d00a) changed `FromLambda.before()` to return the method reference `String::compareToIgnoreCase`, making it an exact duplicate of `FromMethodReference` and breaking matching of the actual lambda form `(a, b) -> a.compareToIgnoreCase(b)`.

This broke `UseStringCaseInsensitiveOrderTest.lambdaRewrites()` and `wrappedInNullsFirst()` on main (run 28649879767).

Reverts that one line back to the lambda `before()` template.

`./gradlew test --tests UseStringCaseInsensitiveOrderTest` passes.