### PR TITLE
Keep (Object) cast on array argument at varargs position

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -135,6 +135,17 @@ public class RemoveRedundantTypeCast extends Recipe {
                                         methodType.getParameterTypes().get(i) instanceof JavaType.Array) {
                                     return visited;
                                 }
+                                // A cast to a non-array type (e.g. `(Object)`) on an array-typed argument at the
+                                // varargs position marks the array as a single varargs element rather than being
+                                // spread, and silences Error Prone's `PrimitiveArrayPassedToVarargsMethod`.
+                                // Removing it changes argument semantics, so preserve the cast.
+                                if (i == methodType.getParameterTypes().size() - 1 &&
+                                        i == arguments.size() - 1 &&
+                                        methodType.getParameterTypes().get(i) instanceof JavaType.Array &&
+                                        typeCast.getExpression().getType() instanceof JavaType.Array &&
+                                        !(castType instanceof JavaType.Array)) {
+                                    return visited;
+                                }
                                 targetType = getParameterType(methodType, i);
                                 break;
                             }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -127,23 +127,18 @@ public class RemoveRedundantTypeCast extends Recipe {
                         for (int i = 0; i < arguments.size(); i++) {
                             Expression arg = arguments.get(i);
                             if (arg == typeCast) {
-                                // A `null` literal cast at the last position of a (potential) varargs call
-                                // disambiguates between passing `null` as the array vs. a single null element.
-                                if (J.Literal.isLiteralValue(typeCast.getExpression(), null) &&
-                                        i == methodType.getParameterTypes().size() - 1 &&
-                                        i == arguments.size() - 1 &&
-                                        methodType.getParameterTypes().get(i) instanceof JavaType.Array) {
-                                    return visited;
-                                }
-                                // A cast to a non-array type (e.g. `(Object)`) on an array-typed argument at the
-                                // varargs position marks the array as a single varargs element rather than being
-                                // spread, and silences Error Prone's `PrimitiveArrayPassedToVarargsMethod`.
-                                // Removing it changes argument semantics, so preserve the cast.
+                                // A cast at the last position of a (potential) varargs call can be
+                                // semantically significant, so preserve it: a `null` literal cast
+                                // disambiguates passing `null` as the array vs. a single null element, and a
+                                // cast to a non-array type (e.g. `(Object)`) on an array-typed argument marks
+                                // the array as a single element rather than being spread (also silencing
+                                // Error Prone's `PrimitiveArrayPassedToVarargsMethod`).
                                 if (i == methodType.getParameterTypes().size() - 1 &&
                                         i == arguments.size() - 1 &&
                                         methodType.getParameterTypes().get(i) instanceof JavaType.Array &&
-                                        typeCast.getExpression().getType() instanceof JavaType.Array &&
-                                        !(castType instanceof JavaType.Array)) {
+                                        (J.Literal.isLiteralValue(typeCast.getExpression(), null) ||
+                                                typeCast.getExpression().getType() instanceof JavaType.Array &&
+                                                        !(castType instanceof JavaType.Array))) {
                                     return visited;
                                 }
                                 targetType = getParameterType(methodType, i);

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -127,12 +127,9 @@ public class RemoveRedundantTypeCast extends Recipe {
                         for (int i = 0; i < arguments.size(); i++) {
                             Expression arg = arguments.get(i);
                             if (arg == typeCast) {
-                                // A cast at the last position of a (potential) varargs call can be
-                                // semantically significant, so preserve it: a `null` literal cast
-                                // disambiguates passing `null` as the array vs. a single null element, and a
-                                // cast to a non-array type (e.g. `(Object)`) on an array-typed argument marks
-                                // the array as a single element rather than being spread (also silencing
-                                // Error Prone's `PrimitiveArrayPassedToVarargsMethod`).
+                                // Preserve a semantically significant cast at the varargs position: a `null`
+                                // literal (array vs. single null element) or an array cast to a non-array type
+                                // (e.g. `(Object)`, marking the array as a single element rather than spread).
                                 if (i == methodType.getParameterTypes().size() - 1 &&
                                         i == arguments.size() - 1 &&
                                         methodType.getParameterTypes().get(i) instanceof JavaType.Array &&

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -865,4 +865,42 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/934")
+    @Test
+    void doNotRemoveObjectCastOnPrimitiveArrayVarargs() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Example {
+                  void run() {
+                      sink((Object) new int[] {1, 2, 3});
+                  }
+
+                  static void sink(Object... args) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/934")
+    @Test
+    void doNotRemoveObjectCastOnReferenceArrayVarargs() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Example {
+                  void run(String[] arr) {
+                      sink((Object) arr);
+                  }
+
+                  static void sink(Object... args) {}
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Fixes #934

`RemoveRedundantTypeCast` was stripping an `(Object)` cast on an array argument passed to an `Object...` varargs method, e.g. rewriting `sink((Object) new int[]{1, 2, 3})` to `sink(new int[]{1, 2, 3})`.

That cast is not redundant:
- For a **primitive array** (`int[]`), the cast silences Error Prone's `PrimitiveArrayPassedToVarargsMethod`, which is exactly the pattern it exists for (e.g. `Method.invoke(null, (Object) new int[]{port})`).
- For a **reference-type array** (`String[]` into `Object...`), removing the cast is a silent behaviour change: `sink((Object) arr)` passes the array as a single element, whereas `sink(arr)` spreads it.

- The prior fix in #904 only guarded the overload-disambiguation case (`Object...` vs `Throwable`); here the varargs method has no competing overload, so that guard didn't apply.

## Fix

Preserve the cast when it sits at the varargs position, its expression is array-typed, and the cast target is a non-array type. This mirrors the existing guard for a `null` literal cast at the varargs position.