### PR TITLE
Do not wrap operators onto a new line in Kotlin sources

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/OperatorWrap.java
+++ b/src/main/java/org/openrewrite/staticanalysis/OperatorWrap.java
@@ -53,6 +53,11 @@ public class OperatorWrap extends Recipe {
             @Override
             public J visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree instanceof JavaSourceFile) {
+                    // Kotlin treats a newline as an expression terminator, so a leading binary operator
+                    // becomes a unary operator on a new statement. Only reformat Java compilation units.
+                    if (!(tree instanceof J.CompilationUnit)) {
+                        return (J) tree;
+                    }
                     SourceFile cu = (SourceFile) tree;
                     operatorWrapStyle = Style.from(OperatorWrapStyle.class, cu, Checkstyle::operatorWrapStyle);
 

--- a/src/test/java/org/openrewrite/staticanalysis/OperatorWrapKotlinTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/OperatorWrapKotlinTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class OperatorWrapKotlinTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new OperatorWrap(null));
+    }
+
+    @Test
+    void doesNotMoveBinaryOperatorToNewLineInKotlin() {
+        // In Kotlin a newline ends an expression, so a leading binary operator is parsed as a unary
+        // operator on a new statement. Moving `+` to the start of the next line breaks the code.
+        rewriteRun(
+          kotlin(
+            """
+              fun method(): String {
+                  val s = "aaa" + "b" +
+                      "c"
+                  return s
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
### What's changed

`OperatorWrap` now only reformats Java compilation units, leaving Kotlin (and other non-Java `JavaSourceFile`s) untouched. Adds a Kotlin test.

### Why

In Kotlin a newline terminates an expression, so a leading binary operator is parsed as a unary operator on a new statement. With the default `WrapOption.NL` style the recipe moves a binary operator to the start of the next line:

```kotlin
val s = "aaa" + "b" +
    "c"
```

becomes

```kotlin
val s = "aaa" + "b"
    + "c"
```

The trailing `+ "c"` is now a `unaryPlus` on a separate statement, so the code no longer compiles. This surfaced running a `CodeCleanup` composite over Apache JMeter's mixed Java/Kotlin sources — a `letsPlot(...) + geomLine {...} + ...` chain was broken the same way.

The recipe's `visitBinary` moves operators purely by relocating whitespace, which is only valid under Java's newline rules. Restricting the visitor to `J.CompilationUnit` (rather than every `JavaSourceFile`) keeps the Java behaviour and stops it corrupting Kotlin.

### How to verify

`./gradlew test --tests "*.OperatorWrapKotlinTest" --tests "*.OperatorWrapTest"` — the new Kotlin test passes and the existing Java suite (19 tests) is unchanged.
