### PR TITLE
Qualify `this` for outer-class methods in ReplaceLambdaWithMethodReference

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
+++ b/src/main/java/org/openrewrite/staticanalysis/JavaElementFactory.java
@@ -187,4 +187,24 @@ final class JavaElementFactory {
     public static J.Identifier newThis(JavaType type) {
         return new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "this", type, null);
     }
+
+    /**
+     * Create a qualified {@code this} expression such as {@code Outer.this}, used when referencing a
+     * member of an enclosing (outer) class from within an inner class.
+     */
+    public static J.FieldAccess newQualifiedThis(JavaType.FullyQualified type) {
+        String className = type.getClassName();
+        String simpleName = className.substring(className.lastIndexOf('.') + 1);
+        return new J.FieldAccess(
+                randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), simpleName, type, null),
+                new JLeftPadded<>(
+                        Space.EMPTY,
+                        new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), "this", type, null),
+                        Markers.EMPTY),
+                type
+        );
+    }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReference.java
@@ -234,8 +234,14 @@ public class ReplaceLambdaWithMethodReference extends Recipe {
                     Cursor owner = getCursor().dropParentUntil(is -> is instanceof J.ClassDeclaration ||
                             (is instanceof J.NewClass && ((J.NewClass) is).getBody() != null) ||
                             is instanceof J.Lambda);
+                    JavaType ownerType = owner.<TypedTree>getValue().getType();
+                    JavaType.FullyQualified declaringType = methodType.getDeclaringType();
+                    // When the method belongs to an enclosing (outer) class, qualify `this` as `Outer.this`
+                    Expression thisExpression = ownerType != null && !TypeUtils.isAssignableTo(declaringType, ownerType) ?
+                            JavaElementFactory.newQualifiedThis(declaringType) :
+                            JavaElementFactory.newThis(ownerType);
                     return JavaElementFactory.newInstanceMethodReference(
-                            JavaElementFactory.newThis(owner.<TypedTree>getValue().getType()),
+                            thisExpression,
                             methodType,
                             lambda.getType()
                     ).withPrefix(lambda.getPrefix());

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceLambdaWithMethodReferenceTest.java
@@ -909,6 +909,42 @@ class ReplaceLambdaWithMethodReferenceTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/941")
+    void qualifiedThisForOuterClassMethod() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Outer {
+                  class Inner {
+                      void caller() {
+                          List.of("something").forEach((s) -> test(s));
+                      }
+                  }
+
+                  void test(String something) {}
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Outer {
+                  class Inner {
+                      void caller() {
+                          List.of("something").forEach(Outer.this::test);
+                      }
+                  }
+
+                  void test(String something) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void functionReference() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
- Fixes #941.

`ReplaceLambdaWithMethodReference` produced non-compiling code when a lambda called an unqualified method belonging to an enclosing (outer) class from within an inner class, emitting `this::test` where `this` refers to the inner instance that has no such method. It now compares the method's declaring type against the enclosing owner and emits `Outer.this::test` in that case, keeping plain `this` for methods declared on or inherited by the innermost class. A new `newQualifiedThis` factory builds the qualified `this` expression, and a regression test covers the reported scenario.