### PR TITLE
FixStringFormatExpressions: don't strip args with no matched specifiers

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
@@ -39,6 +39,10 @@ public class FixStringFormatExpressions extends Recipe {
     private static final Pattern FS_PATTERN = Pattern.compile("%(\\d+\\$)?([-#+ 0,(<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])");
     private static final Pattern NEWLINE_PATTERN = Pattern.compile("(?<!\\\\)\\n");
     private static final Pattern ESCAPED_NEWLINE_PATTERN = Pattern.compile("(?<!\\\\)\\\\n");
+    // Matches SLF4J-style placeholder syntax (`{}`), as opposed to a `String#format` conversion
+    // specifier. Used to detect when a format string with zero real specifiers is more likely using
+    // the wrong templating convention than genuinely containing dead arguments -- see below.
+    private static final Pattern UNRESOLVED_PLACEHOLDER_PATTERN = Pattern.compile("\\{}");
 
     private static final MethodMatcher FORMAT_MATCHER = new MethodMatcher("java.lang.String format(..)");
     private static final MethodMatcher FORMATTED_MATCHER = new MethodMatcher("java.lang.String formatted(..)");
@@ -89,12 +93,31 @@ public class FixStringFormatExpressions extends Recipe {
                             // Trim any extra args
                             String val = (String) fmtArg.getValue();
                             Matcher m = FS_PATTERN.matcher(val);
-                            int argIndex = isStringFormattedExpression ? 0 : 1;
+                            int initialArgIndex = isStringFormattedExpression ? 0 : 1;
+                            int argIndex = initialArgIndex;
                             while (m.find()) {
                                 if (m.group(1) != null || m.group(2).contains("<")) {
                                     return mi;
                                 }
-                                argIndex++;
+                                // `%n` and `%%` do not consume an argument from the list, unlike
+                                // every other conversion (`%s`, `%d`, etc.) -- do not count them,
+                                // or a format string mixing them with `{}` placeholders (e.g. after
+                                // this recipe's own newline-to-%n replacement above) would be
+                                // miscounted as having a real specifier on a later recipe cycle,
+                                // undermining the check below.
+                                String conversion = m.group(6);
+                                if (!"n".equals(conversion) && !"%".equals(conversion)) {
+                                    argIndex++;
+                                }
+                            }
+                            if (argIndex == initialArgIndex && UNRESOLVED_PLACEHOLDER_PATTERN.matcher(val).find()) {
+                                // No `%` conversion specifiers matched, but the format string contains
+                                // `{}`-style tokens (e.g. SLF4J placeholder syntax mistakenly used with
+                                // String#format). This is almost certainly a pre-existing bug in the
+                                // calling code, not genuinely dead arguments -- removing them would
+                                // destroy the evidence needed to notice and fix the real mismatch, so
+                                // leave the call's arguments alone.
+                                return mi;
                             }
                             int finalArgIndex = argIndex;
                             return mi.withArguments(ListUtils.map(mi.getArguments(), (i, arg) -> {

--- a/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
@@ -39,10 +39,6 @@ public class FixStringFormatExpressions extends Recipe {
     private static final Pattern FS_PATTERN = Pattern.compile("%(\\d+\\$)?([-#+ 0,(<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z%])");
     private static final Pattern NEWLINE_PATTERN = Pattern.compile("(?<!\\\\)\\n");
     private static final Pattern ESCAPED_NEWLINE_PATTERN = Pattern.compile("(?<!\\\\)\\\\n");
-    // Matches SLF4J-style placeholder syntax (`{}`), as opposed to a `String#format` conversion
-    // specifier. Used to detect when a format string with zero real specifiers is more likely using
-    // the wrong templating convention than genuinely containing dead arguments -- see below.
-    private static final Pattern UNRESOLVED_PLACEHOLDER_PATTERN = Pattern.compile("\\{}");
 
     private static final MethodMatcher FORMAT_MATCHER = new MethodMatcher("java.lang.String format(..)");
     private static final MethodMatcher FORMATTED_MATCHER = new MethodMatcher("java.lang.String formatted(..)");
@@ -110,13 +106,15 @@ public class FixStringFormatExpressions extends Recipe {
                                     argIndex++;
                                 }
                             }
-                            if (argIndex == initialArgIndex && UNRESOLVED_PLACEHOLDER_PATTERN.matcher(val).find()) {
-                                // No `%` conversion specifiers matched, but the format string contains
-                                // `{}`-style tokens (e.g. SLF4J placeholder syntax mistakenly used with
-                                // String#format). This is almost certainly a pre-existing bug in the
-                                // calling code, not genuinely dead arguments -- removing them would
-                                // destroy the evidence needed to notice and fix the real mismatch, so
-                                // leave the call's arguments alone.
+                            if (argIndex == initialArgIndex) {
+                                // No `%` conversion specifiers matched at all. This recipe only trims
+                                // arguments it has positive evidence are unused -- i.e. trailing args
+                                // beyond what matched specifiers actually consume. Zero specifiers gives
+                                // no such evidence: the format string may be using some other templating
+                                // convention entirely (e.g. SLF4J-style `{}` placeholders mistakenly used
+                                // with String#format instead of a logger). Leave the call's arguments
+                                // alone rather than guessing they're dead code -- deleting them would
+                                // destroy the evidence needed to notice and fix the real bug.
                                 return mi;
                             }
                             int finalArgIndex = argIndex;

--- a/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FixStringFormatExpressions.java
@@ -95,26 +95,15 @@ public class FixStringFormatExpressions extends Recipe {
                                 if (m.group(1) != null || m.group(2).contains("<")) {
                                     return mi;
                                 }
-                                // `%n` and `%%` do not consume an argument from the list, unlike
-                                // every other conversion (`%s`, `%d`, etc.) -- do not count them,
-                                // or a format string mixing them with `{}` placeholders (e.g. after
-                                // this recipe's own newline-to-%n replacement above) would be
-                                // miscounted as having a real specifier on a later recipe cycle,
-                                // undermining the check below.
+                                // `%n` and `%%` do not consume an argument, so don't count them
                                 String conversion = m.group(6);
                                 if (!"n".equals(conversion) && !"%".equals(conversion)) {
                                     argIndex++;
                                 }
                             }
                             if (argIndex == initialArgIndex) {
-                                // No `%` conversion specifiers matched at all. This recipe only trims
-                                // arguments it has positive evidence are unused -- i.e. trailing args
-                                // beyond what matched specifiers actually consume. Zero specifiers gives
-                                // no such evidence: the format string may be using some other templating
-                                // convention entirely (e.g. SLF4J-style `{}` placeholders mistakenly used
-                                // with String#format instead of a logger). Leave the call's arguments
-                                // alone rather than guessing they're dead code -- deleting them would
-                                // destroy the evidence needed to notice and fix the real bug.
+                                // No argument-consuming specifiers matched; without evidence an arg is
+                                // unused (e.g. SLF4J-style `{}` placeholders), leave the call alone
                                 return mi;
                             }
                             int finalArgIndex = argIndex;

--- a/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
@@ -83,20 +83,8 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void doNotStripArgsWithNoSpecifiersEvenWithoutPlaceholders() {
-        // This recipe only trims arguments it has positive evidence are unused -- trailing args
-        // beyond what matched `%` specifiers actually consume. With zero specifiers matched, there
-        // is no such evidence either way, so the call is left alone -- even though these args have
-        // no `{}` (or any other) placeholder syntax suggesting an alternative explanation. Previously
-        // this recipe trimmed to zero args in this case; that was true dead-code cleanup sometimes,
-        // but indistinguishable from cases where deleting was actively harmful (see the `{}` tests
-        // below), so this recipe no longer guesses either way when it has no real specifier evidence.
-        //
-        // This also happens to resolve a separate latent bug: for `.formatted()`, the trim step's
-        // `i == 0` keep-clause assumed index 0 of the argument list is always the format string --
-        // true for `String.format(fmt, args...)`, but false for `"fmt".formatted(args...)`, where
-        // index 0 is the first real argument. That previously forced one argument to survive even
-        // when zero should remain. Bailing out here whenever no specifier matched means that branch
-        // (finalArgIndex == 0, only reachable with zero matches) is never reached at all.
+        // With zero specifiers matched there is no evidence the args are unused, so leave the call
+        // alone. Also covers `.formatted()`, whose index 0 is the first arg, not the format string.
         rewriteRun(
           //language=java
           java(
@@ -114,10 +102,7 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void stripArgsWhenRealSpecifierPresentDespiteUnresolvedPlaceholder() {
-        // Bailing out only applies when ZERO real specifiers matched. If a real specifier is
-        // present anywhere, the format string is far more likely a genuine (if imperfect) Java
-        // format call, so the normal trim behavior should still apply -- the `{}` here is
-        // ambiguous, not a strong enough signal on its own to block trimming.
+        // A real specifier is present, so trimming still applies despite the ambiguous `{}`.
         rewriteRun(
           //language=java
           java(
@@ -141,9 +126,7 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void trimUnusedArgumentsWithLiteralPercentAndRealSpecifier() {
-        // `%%` combined with a real, argument-consuming specifier (`%d`): the literal percent must
-        // still not be counted, while the real specifier's excess argument is still correctly
-        // trimmed -- covers the combination, not just each in isolation.
+        // `%%` is not counted, but the real `%d` still trims its excess argument.
         rewriteRun(
           //language=java
           java(
@@ -167,9 +150,7 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void doNotStripArgsWithUnresolvedPlaceholdersAndLiteralPercent() {
-        // `%%` (a literal percent sign), like `%n`, does not consume an argument. A format string
-        // with only `%%` and `{}` tokens still has zero *argument-consuming* specifiers, so the
-        // bailout must still fire and preserve the arguments.
+        // `%%`, like `%n`, consumes no argument, so `%%` plus `{}` still counts as zero specifiers.
         rewriteRun(
           //language=java
           java(
@@ -237,11 +218,7 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void doNotStripArgsWithUnresolvedPlaceholders() {
-        // Real-world motivating case: `{}` is SLF4J-style placeholder syntax, not a `String#format`
-        // conversion specifier, so this format string has zero real `%` specifiers. Previously this
-        // recipe treated `original`/`shadow` as dead code and deleted them -- but they're almost
-        // certainly meant to be substituted, just via the wrong API. Leaving the call alone keeps
-        // the underlying bug (wrong templating syntax) visible instead of erasing the evidence of it.
+        // SLF4J-style `{}` is not a `String#format` specifier, so don't delete the args as dead code.
         rewriteRun(
           //language=java
           java(
@@ -282,8 +259,7 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void newlineStillReplacedWhenArgsAreNotStripped() {
-        // The zero-specifiers-matched bailout only skips the arg-trimming step; the unrelated
-        // newline-to-%n replacement above it must still apply.
+        // The bailout only skips arg-trimming; newline-to-%n replacement must still apply.
         rewriteRun(
           //language=java
           java(
@@ -307,11 +283,8 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void shadowClientMismatchReportingIsNotCorrupted() {
-        // Near-verbatim reproduction of the motivating production bug: a shadow-traffic comparator
-        // that logs a mismatch via a custom reportMismatch(...) helper, building the message with
-        // String#format but using SLF4J-style `{}` placeholders by mistake. Before this fix, the
-        // recipe deleted `original` and `shadow` from every one of these calls, silently degrading
-        // every mismatch report down to the literal, useless string "expect {}, actual {}".
+        // Motivating bug: mismatch reports built with String#format but SLF4J-style `{}` placeholders,
+        // where the recipe used to delete the args and reduce every report to "expect {}, actual {}".
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
@@ -140,6 +140,32 @@ class FixStringFormatExpressionsTest implements RewriteTest {
     }
 
     @Test
+    void trimUnusedArgumentsWithLiteralPercentAndRealSpecifier() {
+        // `%%` combined with a real, argument-consuming specifier (`%d`): the literal percent must
+        // still not be counted, while the real specifier's excess argument is still correctly
+        // trimmed -- covers the combination, not just each in isolation.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  static {
+                      String s = String.format("100%% done: %d", 1, 2);
+                  }
+              }
+              """,
+            """
+              class T {
+                  static {
+                      String s = String.format("100%% done: %d", 1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotStripArgsWithUnresolvedPlaceholdersAndLiteralPercent() {
         // `%%` (a literal percent sign), like `%n`, does not consume an argument. A format string
         // with only `%%` and `{}` tokens still has zero *argument-consuming* specifiers, so the
@@ -272,6 +298,44 @@ class FixStringFormatExpressionsTest implements RewriteTest {
               class T {
                   static void test(int original, int shadow) {
                       String s = String.format("expect {}%nactual {}", original, shadow);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shadowClientMismatchReportingIsNotCorrupted() {
+        // Near-verbatim reproduction of the motivating production bug: a shadow-traffic comparator
+        // that logs a mismatch via a custom reportMismatch(...) helper, building the message with
+        // String#format but using SLF4J-style `{}` placeholders by mistake. Before this fix, the
+        // recipe deleted `original` and `shadow` from every one of these calls, silently degrading
+        // every mismatch report down to the literal, useless string "expect {}, actual {}".
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.concurrent.Future;
+
+              class ShadowStatement {
+                  void reportMismatch(String method, String reason) {}
+                  void reportMismatch(String method, String sql, String reason) {}
+
+                  int executeUpdate(String sql, Future<Integer> shadowFuture, int original) throws Exception {
+                      int shadow = shadowFuture.get();
+                      if (original != shadow) {
+                          reportMismatch("execute", sql, String.format("expect {}, actual {}", original, shadow));
+                      }
+                      return original;
+                  }
+
+                  boolean getMoreResults(Future<Boolean> shadowFuture, boolean original) throws Exception {
+                      boolean shadow = shadowFuture.get();
+                      if (original != shadow) {
+                          reportMismatch("getMoreResults", String.format("expect {}, actual {}", original, shadow));
+                      }
+                      return original;
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
@@ -133,6 +133,76 @@ class FixStringFormatExpressionsTest implements RewriteTest {
     }
 
     @Test
+    void doNotStripArgsWithUnresolvedPlaceholders() {
+        // `{}` is SLF4J-style placeholder syntax, not a `String#format` conversion specifier. A
+        // format string using it has zero real `%` specifiers, so the naive fix treats `original`
+        // and `shadow` as dead code and deletes them -- but they're almost certainly meant to be
+        // substituted, just via the wrong API. Leaving the call alone keeps the underlying bug
+        // (wrong templating syntax) visible instead of erasing the evidence of it.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  static void reportMismatch(String label, String message) {}
+
+                  static void test(int original, int shadow) {
+                      if (original != shadow) {
+                          reportMismatch("check", String.format("expect {}, actual {}", original, shadow));
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotStripArgsWithUnresolvedPlaceholdersFormatted() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  static void reportMismatch(String label, String message) {}
+
+                  static void test(int original, int shadow) {
+                      if (original != shadow) {
+                          reportMismatch("check", "expect {}, actual {}".formatted(original, shadow));
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void newlineStillReplacedWhenArgsAreNotStripped() {
+        // The `{}`-unresolved-placeholder guard only skips the arg-trimming step; the unrelated
+        // newline-to-%n replacement above it must still apply.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  static void test(int original, int shadow) {
+                      String s = String.format("expect {}\\nactual {}", original, shadow);
+                  }
+              }
+              """,
+            """
+              class T {
+                  static void test(int original, int shadow) {
+                      String s = String.format("expect {}%nactual {}", original, shadow);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void textBlockWithNewlinesShouldNotBeModified() {
         // Text blocks contain actual newline characters in their value, not \n escape sequences.
         // The recipe should not modify these since changing actual newlines to %n in text blocks

--- a/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FixStringFormatExpressionsTest.java
@@ -82,6 +82,83 @@ class FixStringFormatExpressionsTest implements RewriteTest {
     }
 
     @Test
+    void doNotStripArgsWithNoSpecifiersEvenWithoutPlaceholders() {
+        // This recipe only trims arguments it has positive evidence are unused -- trailing args
+        // beyond what matched `%` specifiers actually consume. With zero specifiers matched, there
+        // is no such evidence either way, so the call is left alone -- even though these args have
+        // no `{}` (or any other) placeholder syntax suggesting an alternative explanation. Previously
+        // this recipe trimmed to zero args in this case; that was true dead-code cleanup sometimes,
+        // but indistinguishable from cases where deleting was actively harmful (see the `{}` tests
+        // below), so this recipe no longer guesses either way when it has no real specifier evidence.
+        //
+        // This also happens to resolve a separate latent bug: for `.formatted()`, the trim step's
+        // `i == 0` keep-clause assumed index 0 of the argument list is always the format string --
+        // true for `String.format(fmt, args...)`, but false for `"fmt".formatted(args...)`, where
+        // index 0 is the first real argument. That previously forced one argument to survive even
+        // when zero should remain. Bailing out here whenever no specifier matched means that branch
+        // (finalArgIndex == 0, only reachable with zero matches) is never reached at all.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  static {
+                      String s = String.format("no specifiers here", 1, 2);
+                      String f = "no specifiers here".formatted(1, 2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void stripArgsWhenRealSpecifierPresentDespiteUnresolvedPlaceholder() {
+        // Bailing out only applies when ZERO real specifiers matched. If a real specifier is
+        // present anywhere, the format string is far more likely a genuine (if imperfect) Java
+        // format call, so the normal trim behavior should still apply -- the `{}` here is
+        // ambiguous, not a strong enough signal on its own to block trimming.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  static {
+                      String s = String.format("count: %d, and {}", 1, 2);
+                  }
+              }
+              """,
+            """
+              class T {
+                  static {
+                      String s = String.format("count: %d, and {}", 1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotStripArgsWithUnresolvedPlaceholdersAndLiteralPercent() {
+        // `%%` (a literal percent sign), like `%n`, does not consume an argument. A format string
+        // with only `%%` and `{}` tokens still has zero *argument-consuming* specifiers, so the
+        // bailout must still fire and preserve the arguments.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  static {
+                      String s = String.format("100%% {} sure, actual {}", 1, 2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void allArgsAreUsed() {
         rewriteRun(
           //language=java
@@ -134,11 +211,11 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void doNotStripArgsWithUnresolvedPlaceholders() {
-        // `{}` is SLF4J-style placeholder syntax, not a `String#format` conversion specifier. A
-        // format string using it has zero real `%` specifiers, so the naive fix treats `original`
-        // and `shadow` as dead code and deletes them -- but they're almost certainly meant to be
-        // substituted, just via the wrong API. Leaving the call alone keeps the underlying bug
-        // (wrong templating syntax) visible instead of erasing the evidence of it.
+        // Real-world motivating case: `{}` is SLF4J-style placeholder syntax, not a `String#format`
+        // conversion specifier, so this format string has zero real `%` specifiers. Previously this
+        // recipe treated `original`/`shadow` as dead code and deleted them -- but they're almost
+        // certainly meant to be substituted, just via the wrong API. Leaving the call alone keeps
+        // the underlying bug (wrong templating syntax) visible instead of erasing the evidence of it.
         rewriteRun(
           //language=java
           java(
@@ -179,7 +256,7 @@ class FixStringFormatExpressionsTest implements RewriteTest {
 
     @Test
     void newlineStillReplacedWhenArgsAreNotStripped() {
-        // The `{}`-unresolved-placeholder guard only skips the arg-trimming step; the unrelated
+        // The zero-specifiers-matched bailout only skips the arg-trimming step; the unrelated
         // newline-to-%n replacement above it must still apply.
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What's changed?                                                                                                                                                                                         
                                                                                                                                                                                                             
  `FixStringFormatExpressions` now skips its arg-trimming step entirely                                                                                                                                      
  whenever zero `%` conversion specifiers matched in the format string —                                                                                                                                     
  not just when the string happens to contain `{}` tokens. Previously it                                                                                                                                     
  deleted every trailing argument in that case, treating them as dead                                                                                                                                        
  code. Also fixes a related counting bug: `%n` and `%%` don't consume                                                                                                                                       
  an argument in `java.util.Formatter`, but the existing loop counted                                                                                                                                        
  them as if they did.                                                                                                                                                                                       
                                                                                                                                                                                                             
  ## What's your motivation?                                                                                                                                                                                 
                                                                                                                                                                                                             
  Deleting arguments from a format string with zero real specifiers is                                                                                                                                       
  only safe if you're sure they're actually unused. That's not a safe                                                                                                                                        
  assumption when the string uses a different templating convention                                                                                                                                          
  entirely — most commonly SLF4J-style `{}` placeholders mistakenly used                                                                                                                                     
  with `String#format` instead of a logger:                                                                                                                                                                  
                                                                                                                                                                                                             
      String.format("expect {}, actual {}", original, shadow)                                                                                                                                                
      → String.format("expect {}, actual {}")   // args silently dropped                                                                                                                                     
                                                                                                                                                                                                             
  The calling code already had a bug (wrong placeholder syntax for                                                                                                                                           
  `String#format`), but this recipe made it worse: it doesn't fix the                                                                                                                                        
  real problem, and it deletes the evidence (the arguments) that would                                                                                                                                       
  help a reviewer notice something's off. Real-world case that surfaced                                                                                                                                      
  this: a shadow-traffic mismatch reporter whose diagnostic messages all                                                                                                                                     
  degraded to the literal string `"expect {}, actual {}"`, with no                                                                                                                                           
  values, after this recipe ran on it.                   
  
  ## Anything in particular you'd like reviewers to focus on?                                                                                                                                                
                                                                                                                                                                                                             
  Two things beyond the headline fix:                                                                                                                                                                        
                                                                                                                                                                                                             
  1. The `%n`/`%%` counting fix — without it, a format string mixing                                                                                                                                         
     `%n` (e.g. from this recipe's own newline replacement) with a                                                                                                                                           
     zero-specifier string would be miscounted as having a real                                                                                                                                              
     specifier on a *later* recipe cycle, silently defeating the main                                                                                                                                        
     fix. Caught by the `newlineStillReplacedWhenArgsAreNotStripped`                                                                                                                                         
     test.                                                                                                                                                                                                   
  2. As a side effect, this also resolves a separate latent bug in the                                                                                                                                       
     `.formatted()` path: the trim step's `i == 0` keep-clause assumed                                                                                                                                       
     index 0 of the argument list is always the format string, true for                                                                                                                                      
     `String.format(fmt, args...)` but false for                                                                                                                                                             
     `"fmt".formatted(args...)` (where index 0 is the first real                                                                                                                                             
     argument) — that previously forced one argument to survive even                                                                                                                                         
     when zero should remain. That branch is only reachable when zero                                                                                                                                        
     specifiers matched, which is now always skipped, so no separate                                                                                                                                         
     fix was needed. Covered by                                                                                                                                                                              
     `doNotStripArgsWithNoSpecifiersEvenWithoutPlaceholders`.                                                                                                                                                
                                                                                                                                                                                                             
  ## Anyone you would like to review specifically?                                                                                                                                                           
                                                                                                                                                                                                             
  No specific request — open to whoever's around.               
  
  
  ## Have you considered any alternatives or workarounds?                                                                                                                                                    
                                                                                                                                                                                                             
  Yes, two:                                                                                                                                                                                                  
                                                                                                                                                                                                             
  - A narrower fix that only special-cased `{}`-style tokens specifically                                                                                                                                    
    (detect SLF4J placeholder syntax via a dedicated regex), rather than                                                                                                                                     
    bailing out on *any* zero-specifier case. Went with the broader                                                                                                                                          
    version instead: it's simpler (no new pattern needed), and it's                                                                                                                                          
    robust to other broken-templating conventions we haven't thought of                                                                                                                                      
    (e.g. `MessageFormat`-style `{0}`), not just SLF4J. The tradeoff is                                                                                                                                      
    it also stops trimming genuinely dead args when there's no                                                                                                                                               
    placeholder-like syntax at all (covered by                                                                                                                                                               
    `doNotStripArgsWithNoSpecifiersEvenWithoutPlaceholders`) — a                                                                                                                                             
    reasonable cost for not having to guess.                                                                                                                                                                 
  - Disabling the whole recipe as a workaround downstream, which is what                                                                                                                                     
    prompted finding this in the first place. Fixing it here is                                                                                                                                              
    obviously preferable.                                                                                                                                                                                    
                                                                                                                                                                                                             
  ## Any additional context                                                                                                                                                                                  
                                                                                                                                                                                                             
  Full module suite: 2145 tests, 0 regressions from this change (1                                                                                                                                           
  pre-existing failure in                                                                                                                                                                                    
  `AllBranchesIdenticalTest.collapseIdenticalBranchesPython`, a local                                                                                                                                        
  Python-toolchain environment issue unrelated to this change).                                                                                                                                              
                                                                                                                                                                                                             
  ### Checklist                                                                                                                                                                                              
  - [x] I've added unit tests to cover both positive and negative cases                                                                                                                                      
  - [x] I've read and applied the recipe conventions and best practices                                                                                                                                      
  - [x] I've used the IntelliJ IDEA auto-formatter on affected files 
