### PR TITLE
UnnecessaryExplicitTypeArguments: retain load-bearing witness in argument position on instance methods too

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -63,8 +63,8 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                             return m;
                         }
                     } else {
-                        // This invocation is an argument of the enclosing invocation.
-                        if (shouldRetainOnStaticMethod(methodType)) {
+                        // As above, retain unless inferable from this call's own arguments (static or not).
+                        if (!canInferTypeArgumentsFromArguments(methodType)) {
                             return m;
                         }
                         // Cannot remove type parameters if it would introduce ambiguity about which method should be called
@@ -151,13 +151,6 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                     return null;
                 }
                 return samReturn;
-            }
-
-            private boolean shouldRetainOnStaticMethod(JavaType.Method methodType) {
-                // Without a target type, removing the explicit type arguments of a static method can break
-                // overload resolution in the enclosing call when the type variables are not inferable from
-                // the call's own arguments.
-                return methodType.hasFlags(Flag.Static) && !canInferTypeArgumentsFromArguments(methodType);
             }
 
             private boolean canInferTypeArgumentsFromArguments(JavaType.Method methodType) {

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -246,6 +246,75 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void retainsWitnessOnInstanceMethodPassedAsArgumentToGenericMethod() {
+        // STATE_VALUE isn't inferable from source()'s (zero) args or from of()'s target type.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              interface Transition {
+                  <STATE_VALUE> STATE_VALUE source();
+              }
+
+              class Pair<STATE_VALUE extends Enum<STATE_VALUE>> {
+                  static <STATE_VALUE extends Enum<STATE_VALUE>> Pair<STATE_VALUE> of(STATE_VALUE a, STATE_VALUE b) {
+                      return new Pair<>();
+                  }
+              }
+
+              class Test<STATE_VALUE extends Enum<STATE_VALUE>> {
+                  Pair<STATE_VALUE> test(Transition t, STATE_VALUE b) {
+                      return Pair.of(t.<STATE_VALUE>source(), b);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removesWitnessOnInstanceMethodArgumentWhenInferableFromOwnArguments() {
+        // Unlike above, T is inferable from identity()'s own argument, so it's still removable.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Holder {
+                  <T> T identity(T value) {
+                      return value;
+                  }
+              }
+
+              class Test {
+                  void accept(Object o) {
+                  }
+
+                  void test(Holder h) {
+                      accept(h.<String>identity("x"));
+                  }
+              }
+              """,
+            """
+              class Holder {
+                  <T> T identity(T value) {
+                      return value;
+                  }
+              }
+
+              class Test {
+                  void accept(Object o) {
+                  }
+
+                  void test(Holder h) {
+                      accept(h.identity("x"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class StaticMethods {
         static final SourceSpecs GENERIC_CLASS_SOURCE = java(


### PR DESCRIPTION
## What's changed?                                                                                                                                                    
  Generalizes `UnnecessaryExplicitTypeArguments`'s argument-position guard to retain a type witness on instance methods too, not just static ones, when the witness's  type variables aren't inferable from the call's own arguments. Removes the now-redundant `shouldRetainOnStaticMethod` helper in favor of applying              `canInferTypeArgumentsFromArguments` uniformly — the same check already used for the sibling select-position branch.                                                  
                                                                                                                                                                        
## What's your motivation?                                                                                                                                            
The argument-position branch only guarded static methods (via `shouldRetainOnStaticMethod`) against removing a witness whose type variables aren't inferable from the call's own arguments. Instance methods used as arguments skipped that guard entirely, so a witness like `t.<STATE_VALUE>source()` passed to a generic static factory `Transition.of(...)` got stripped even though `STATE_VALUE` has no argument to infer it from and the factory itself provides no target type, leaving `STATE_VALUE`   unresolved.                                                                                                                                                           
                                                                                                                                                                        
We hit this piloting the recipe against a state-machine interpreter with recursive/self-bounded generics (`StateMachineInterpreter<STATE_VALUE extends  Enum<STATE_VALUE>, ...>`), where it silently broke compilation.                                                                                                       
                                                                                                                                                                        
## Anything in particular you'd like reviewers to focus on?                                                                                                           
 Whether folding the argument-position and select-position branches into one shared check is worth a larger refactor — they both now reduce to "retain unless inferable from the call's own arguments" and only diverge afterward on the overload-ambiguity check, which is argument-position-only.                                           
                                                                                                                                                                        
## Anyone you would like to review specifically?                                                                                                                      
No specific request — open to whoever's around.                                                                                                                       
                                                      
## Have you considered any alternatives or workarounds?                                                                                                               
Considered keeping `shouldRetainOnStaticMethod`'s name/shape and just widening its condition (adding `|| !isStatic` or similar). Removed it instead since   "static-only" naming became misleading once the check applies to both static and instance methods, and both branches already share `canInferTypeArgumentsFromArguments`.                                                                                                                                 
                                                                                                                                                                        
## Any additional context                                                                                                                                             
Full module suite: 2147 tests, 0 regressions from this change (one pre-existing intermittent failure in `AllBranchesIdenticalTest.collapseIdenticalBranchesPython`,   reproduced independent of this diff — a flaky Python-parser round-trip test unrelated to this recipe). Added both a negative-case test (witness retained, matching the bug) and a positive-case test (witness still removed when inference from the call's own arguments is possible) to make sure the fix doesn't over-correct into blanket  retention.                                                                                                                                                            
                                                                                                                                                                        
  ### Checklist                                                                                                                                                         
  - [x] I've added unit tests to cover both positive and negative cases                                                                                                 
  - [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)         
  - [x] I've used the IntelliJ IDEA auto-formatter on affected files                 