### PR TITLE
Do not remove casts from raw types to their parameterized form

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -114,6 +114,14 @@ public class RemoveRedundantTypeCast extends Recipe {
                     return visited;
                 }
 
+                // A cast from a raw type to its parameterized form (e.g. `(Box<?>) raw`) re-enters the
+                // generic type system; without it every member accessed on the expression is erased.
+                JavaType.FullyQualified exprFullyQualified = TypeUtils.asFullyQualified(expressionType);
+                if (TypeUtils.asParameterized(castType) != null && exprParameterized == null &&
+                        exprFullyQualified != null && !exprFullyQualified.getTypeParameters().isEmpty()) {
+                    return visited;
+                }
+
                 JavaType targetType = null;
                 if (castType.equals(expressionType)) {
                     targetType = castType;

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -842,6 +842,33 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/952")
+    @Test
+    void doNotRemoveCastFromRawToWildcard() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              class Box<T> {
+                  List<String> items() {
+                      return List.of();
+                  }
+              }
+
+              class Test {
+                  @SuppressWarnings("rawtypes")
+                  void test(Box raw) {
+                      var typed = (Box<?>) raw;
+                      typed.items().forEach(s -> s.trim());
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void doNotRemoveObjectCastOnGenericMethodCallWithOverloads() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #952

`RemoveRedundantTypeCast` removed `(Box<?>) raw` where `raw` has the raw type `Box`. The two types are erasure-equivalent at runtime, but the cast is required at compile time: raw-type erasure infects every member accessed on `raw`, so `raw.items()` returns raw `List` while `((Box<?>) raw).items()` returns `List<String>`. Removing the cast broke compilation of downstream calls.

Now the cast is preserved when the cast type is parameterized and the expression type is a raw use of a generic type.