### PR TITLE
Pre-install the JavaScript RPC npm package before running tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,9 @@
 @file:Suppress("UnstableApiUsage")
+
+import java.io.InputStream
+import org.gradle.process.ExecOperations
+import org.gradle.kotlin.dsl.support.serviceOf
+
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
     id("org.openrewrite.build.moderne-source-available-license") version "latest.release"
@@ -47,8 +52,41 @@ dependencies {
     testRuntimeOnly("com.google.code.findbugs:jsr305:latest.release")
 }
 
+// The TypeScript tests spawn `npx --package=@openrewrite/rewrite@<version> rewrite-rpc`, and the RPC
+// process is shut down between test classes. On a cold npx cache each of those starts its own install
+// into the same `~/.npm/_npx` directory, and the resulting overlap leaves the package half-written, so
+// the tests fail with "RPC process shut down early". Installing once up front keeps every spawn a
+// cache hit.
+val warmJavaScriptRpcCache by tasks.registering {
+    description = "Installs the npm package that the JavaScript RPC tests spawn, so they never race on a cold npx cache."
+    val rewriteJavaScriptJars = configurations.named("testRuntimeClasspath")
+        .map { classpath -> classpath.filter { it.name.startsWith("rewrite-javascript-") } }
+    val marker = layout.buildDirectory.file("tmp/warmJavaScriptRpcCache/version.txt")
+    val npx = if (System.getProperty("os.name").lowercase().contains("windows")) "npx.cmd" else "npx"
+    val execOperations = serviceOf<ExecOperations>()
+
+    inputs.files(rewriteJavaScriptJars)
+    outputs.file(marker)
+
+    doLast {
+        val jar = rewriteJavaScriptJars.get().singleOrNull() ?: return@doLast
+        val version = zipTree(jar).matching { include("META-INF/rewrite-javascript-version.txt") }
+            .singleFile.readText().trim()
+        val result = execOperations.exec {
+            commandLine(npx, "--yes", "--package=@openrewrite/rewrite@$version", "rewrite-rpc")
+            standardInput = InputStream.nullInputStream()
+            isIgnoreExitValue = true
+        }
+        if (result.exitValue != 0) {
+            logger.warn("Could not pre-install @openrewrite/rewrite@$version; JavaScript RPC tests may be flaky.")
+        }
+        marker.get().asFile.writeText(version)
+    }
+}
+
 tasks.withType<Test> {
     jvmArgs("-Xmx1g", "-Xms512m")
+    dependsOn(warmJavaScriptRpcCache)
 }
 
 tasks.withType<JavaCompile> {


### PR DESCRIPTION
## What's changed

`test` now depends on a `warmJavaScriptRpcCache` task that runs `npx --yes --package=@openrewrite/rewrite@<version> rewrite-rpc` once, using the version embedded in the resolved `rewrite-javascript` jar.

## Why

CI has been failing intermittently for weeks with ~9 TypeScript tests reporting `RPC process shut down early with exit code 1` (also 127 and 217, varying within a single run) — see [run 30564235862](https://github.com/openrewrite/rewrite-static-analysis/actions/runs/30564235862), and previously 2026-07-15, 07-16, 07-19 and 07-28. It never reproduced locally.

`JavaScriptRewriteRpc` spawns `npx --package=@openrewrite/rewrite@<version> rewrite-rpc`, and the RPC process is shut down between test classes. Shimming `npx` on a runner showed four overlapping invocations in seven seconds, each triggering its own `npm warn exec The following package was not found and will be installed`, none of them reaching an exit:

```
=== 17:54:41.318702951 pid=3015 argv: --package=@openrewrite/rewrite@8.89.0-20260730-165737 rewrite-rpc
=== 17:54:44.022766233 pid=3053 argv: --package=@openrewrite/rewrite@8.89.0-20260730-165737 rewrite-rpc
=== 17:54:47.525195532 pid=3079 argv: --package=@openrewrite/rewrite@8.89.0-20260730-165737 rewrite-rpc
=== 17:54:48.681182317 pid=3097 argv: --package=@openrewrite/rewrite@8.89.0-20260730-165737 rewrite-rpc
```

An install takes ~3s, so on a cold cache these overlap in the same `~/.npm/_npx/<hash>` directory and leave it half-written — one symptom being `sh: 1: rewrite-rpc: Permission denied` (exit 127) from a bin symlink whose target has not been chmod'ed yet. Locally the cache is always warm, so the install never happens and the race never opens.

## Testing

On a clean `ubuntu-latest` runner, running the nine TypeScript test classes:

- without this change: all nine fail
- with this change: all nine pass

## Follow-up

- The underlying race is in `JavaScriptRewriteRpc`/`RewriteRpcProcessManager` upstream — any consumer with TypeScript tests can hit it, and the discarded subprocess stderr is what made it undiagnosable for so long (cf. openrewrite/rewrite#8343). This change works around it here.