### PR TITLE
Fix NPE in NestedEnumsAreNotStatic when class body is null

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NestedEnumsAreNotStatic.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NestedEnumsAreNotStatic.java
@@ -66,6 +66,7 @@ public class NestedEnumsAreNotStatic extends Recipe {
                 return cd.getKind() == J.ClassDeclaration.Kind.Type.Enum &&
                         cd.getType() != null &&
                         cd.getType().getOwningClass() != null &&
+                        cd.getBody() != null &&
                         J.Modifier.hasModifier(cd.getModifiers(), Static);
             }
         });


### PR DESCRIPTION
## What's changed?
Added a null check for `ClassDeclaration.getBody()` in `NestedEnumsAreNotStatic`'s `shouldRemoveStaticModifierFromClass` method.

## What's your motivation?
Previously, when a class declaration's body was null, the recipe would still call `maybeAutoFormat`, causing a `NullPointerException` deep in `SpacesVisitor.visitClassDeclaration` (`getBody().getPrefix()` on a null body).

- Fixes #796

## Anything in particular you'd like reviewers to focus on?
This is a defensive fix based on the reported stack trace rather than a literal reproduction, since the null body appears to stem from a parser edge case that's difficult to construct directly in a test. Ran the full existing `NestedEnumsAreNotStaticTest` suite — all tests pass.

## Anyone you would like to review specifically?


## Have you considered any alternatives or workarounds?
Could alternatively guard inside `maybeAutoFormat` or `SpacesVisitor` itself, but scoping the fix to this recipe felt safer and more targeted to the reported issue.

## Any additional context


### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the recipe conventions and best practices
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files