### PR TITLE
UnnecessaryExplicitTypeArguments: retain witness for a return-only ty…

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -22,8 +22,9 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class UnnecessaryExplicitTypeArguments extends Recipe {
 
@@ -95,13 +96,20 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                     }
                     inferredType = ((NameTree) enclosing).getType();
                 } else if (enclosing instanceof J.Return) {
-                    Object e = getCursor().dropParentUntil(p -> p instanceof J.MethodDeclaration || p instanceof J.Lambda || Cursor.ROOT_VALUE.equals(p)).getValue();
+                    Cursor enclosingFnCursor = getCursor().dropParentUntil(p -> p instanceof J.MethodDeclaration || p instanceof J.Lambda || Cursor.ROOT_VALUE.equals(p));
+                    Object e = enclosingFnCursor.getValue();
                     if (e instanceof J.MethodDeclaration) {
                         J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) e;
                         if (methodDeclaration.getReturnTypeExpression() != null) {
                             inferredType = methodDeclaration.getReturnTypeExpression().getType();
                         }
                     } else if (e instanceof J.Lambda) {
+                        // A lambda passed as a call argument has the same inference circularity as the
+                        // select/argument branches above; guard it the same way.
+                        Object lambdaEnclosing = enclosingFnCursor.getParentTreeCursor().getValue();
+                        if (lambdaEnclosing instanceof J.MethodInvocation && !canInferTypeArgumentsFromArguments(methodType)) {
+                            return m;
+                        }
                         inferredType = getLambdaReturnType(((J.Lambda) e).getType());
                     }
                 }
@@ -158,13 +166,52 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                 if (methodType.getParameterTypes().isEmpty()) {
                     return false;
                 }
-                List<String> formalTypeNames = new ArrayList<>(methodType.getDeclaredFormalTypeNames());
-                methodType.getParameterTypes().stream()
-                        .filter(p -> p instanceof JavaType.Parameterized)
-                        .flatMap(p -> ((JavaType.Parameterized) p).getTypeParameters().stream())
-                        .filter(t -> t instanceof JavaType.GenericTypeVariable)
-                        .forEach(it -> formalTypeNames.remove(((JavaType.GenericTypeVariable) it).getName()));
-                return formalTypeNames.isEmpty();
+                // methodType is already substituted (no GenericTypeVariable left) and
+                // getDeclaredFormalTypeNames() is unreliable; look up the real declared signature instead.
+                JavaType.Method declared = findDeclaredSignature(methodType);
+                if (declared == null) {
+                    return false;
+                }
+                Set<String> returnTypeVariables = new HashSet<>();
+                collectGenericTypeVariableNames(declared.getReturnType(), returnTypeVariables);
+                if (returnTypeVariables.isEmpty()) {
+                    return true;
+                }
+                Set<String> parameterTypeVariables = new HashSet<>();
+                for (JavaType paramType : declared.getParameterTypes()) {
+                    collectGenericTypeVariableNames(paramType, parameterTypeVariables);
+                }
+                return parameterTypeVariables.containsAll(returnTypeVariables);
+            }
+
+            private JavaType.@Nullable Method findDeclaredSignature(JavaType.Method methodType) {
+                if (!(methodType.getDeclaringType() instanceof JavaType.Class)) {
+                    return null;
+                }
+                JavaType.Class declaringClass = (JavaType.Class) methodType.getDeclaringType();
+                JavaType.Method match = null;
+                for (JavaType.Method candidate : declaringClass.getMethods()) {
+                    if (candidate.getName().equals(methodType.getName()) &&
+                            candidate.getParameterTypes().size() == methodType.getParameterTypes().size()) {
+                        if (match != null) {
+                            return null; // ambiguous same-arity overload
+                        }
+                        match = candidate;
+                    }
+                }
+                return match;
+            }
+
+            private void collectGenericTypeVariableNames(@Nullable JavaType type, Set<String> names) {
+                if (type instanceof JavaType.GenericTypeVariable) {
+                    names.add(((JavaType.GenericTypeVariable) type).getName());
+                } else if (type instanceof JavaType.Parameterized) {
+                    for (JavaType typeParameter : ((JavaType.Parameterized) type).getTypeParameters()) {
+                        collectGenericTypeVariableNames(typeParameter, names);
+                    }
+                } else if (type instanceof JavaType.Array) {
+                    collectGenericTypeVariableNames(((JavaType.Array) type).getElemType(), names);
+                }
             }
         });
     }

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -217,6 +217,60 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
     }
 
     @Test
+    void retainsWitnessOnGenericInstanceMethodWithConcreteArgumentsAsSelect() {
+        // T is method-level but appears in neither argument, so it's not inferable from them.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Map;
+              import java.util.Optional;
+
+              class PayloadValue {}
+              class Datasource {}
+
+              class Handler {
+                  <T> Optional<T> getPayloadOptionalValue(Map<String, PayloadValue> map, Datasource datasource) {
+                      return Optional.empty();
+                  }
+
+                  String test(Map<String, PayloadValue> map, Datasource datasource) {
+                      return this.<String>getPayloadOptionalValue(map, datasource).orElse(null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainsWitnessOnNoArgStaticMethodReturnedFromBlockBodiedLambdaArgument() {
+        // Optional.empty() takes no args, and the lambda itself is a .map() argument, so
+        // neither provides an independent target type to infer T from.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+              import java.util.Optional;
+              import java.util.stream.Stream;
+
+              class Test {
+                  Stream<Optional<List<String>>> test(Stream<String> contents) {
+                      return contents.map(content -> {
+                          if (content == null) {
+                              return Optional.<List<String>>empty();
+                          }
+                          return Optional.of(List.of(content));
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void retainsWitnessWhenResultIsSelectOfMethodInvocation() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What's changed?                                                                                                                                                                                                                       
                                                                                                                                                                                                                                        
  UnnecessaryExplicitTypeArguments no longer trusts getDeclaredFormalTypeNames() to decide whether a witness is inferable from a call's own arguments. Instead it looks the method back up on its declaring type to recover its real,   
  unsubstituted signature, then checks whether every generic variable in that signature's return type also appears in one of its parameter types. The same check is now also applied to the J.Return -> J.Lambda branch, which          
  previously had no arguments-based guard at all.                                                                                                                                                                                       
                                                                                                                                                                                                                                        
  ## What's your motivation?                                                                                                                                                                                                               
                                                                                                                                                                                                                                        
  getDeclaredFormalTypeNames() comes back empty whenever a method type variable is used only inside the return type (e.g. <T> Optional<T> get(Map<String, V> m, Datasource d)), not just as a bare parameter. An empty list trivially   
  satisfies isEmpty(), so the old check concluded "inferable" and stripped the witness even though neither argument carries T anywhere — breaking compilation at the call site.                                                         
                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                        
##  Anything in particular you'd like reviewers to focus on?                                                                                                                                                                              
                                                                                                                                                                                                                                        
  findDeclaredSignature matches by name + parameter count and bails out (retains the witness) on any ambiguity — same-arity overloads, or a declaring type that isn't a JavaType.Class. Worth double-checking that's conservative       
  enough, and whether there's a more direct way to recover a method's unsubstituted declaration than re-looking it up via getMethods().                                                                                                 
                                                                                                                                                                                                                                        
  ## Anyone you would like to review specifically?                                                                                                                                                                                         
                                                                                                                                                                                                                                        
  No specific request — open to whoever's around.                                                                                                                                                                                       
                                                                                                                                                                                                                                        
   ## Have you considered any alternatives or workarounds?                                                                                                                                                                                  
                                                                                                                                                                                                                                        
  Tried scanning the call-site methodType's own parameter types for any GenericTypeVariable instead of re-deriving the declared signature. Doesn't work: methodType is already substituted for this call site, so parameter types are   
  concrete too (e.g. identity(T value) shows up as identity(String value)), leaving nothing to scan.                                                                                                                                    
                                                                                                                                                                                                                                        
 ## Any additional context                                                                                                                                                                                                                
                                                                                                                                                                                                                                        
  Two new tests reproduce both call sites and fail against the old code. Full module suite: 2198 tests, 0 regressions (2 pre-existing, unrelated Python-RPC infra failures in CollapsibleIfStatementsTest/MergeIdenticalBranchesTest).  
                                                                                                                                                                                                                                        
## Checklist                                                                                                                                                                                                                             
                                                                                                                                                                                                                                        
  - [x] I've added unit tests to cover both positive and negative cases                                                                                                                                                                 
  - [x] I've read and applied the recipe conventions and best practices                                                                                                                                                                 
  - [x] I've used the IntelliJ IDEA auto-formatter on affected files 