### PR TITLE
Do not delete expressions that may have side effects

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/AllBranchesIdentical.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AllBranchesIdentical.java
@@ -21,6 +21,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.SemanticallyEqual;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static org.openrewrite.staticanalysis.SideEffects.mayHaveSideEffects;
 
 @Getter
 public class AllBranchesIdentical extends Recipe {
@@ -56,10 +58,12 @@ public class AllBranchesIdentical extends Recipe {
                 }
 
                 List<Statement> bodies = new ArrayList<>();
+                List<Expression> conditions = new ArrayList<>();
                 J.If current = if__;
 
                 while (current != null) {
                     bodies.add(current.getThenPart());
+                    conditions.add(current.getIfCondition().getTree());
                     if (current.getElsePart() == null) {
                         return if__;
                     }
@@ -75,6 +79,13 @@ public class AllBranchesIdentical extends Recipe {
                 Statement first = bodies.get(0);
                 for (int i = 1; i < bodies.size(); i++) {
                     if (!SemanticallyEqual.areEqual(first, bodies.get(i))) {
+                        return if__;
+                    }
+                }
+
+                // Collapsing the chain stops evaluating the conditions, which is only safe when they are pure
+                for (Expression condition : conditions) {
+                    if (mayHaveSideEffects(condition)) {
                         return if__;
                     }
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/AvoidBoxedBooleanExpressions.java
+++ b/src/main/java/org/openrewrite/staticanalysis/AvoidBoxedBooleanExpressions.java
@@ -59,7 +59,8 @@ public class AvoidBoxedBooleanExpressions extends Recipe {
             @Override
             public J visitUnary(J.Unary unary, ExecutionContext ctx) {
                 J.Unary un = (J.Unary) super.visitUnary(unary, ctx);
-                if (J.Unary.Type.Not == un.getOperator() && TypeUtils.isOfClassType(un.getExpression().getType(), "java.lang.Boolean")) {
+                if (J.Unary.Type.Not == un.getOperator() && TypeUtils.isOfClassType(un.getExpression().getType(), "java.lang.Boolean") &&
+                        isControlExpression(unary)) {
                     return JavaTemplate.apply("Boolean.FALSE.equals(#{any(java.lang.Boolean)})",
                             updateCursor(un), un.getCoordinates().replace(), un.getExpression());
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveDuplicateConditions.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveDuplicateConditions.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static org.openrewrite.staticanalysis.SideEffects.mayHaveSideEffects;
 
 @Getter
 public class RemoveDuplicateConditions extends Recipe {
@@ -74,6 +75,14 @@ public class RemoveDuplicateConditions extends Recipe {
                     }
                     Statement elseBody = current.getElsePart().getBody();
                     current = elseBody instanceof J.If ? (J.If) elseBody : null;
+                }
+
+                // A later condition is only unreachable if every condition up to it evaluates the same way each
+                // time; a side effect anywhere in the chain can change that, so require them all to be pure
+                for (Expression condition : conditions) {
+                    if (mayHaveSideEffects(condition)) {
+                        return if__;
+                    }
                 }
 
                 // Find and remove branches with duplicate conditions

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnconditionalValueOverwrite.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnconditionalValueOverwrite.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static org.openrewrite.staticanalysis.SideEffects.mayHaveSideEffects;
 
 @Getter
 public class RemoveUnconditionalValueOverwrite extends Recipe {
@@ -78,12 +79,35 @@ public class RemoveUnconditionalValueOverwrite extends Recipe {
                     }
 
                     if (SemanticallyEqual.areEqual(key, nextKey) &&
-                        SemanticallyEqual.areEqual(receiver, nextReceiver)) {
+                        SemanticallyEqual.areEqual(receiver, nextReceiver) &&
+                        !discardsSideEffects(stmt)) {
                         //noinspection DataFlowIssue
                         return null;
                     }
                     return stmt;
                 }));
+            }
+
+            /**
+             * The overwritten call is dead, but the expressions it evaluates on the way are not: dropping the
+             * statement also drops the receiver, the key and the value it would have computed.
+             */
+            private boolean discardsSideEffects(Statement stmt) {
+                if (stmt instanceof J.Assignment) {
+                    J.Assignment assignment = (J.Assignment) stmt;
+                    return mayHaveSideEffects(assignment.getVariable()) ||
+                           mayHaveSideEffects(assignment.getAssignment());
+                }
+                J.MethodInvocation method = (J.MethodInvocation) stmt;
+                if (mayHaveSideEffects(method.getSelect())) {
+                    return true;
+                }
+                for (Expression argument : method.getArguments()) {
+                    if (mayHaveSideEffects(argument)) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             private Expression extractMapPutKey(Statement stmt) {

--- a/src/main/java/org/openrewrite/staticanalysis/SideEffects.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SideEffects.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Whether evaluating an expression might do something observable beyond producing its value. Recipes that
+ * delete an expression, or that stop evaluating one, are only correct when the answer is {@code false}.
+ * <p>
+ * Deliberately conservative: any method invocation, constructor call, assignment or increment counts, since
+ * whether those are pure cannot be decided from the LST alone. {@link org.openrewrite.java.tree.Expression#getSideEffects()}
+ * is not used here because it reports only the side effects of the expression's own node type, and so misses
+ * those nested inside a ternary or a lambda.
+ */
+final class SideEffects {
+
+    private SideEffects() {
+    }
+
+    static boolean mayHaveSideEffects(@Nullable J tree) {
+        if (tree == null) {
+            return false;
+        }
+        return new JavaIsoVisitor<AtomicBoolean>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean result) {
+                result.set(true);
+                return method;
+            }
+
+            @Override
+            public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean result) {
+                result.set(true);
+                return assignment;
+            }
+
+            @Override
+            public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp, AtomicBoolean result) {
+                result.set(true);
+                return assignOp;
+            }
+
+            @Override
+            public J.Unary visitUnary(J.Unary unary, AtomicBoolean result) {
+                switch (unary.getOperator()) {
+                    case PreIncrement:
+                    case PreDecrement:
+                    case PostIncrement:
+                    case PostDecrement:
+                        result.set(true);
+                        return unary;
+                    default:
+                        return super.visitUnary(unary, result);
+                }
+            }
+
+            @Override
+            public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean result) {
+                result.set(true);
+                return newClass;
+            }
+
+            @Override
+            public @Nullable J visit(@Nullable Tree t, AtomicBoolean result) {
+                if (result.get()) {
+                    return (J) t;
+                }
+                return super.visit(t, result);
+            }
+        }.reduce(tree, new AtomicBoolean(false)).get();
+    }
+}

--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyRedundantLogicalExpression.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyRedundantLogicalExpression.java
@@ -16,21 +16,18 @@
 package org.openrewrite.staticanalysis;
 
 import lombok.Getter;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.J;
 
 import java.time.Duration;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singleton;
+import static org.openrewrite.staticanalysis.SideEffects.mayHaveSideEffects;
 
 @Getter
 public class SimplifyRedundantLogicalExpression extends Recipe {
@@ -59,7 +56,7 @@ public class SimplifyRedundantLogicalExpression extends Recipe {
                     case BitAnd:
                     case BitOr:
                         if (SemanticallyEqual.areEqual(b.getLeft(), b.getRight()) &&
-                                !hasSideEffects(b.getLeft())) {
+                                !mayHaveSideEffects(b.getLeft())) {
                             return b.getLeft().unwrap().withPrefix(b.getPrefix());
                         }
                         break;
@@ -67,56 +64,6 @@ public class SimplifyRedundantLogicalExpression extends Recipe {
                         break;
                 }
                 return b;
-            }
-
-            private boolean hasSideEffects(J tree) {
-                return new JavaIsoVisitor<AtomicBoolean>() {
-                    @Override
-                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean result) {
-                        result.set(true);
-                        return method;
-                    }
-
-                    @Override
-                    public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean result) {
-                        result.set(true);
-                        return assignment;
-                    }
-
-                    @Override
-                    public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp, AtomicBoolean result) {
-                        result.set(true);
-                        return assignOp;
-                    }
-
-                    @Override
-                    public J.Unary visitUnary(J.Unary unary, AtomicBoolean result) {
-                        switch (unary.getOperator()) {
-                            case PreIncrement:
-                            case PreDecrement:
-                            case PostIncrement:
-                            case PostDecrement:
-                                result.set(true);
-                                return unary;
-                            default:
-                                return super.visitUnary(unary, result);
-                        }
-                    }
-
-                    @Override
-                    public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean result) {
-                        result.set(true);
-                        return newClass;
-                    }
-
-                    @Override
-                    public @Nullable J visit(@Nullable Tree t, AtomicBoolean result) {
-                        if (result.get()) {
-                            return (J) t;
-                        }
-                        return super.visit(t, result);
-                    }
-                }.reduce(tree, new AtomicBoolean(false)).get();
             }
         };
     }

--- a/src/test/java/org/openrewrite/staticanalysis/AllBranchesIdenticalTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AllBranchesIdenticalTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -284,6 +285,32 @@ class AllBranchesIdenticalTest implements RewriteTest {
             """
               def test(a):
                   print("hello")
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenConditionHasSideEffects() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Iterator;
+
+              class Test {
+                  void p(String s) {
+                  }
+
+                  void test(Iterator<String> it) {
+                      if (it.next() != null) {
+                          p("x");
+                      } else {
+                          p("x");
+                      }
+                  }
+              }
               """
           )
         );

--- a/src/test/java/org/openrewrite/staticanalysis/AvoidBoxedBooleanExpressionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/AvoidBoxedBooleanExpressionsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -141,6 +142,24 @@ class AvoidBoxedBooleanExpressionsTest implements RewriteTest {
               class Test {
                   String whatToGet(Boolean forThing1) {
                       return Boolean.TRUE.equals(forThing1) ? "a fish" : "a bowl";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeUnaryOutsideControlExpression() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  boolean test(Boolean b) {
+                      boolean x = !b;
+                      return x;
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveDuplicateConditionsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveDuplicateConditionsTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -282,6 +283,36 @@ class RemoveDuplicateConditionsTest implements RewriteTest {
                   print("has items")
               else:
                   print("empty")
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenConditionHasSideEffects() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  int calls = 0;
+
+                  boolean advance() {
+                      return calls++ == 1;
+                  }
+
+                  void p(String s) {
+                  }
+
+                  void test() {
+                      if (advance()) {
+                          p("a");
+                      } else if (advance()) {
+                          p("b");
+                      }
+                  }
+              }
               """
           )
         );

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveSelfAssignmentTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveSelfAssignmentTest.java
@@ -17,6 +17,9 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -194,6 +197,50 @@ class RemoveSelfAssignmentTest implements RewriteTest {
                   println("after")
               }
               """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeFieldAssignedFromParameterGroovy() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+            """
+              class Test {
+                  private final boolean readOnly
+
+                  Test(boolean readOnly) {
+                      this.readOnly = readOnly
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeFieldAssignedFromParameterWithoutTypeAttribution() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  private final int x;
+
+                  Test(int x) {
+                      this.x = x;
+                  }
+              }
+              """,
+            spec -> spec.mapBeforeRecipe(cu -> (J.CompilationUnit) new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+                    return identifier.withFieldType(null).withType(null);
+                }
+            }.visitNonNull(cu, 0))
           )
         );
     }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnconditionalValueOverwriteTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnconditionalValueOverwriteTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -252,6 +253,63 @@ class RemoveUnconditionalValueOverwriteTest implements RewriteTest {
             """
               function test(map: Map<string, number>) {
                   map.set("key", 2);
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenOverwrittenValueHasSideEffects() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+                  int calls = 0;
+
+                  int register() {
+                      return ++calls;
+                  }
+
+                  void test() {
+                      Map<String, Integer> map = new HashMap<>();
+                      map.put("key", register());
+                      map.put("key", 2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenKeyHasSideEffects() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class Test {
+                  int calls = 0;
+
+                  String key() {
+                      calls++;
+                      return "key";
+                  }
+
+                  void test() {
+                      Map<String, Integer> map = new HashMap<>();
+                      map.put(key(), 1);
+                      map.put(key(), 2);
+                  }
               }
               """
           )


### PR DESCRIPTION
- Addresses the "missing purity guards" half of #953. Draft because the guard is deliberately conservative and how conservative it should be is worth a discussion — see the open question at the bottom.

## The problem

- Four recipes decide to delete a statement, branch or expression using a comparison that says nothing about what the deleted code *does*. When the deleted code has side effects, the output no longer behaves like the input. All four reproduce with complete type information, so they are ordinary missing purity guards rather than instances of the type-attribution bug that #953 originally reported.

| Recipe | Before | After | Effect |
|---|---|---|---|
| `RemoveUnconditionalValueOverwrite` | `m.put("k", register()); m.put("k", 2);` | `m.put("k", 2);` | `register()` is never called |
| `AllBranchesIdentical` | `if (it.next() != null) p("x"); else p("x");` | `p("x");` | the iterator never advances |
| `RemoveDuplicateConditions` | `if (advance()) p("a"); else if (advance()) p("b");` | `if (advance()) p("a");` | prints nothing where the original printed `b` |
| `AvoidBoxedBooleanExpressions` | `boolean x = !b;` | `boolean x = Boolean.FALSE.equals(b);` | a would-be `NullPointerException` becomes `false` |

## The fix

`SimplifyRedundantLogicalExpression` already carried exactly the purity check the other three need, as a private method. This moves it to `SideEffects.mayHaveSideEffects` and shares it:

- **`RemoveUnconditionalValueOverwrite`** — the overwritten `put` really is dead, but the receiver, key and value it evaluates on the way are not, so only those are checked, not the call itself. Otherwise the guard would block every case the recipe exists for.
- **`AllBranchesIdentical`** and **`RemoveDuplicateConditions`** — require every condition in the chain to be pure. For `RemoveDuplicateConditions` it is not enough to check the duplicated condition alone: a side effect in an *intervening* condition can change what the later one evaluates to, which is what makes the branch reachable.
- **`AvoidBoxedBooleanExpressions`** — `visitExpression` already gated its rewrite on `isControlExpression`; `visitUnary` now does too. In an `if` or ternary the substitution preserves meaning, which is the recipe's purpose; in an assignment it does not.

Each recipe gains a `doNotChange…` test built from the reproduction above, plus one for a side-effecting *key* in `RemoveUnconditionalValueOverwrite`. Full suite green (2205 tests).

## Also included

- The first commit adds two `RemoveSelfAssignment` regression tests for openrewrite/rewrite#8333, the upstream fix for the original half of #953. The Groovy one needs no harness setup at all — the Groovy parser passes `null` for `fieldType` at essentially every reference site, so `this.readOnly = readOnly` in a constructor reproduced the deletion directly. That is worth having as a permanent guard, since it does not depend on stripping attribution by hand. Happy to split it into its own PR if you would rather land it separately — it is independent of the purity work.

## Open question

`mayHaveSideEffects` treats *any* method invocation as impure, because purity cannot be decided from the LST alone. That is the safe direction for recipes that delete code, but it does narrow `RemoveDuplicateConditions` in particular: `if (isFoo()) … else if (isFoo()) …` is a common shape for that rule and is now skipped. Every existing test still passes, so nothing currently covered regresses — but if you would rather keep firing on repeated calls and accept the risk, or gate on something narrower, say so and I will adjust.

Two smaller notes:

- `Expression#getSideEffects()` looked like the natural built-in, but it reports only the side effects of the expression's own node type. `J.Ternary` has no override, so `c ? f() : g()` reports as pure. The conservative subtree walk is used instead; the reasoning is in the javadoc on `SideEffects`.
- None of these four recipes is wired into `CommonStaticAnalysis` or any other collection, so exposure today is direct invocation only.
