### PR TITLE
UseLambdaForFunctionalInterface: only convert when the anonymous class implements the SAM

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -130,6 +130,13 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                     return false;
                 }
                 J.MethodDeclaration methodDeclaration = (J.MethodDeclaration) n.getBody().getStatements().get(0);
+                // A lambda can only implement the single abstract method; overriding a `default` method is not equivalent.
+                JavaType.Method declaredMethod = methodDeclaration.getMethodType();
+                if (declaredMethod == null ||
+                    !sam.getName().equals(declaredMethod.getName()) ||
+                    sam.getParameterTypes().size() != declaredMethod.getParameterTypes().size()) {
+                    return false;
+                }
                 // If the functional interface method has type parameters, we can't replace it with a lambda.
                 return methodDeclaration.getTypeParameters() == null || methodDeclaration.getTypeParameters().isEmpty();
             }

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -826,7 +826,7 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
                       Object o = new MapDropdownChoice<String, Integer>(
                             new Supplier<Map<String, Integer>>() {
                                 @Override
-                                public Map<String, Integer> getObject() {
+                                public Map<String, Integer> get() {
                                     Map<String, Integer> choices = Map.of("id1", 1);
                                     return choices.entrySet().stream()
                                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
@@ -835,7 +835,7 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
                       Object o2 = new MapDropdownChoice<String, Integer>(
                             new Supplier<Map<String, Integer>>() {
                                 @Override
-                                public Map<String, Integer> getObject() {
+                                public Map<String, Integer> get() {
                                     Map<String, Integer> choices = Map.of("id1", 2);
                                     return choices.entrySet().stream()
                                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -1038,6 +1038,64 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
                       binder.bind(new TypeLiteral<Supplier<String>>() {
                       }).toInstance(() -> suffix.getAndIncrement() + "");
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/961")
+    @Test
+    void dontUseLambdaWhenOverridingDefaultMethod() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              interface BusinessRule {
+                  default List<String> getConfigurationTexts() {
+                      return List.of();
+                  }
+              }
+
+              class Test {
+                  BusinessRule rule = new BusinessRule() {
+                      @Override
+                      public List<String> getConfigurationTexts() {
+                          return List.of("zero", "one", "two");
+                      }
+                  };
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/961")
+    @Test
+    void dontUseLambdaWhenOverridingDefaultMethodOfFunctionalInterface() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              interface BusinessRule {
+                  void apply();
+
+                  default List<String> getConfigurationTexts() {
+                      return List.of();
+                  }
+              }
+
+              class Test {
+                  BusinessRule rule = new BusinessRule() {
+                      @Override
+                      public List<String> getConfigurationTexts() {
+                          return List.of("zero", "one", "two");
+                      }
+                  };
               }
               """
           )


### PR DESCRIPTION
- Fixes #961

### What's wrong

`UseLambdaForFunctionalInterface` picked the interface's single abstract method (SAM) and then converted the anonymous class body without ever checking that the method the anonymous class declares *is* that SAM. When an anonymous class overrides a `default` method instead, the conversion produced code that fails to compile:

```java
interface BusinessRule {
    void apply();

    default List<String> getConfigurationTexts() {
        return List.of();
    }
}

// before
BusinessRule rule = new BusinessRule() {
    @Override
    public List<String> getConfigurationTexts() {
        return List.of("zero", "one", "two");
    }
};

// after (invalid: implements apply(), not getConfigurationTexts())
BusinessRule rule = () -> List.of("zero", "one", "two");
```

### The fix

`shouldConvertToLambda` now requires the declared method's name and parameter count to match the SAM, so overriding a `default` (or any non-SAM) method leaves the anonymous class alone.

### Note on the test change

`lambdaWithComplexTypeInference` declared `public Map<String, Integer> getObject()` inside a `new Supplier<Map<String, Integer>>() { ... }` — that sample never compiles, since `Supplier`'s method is `get()`. It only passed because the recipe wasn't checking the method name. Renamed to `get()`; the test still asserts the same cast-preserving transformation.
