### PR TITLE
UnnecessaryExplicitTypeArguments: add regression test for #964

### DIFF
--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -270,6 +270,38 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/964")
+    @Test
+    void retainsWitnessReturnedFromSwitchInsideBlockBodiedLambdaArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Collection;
+              import java.util.List;
+              import java.util.Optional;
+              import java.util.stream.Collectors;
+
+              class Test {
+                  Collection<String> test(List<String> details) {
+                      return details.stream()
+                              .map(detail -> {
+                                  switch (detail.length()) {
+                                      case 0:
+                                          return Optional.ofNullable(detail);
+                                      default:
+                                          return Optional.<String>empty();
+                                  }
+                              })
+                              .flatMap(Optional::stream)
+                              .collect(Collectors.toSet());
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void retainsWitnessWhenResultIsSelectOfMethodInvocation() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #964

## What's changed

- The reported case (a load-bearing `Optional.<String>empty()` witness returned from a `switch` inside a block-bodied lambda passed to `.map()`) no longer reproduces on `main`: it was already fixed by #958 ("retain witness for a return-only type variable not inferable from arguments"), which landed after the latest release (v2.40.0) and is therefore not yet in the `rewrite-recipe-bom` version the reporter is on.

I verified this by running the reported snippet against the v2.40.0 version of the recipe (fails, `<String>` removed) and against `main` (passes, witness retained).

This PR only adds a regression test for the exact shape in the issue. It differs from the existing `retainsWitnessOnNoArgStaticMethodReturnedFromBlockBodiedLambdaArgument` test in that the `return` sits inside a `switch`, which exercises the `dropParentUntil` walk up through `J.Case`/`J.Switch` to the enclosing lambda.

I also checked (and did not add tests for, as they're covered by existing cases) these nearby variants on `main`, all of which behave correctly: `Collections.<String>emptyList()` in the same position, a nested lambda inside a lambda, a ternary inside a lambda, and an anonymous `Function` class where the explicit `apply` return type makes the witness genuinely removable.

## Next step for the reporter

No code change is needed — the fix ships with the next release.