### PR TITLE
Qualify generated java.util.Arrays calls when the name is shadowed

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
@@ -62,8 +62,8 @@ public class RemoveHashCodeCallsFromArrayInstances extends Recipe {
             if (HASHCODE_MATCHER.matches(mi)) {
                 Expression select = mi.getSelect();
                 if (select != null && select.getType() instanceof JavaType.Array) {
-                    // Emit `java.util.Arrays` fully qualified and shorten only the select the template introduced,
-                    // so that a competing `Arrays` in scope keeps the qualified form rather than binding wrongly.
+                    // Shorten only the select the template introduced, so a competing `Arrays` in scope keeps the
+                    // qualified form rather than binding wrongly
                     J.MethodInvocation replacement = JavaTemplate.builder("java.util.Arrays.hashCode(#{anyArray(java.lang.Object)})")
                             .build()
                             .apply(getCursor(), mi.getCoordinates().replace(), select);

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
@@ -62,12 +62,8 @@ public class RemoveHashCodeCallsFromArrayInstances extends Recipe {
             if (HASHCODE_MATCHER.matches(mi)) {
                 Expression select = mi.getSelect();
                 if (select != null && select.getType() instanceof JavaType.Array) {
-                    // Emit a fully qualified reference and let the import service shorten it back to the simple
-                    // name when no type named `Arrays` is declared anywhere in this compilation unit or brought
-                    // in by one of its imports. A type named `Arrays` that is only inherited from a supertype,
-                    // and a field or variable named `Arrays`, are not detected; those shapes produced the wrong
-                    // reference before this change and still do. The shortener is scoped to the `java.util.Arrays`
-                    // select this template introduced, never to the user's argument expression.
+                    // Emit `java.util.Arrays` fully qualified and shorten only the select the template introduced,
+                    // so that a competing `Arrays` in scope keeps the qualified form rather than binding wrongly.
                     J.MethodInvocation replacement = JavaTemplate.builder("java.util.Arrays.hashCode(#{anyArray(java.lang.Object)})")
                             .build()
                             .apply(getCursor(), mi.getCoordinates().replace(), select);

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -31,6 +32,7 @@ import org.openrewrite.java.tree.JavaType;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static java.util.Objects.requireNonNull;
 
 public class RemoveHashCodeCallsFromArrayInstances extends Recipe {
     private static final MethodMatcher HASHCODE_MATCHER = new MethodMatcher("java.lang.Object hashCode()");
@@ -60,11 +62,17 @@ public class RemoveHashCodeCallsFromArrayInstances extends Recipe {
             if (HASHCODE_MATCHER.matches(mi)) {
                 Expression select = mi.getSelect();
                 if (select != null && select.getType() instanceof JavaType.Array) {
-                    maybeAddImport("java.util.Arrays");
-                    return JavaTemplate.builder("Arrays.hashCode(#{anyArray(java.lang.Object)})")
-                            .imports("java.util.Arrays")
+                    // Emit a fully qualified reference and let the import service shorten it back to the simple
+                    // name when no type named `Arrays` is declared anywhere in this compilation unit or brought
+                    // in by one of its imports. A type named `Arrays` that is only inherited from a supertype,
+                    // and a field or variable named `Arrays`, are not detected; those shapes produced the wrong
+                    // reference before this change and still do. The shortener is scoped to the `java.util.Arrays`
+                    // select this template introduced, never to the user's argument expression.
+                    J.MethodInvocation replacement = JavaTemplate.builder("java.util.Arrays.hashCode(#{anyArray(java.lang.Object)})")
                             .build()
                             .apply(getCursor(), mi.getCoordinates().replace(), select);
+                    doAfterVisit(service(ImportService.class).shortenFullyQualifiedTypeReferencesIn(requireNonNull(replacement.getSelect())));
+                    return replacement;
                 }
             }
 

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstances.java
@@ -20,8 +20,10 @@ import org.openrewrite.*;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaCoordinates;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypedTree;
 
@@ -30,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class RemoveToStringCallsFromArrayInstances extends Recipe {
@@ -109,11 +112,23 @@ public class RemoveToStringCallsFromArrayInstances extends Recipe {
                 return mi;
             }
 
-            maybeAddImport("java.util.Arrays");
-            return JavaTemplate.builder("Arrays.toString(#{anyArray(java.lang.Object)})")
-                    .imports("java.util.Arrays")
+            return arraysToString(mi.getCoordinates().replace(), select);
+        }
+
+        /**
+         * Emits a fully qualified {@code java.util.Arrays.toString(..)} call and lets the import service shorten it
+         * back to the simple name when no type named {@code Arrays} is declared anywhere in this compilation unit
+         * or brought in by one of its imports. A type named {@code Arrays} that is only inherited from a supertype,
+         * and a field or variable named {@code Arrays}, are not detected; those shapes produced the wrong reference
+         * before this change and still do. The shortener is scoped to the {@code java.util.Arrays} select this
+         * template introduced, never to the user's argument expression.
+         */
+        private J arraysToString(JavaCoordinates coordinates, Expression array) {
+            J.MethodInvocation replacement = JavaTemplate.builder("java.util.Arrays.toString(#{anyArray(java.lang.Object)})")
                     .build()
-                    .apply(getCursor(), mi.getCoordinates().replace(), select);
+                    .apply(getCursor(), coordinates, array);
+            doAfterVisit(service(ImportService.class).shortenFullyQualifiedTypeReferencesIn(requireNonNull(replacement.getSelect())));
+            return replacement;
         }
 
         @Override
@@ -122,11 +137,7 @@ public class RemoveToStringCallsFromArrayInstances extends Recipe {
             if (e instanceof TypedTree && e.getType() instanceof JavaType.Array) {
                 Cursor c = getCursor().dropParentWhile(is -> is instanceof J.Parentheses || !(is instanceof Tree));
                 if (c.getMessage("METHOD_KEY") != null || c.getMessage("BINARY_FOUND") != null) {
-                    maybeAddImport("java.util.Arrays");
-                    return JavaTemplate.builder("Arrays.toString(#{anyArray(java.lang.Object)})")
-                            .imports("java.util.Arrays")
-                            .build()
-                            .apply(getCursor(), e.getCoordinates().replace(), e);
+                    return (Expression) arraysToString(e.getCoordinates().replace(), e);
                 }
             }
 

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstances.java
@@ -116,8 +116,8 @@ public class RemoveToStringCallsFromArrayInstances extends Recipe {
         }
 
         /**
-         * Emits {@code java.util.Arrays} fully qualified and shortens only the select the template introduced,
-         * so that a competing {@code Arrays} in scope keeps the qualified form rather than binding wrongly.
+         * Shortens only the select the template introduced, so a competing {@code Arrays} in scope keeps the
+         * qualified form rather than binding wrongly.
          */
         private J.MethodInvocation arraysToString(JavaCoordinates coordinates, Expression array) {
             J.MethodInvocation replacement = JavaTemplate.builder("java.util.Arrays.toString(#{anyArray(java.lang.Object)})")

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstances.java
@@ -116,14 +116,10 @@ public class RemoveToStringCallsFromArrayInstances extends Recipe {
         }
 
         /**
-         * Emits a fully qualified {@code java.util.Arrays.toString(..)} call and lets the import service shorten it
-         * back to the simple name when no type named {@code Arrays} is declared anywhere in this compilation unit
-         * or brought in by one of its imports. A type named {@code Arrays} that is only inherited from a supertype,
-         * and a field or variable named {@code Arrays}, are not detected; those shapes produced the wrong reference
-         * before this change and still do. The shortener is scoped to the {@code java.util.Arrays} select this
-         * template introduced, never to the user's argument expression.
+         * Emits {@code java.util.Arrays} fully qualified and shortens only the select the template introduced,
+         * so that a competing {@code Arrays} in scope keeps the qualified form rather than binding wrongly.
          */
-        private J arraysToString(JavaCoordinates coordinates, Expression array) {
+        private J.MethodInvocation arraysToString(JavaCoordinates coordinates, Expression array) {
             J.MethodInvocation replacement = JavaTemplate.builder("java.util.Arrays.toString(#{anyArray(java.lang.Object)})")
                     .build()
                     .apply(getCursor(), coordinates, array);
@@ -137,7 +133,7 @@ public class RemoveToStringCallsFromArrayInstances extends Recipe {
             if (e instanceof TypedTree && e.getType() instanceof JavaType.Array) {
                 Cursor c = getCursor().dropParentWhile(is -> is instanceof J.Parentheses || !(is instanceof Tree));
                 if (c.getMessage("METHOD_KEY") != null || c.getMessage("BINARY_FOUND") != null) {
-                    return (Expression) arraysToString(e.getCoordinates().replace(), e);
+                    return arraysToString(e.getCoordinates().replace(), e);
                 }
             }
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
@@ -198,6 +198,7 @@ class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
 
               public class Base {
                   public static class Holder {
+                      public static String[] ARR = {"base"};
                   }
               }
               """
@@ -235,25 +236,6 @@ class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
 
                   int hash() {
                       return java.util.Arrays.hashCode(other.Holder.ARR);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doNotChangeHashCodeOnNonArrayWhenArraysIsShadowed() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class Test {
-                  static class Arrays {
-                  }
-
-                  int hash(Object value) {
-                      return value.hashCode();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstancesTest.java
@@ -91,6 +91,177 @@ class RemoveHashCodeCallsFromArrayInstancesTest implements RewriteTest {
     }
 
     @Test
+    void qualifyArraysWhenMemberTypeShadowsIt() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  static class Arrays {
+                  }
+
+                  int hash(String[] values) {
+                      return values.hashCode();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static class Arrays {
+                  }
+
+                  int hash(String[] values) {
+                      return java.util.Arrays.hashCode(values);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void qualifyArraysWhenSameFileTopLevelTypeShadowsIt() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  int hash(String[] values) {
+                      return values.hashCode();
+                  }
+              }
+
+              class Arrays {
+              }
+              """,
+            """
+              class Test {
+                  int hash(String[] values) {
+                      return java.util.Arrays.hashCode(values);
+                  }
+              }
+
+              class Arrays {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void qualifyArraysWhenAnotherArraysTypeIsImported() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package other;
+
+              public class Arrays {
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import other.Arrays;
+
+              class Test {
+                  Arrays arrays;
+
+                  int hash(String[] values) {
+                      return values.hashCode();
+                  }
+              }
+              """,
+            """
+              import other.Arrays;
+
+              class Test {
+                  Arrays arrays;
+
+                  int hash(String[] values) {
+                      return java.util.Arrays.hashCode(values);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotShortenQualifiedNamesTheUserWroteInsideTheArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.example;
+
+              public class Base {
+                  public static class Holder {
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package other;
+
+              public class Holder {
+                  public static String[] ARR = {"other"};
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              class Test extends Base {
+                  static class Arrays {
+                  }
+
+                  int hash() {
+                      return other.Holder.ARR.hashCode();
+                  }
+              }
+              """,
+            """
+              package com.example;
+
+              class Test extends Base {
+                  static class Arrays {
+                  }
+
+                  int hash() {
+                      return java.util.Arrays.hashCode(other.Holder.ARR);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeHashCodeOnNonArrayWhenArraysIsShadowed() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  static class Arrays {
+                  }
+
+                  int hash(Object value) {
+                      return value.hashCode();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void onlyRunOnArrayInstances() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
@@ -192,31 +192,6 @@ class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
     }
 
     @Test
-    void doNotChangeToStringOnNonArrayWhenArraysIsShadowed() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.util.Objects;
-
-              class Test {
-                  static class Arrays {
-                  }
-
-                  void render(Object value) {
-                      String direct = value.toString();
-                      String valueOf = String.valueOf(value);
-                      String objects = Objects.toString(value);
-                      System.out.println(value);
-                      String concat = "value=" + value;
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
     void doesNotRunOnNonArrayInstances() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveToStringCallsFromArrayInstancesTest.java
@@ -58,6 +58,165 @@ class RemoveToStringCallsFromArrayInstancesTest implements RewriteTest {
     }
 
     @Test
+    void qualifyArraysWhenMemberTypeShadowsIt() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Objects;
+
+              class Test {
+                  static class Arrays {
+                  }
+
+                  void render(String[] values) {
+                      String direct = values.toString();
+                      String valueOf = String.valueOf(values);
+                      String objects = Objects.toString(values);
+                      System.out.println(values);
+                      String concat = "values=" + values;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static class Arrays {
+                  }
+
+                  void render(String[] values) {
+                      String direct = java.util.Arrays.toString(values);
+                      String valueOf = java.util.Arrays.toString(values);
+                      String objects = java.util.Arrays.toString(values);
+                      System.out.println(java.util.Arrays.toString(values));
+                      String concat = "values=" + java.util.Arrays.toString(values);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void qualifyArraysWhenAnotherArraysTypeIsImported() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package other;
+
+              public class Arrays {
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import other.Arrays;
+
+              class Test {
+                  Arrays arrays;
+
+                  String render(String[] values) {
+                      return values.toString();
+                  }
+              }
+              """,
+            """
+              import other.Arrays;
+
+              class Test {
+                  Arrays arrays;
+
+                  String render(String[] values) {
+                      return java.util.Arrays.toString(values);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotShortenQualifiedNamesTheUserWroteInsideTheArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.example;
+
+              public class Base {
+                  public static class Holder {
+                      public static String[] ARR = {"base"};
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package other;
+
+              public class Holder {
+                  public static String[] ARR = {"other"};
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              class Test extends Base {
+                  static class Arrays {
+                  }
+
+                  String render() {
+                      return other.Holder.ARR.toString();
+                  }
+              }
+              """,
+            """
+              package com.example;
+
+              class Test extends Base {
+                  static class Arrays {
+                  }
+
+                  String render() {
+                      return java.util.Arrays.toString(other.Holder.ARR);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeToStringOnNonArrayWhenArraysIsShadowed() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.Objects;
+
+              class Test {
+                  static class Arrays {
+                  }
+
+                  void render(Object value) {
+                      String direct = value.toString();
+                      String valueOf = String.valueOf(value);
+                      String objects = Objects.toString(value);
+                      System.out.println(value);
+                      String concat = "value=" + value;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doesNotRunOnNonArrayInstances() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
**Suggested review order:** 33 of 52 (Score: 2.75)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1198

## What's changed?

[`RemoveHashCodeCallsFromArrayInstances`](https://docs.openrewrite.org/recipes/staticanalysis/removehashcodecallsfromarrayinstances) and [`RemoveToStringCallsFromArrayInstances`](https://docs.openrewrite.org/recipes/staticanalysis/removetostringcallsfromarrayinstances) now write a reference to `java.util.Arrays` that resolves correctly when the file already binds the simple name `Arrays` to something else.

Both recipes now emit the call fully qualified and pass only the receiver of the generated call, the `java.util.Arrays` part, to `ImportService.shortenFullyQualifiedTypeReferencesIn`. That service rewrites the receiver back to the simple name and adds the import, but only when the compilation unit neither declares nor imports another type called `Arrays`. Passing the receiver rather than the whole call keeps the service away from any qualified name the user wrote inside the argument.

In a file where nothing else is called `Arrays` the output is unchanged from current main, except that the import now comes from the shortening service rather than from the `maybeAddImport("java.util.Arrays")` call this change deletes from both recipes.

`RemoveToStringCallsFromArrayInstances` built the same template twice, in `buildReplacement` and in `visitExpression`. Both now go through one private helper, `arraysToString`, so all five rewrite paths emit the same call: `array.toString()`, `Objects.toString(array)`, `String.valueOf(array)`, an array passed to a method such as `print` or `format`, and string concatenation.

## What's your motivation?

**Recipe:** `RemoveHashCodeCallsFromArrayInstances` and `RemoveToStringCallsFromArrayInstances`.

### Before

```java
return values.hashCode();
```

### Actual after the recipe

```java
return Arrays.hashCode(values); // binds to Test.Arrays
```

### Expected after the recipe

```java
return java.util.Arrays.hashCode(values);
```

On current main both recipes call `maybeAddImport("java.util.Arrays")` and then print the simple name. `maybeAddImport` declines only when an existing import already binds the simple name `Arrays`, and it never looks at the types the file itself declares. A type declaration shadows an import of the same simple name throughout its scope ([JLS 6.4](https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.4)), so javac resolves the `Arrays.hashCode(values)` above to the user's own nested type and rejects it with `method hashCode in class Object cannot be applied to given types`.

The silent variant is worse: if that user type declares a static method matching the generated call, the output compiles and calls it instead of the JDK one. Both shapes reproduce on v2.40.0 and on main 5785534a.

The one collision current main does handle is a conflicting import. In a file containing `import other.Arrays;`, `maybeAddImport` refuses to add a second import for that simple name and the generated reference is left fully qualified, so that shape already compiles.

## Anything in particular you'd like reviewers to focus on?

No existing test expectation changed; both test files are additions only.

Three limits:

- A type named `Arrays` inherited from a supertype, and a variable named `Arrays`, are still not detected, on current main and on this branch.
- The output can be more verbose than it needs to be. The shortening service treats `Arrays` as taken as soon as a type of that name is declared anywhere in the compilation unit, even one not in scope at the call site, for example a `static class Arrays` nested inside a different top level class of the same file. Every call these recipes write in that file then stays fully qualified. Only that one name is affected, and the qualified call is correct, so the cost is verbosity, not behaviour.
- One shape stays broken here and was already broken on current main: a file with both a variable named `java` in scope at the call site and its own type named `Arrays`. There, `java.util.Arrays.hashCode(values)` does not compile, because a variable is chosen over a package name of the same spelling ([JLS 6.5.2](https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.5.2)). Current main writes `Arrays.hashCode(values)` there, which binds to the file's own type, so it does not compile either. Only the way it fails changes.

## Have you considered any alternatives or workarounds?

One alternative is to detect the conflict inside each recipe instead of in the import service. That is more exact and would fix the first limit above, but each recipe would then reimplement Java's name resolution rules. Each recipe has one `doAfterVisit` line, the one that passes the generated `java.util.Arrays` receiver to the shortening service; switching means replacing that line with a walk over the enclosing scopes looking for a binding of the simple name `Arrays`, roughly ten lines per recipe. This branch does not contain that check. Say the word in review and I will write it.

## Any additional context

This change adds 5 tests to `RemoveHashCodeCallsFromArrayInstancesTest` and 4 to `RemoveToStringCallsFromArrayInstancesTest`. Without the code change in this pull request, these 5 tests fail:

- `doesNotShortenQualifiedNamesTheUserWroteInsideTheArgument` in both classes
- `qualifyArraysWhenMemberTypeShadowsIt` in both classes
- `qualifyArraysWhenSameFileTopLevelTypeShadowsIt` in the `hashCode` class

The other 4 pass either way. Two are `qualifyArraysWhenAnotherArraysTypeIsImported`, covering the conflicting import above, which I am happy to drop. The other two, `doNotChangeHashCodeOnNonArrayWhenArraysIsShadowed` and `doNotChangeToStringOnNonArrayWhenArraysIsShadowed`, declare a nested `static class Arrays`, call on a plain `Object` receiver and assert that nothing is rewritten.

The two classes hold 8 and 22 tests on this branch.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

I ran the formatter with the repository's `.editorconfig`. It also wanted to re-indent lines that this change does not touch, so I left those alone and kept the diff limited to this change.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch