### PR TITLE
Preserve `Float(double)` rounding when replacing wrapper constructors

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
@@ -95,9 +95,8 @@ public class PrimitiveWrapperClassConstructorToValueOf extends Recipe {
                             if (TypeUtils.isOfClassType(argType, "java.lang.Double")) {
                                 valueOf = JavaTemplate.builder("Float.valueOf(#{any(java.lang.Double)}.floatValue())");
                             } else if (JavaType.Primitive.Double == argType) {
-                                // A cast binds tighter than these operators, so without parentheses it would cover only
-                                // the first operand, either failing to compile (`Float.valueOf((float) a + b)` passes
-                                // a `double`) or rounding to `float` one step too early (`(float) d * 2`).
+                                // A cast binds tighter than these operators, so unparenthesized it covers only the
+                                // first operand, either failing to compile or rounding one step too early
                                 valueOf = JavaTemplate.builder(arg instanceof J.Binary || arg instanceof J.Ternary ||
                                         arg instanceof J.Assignment || arg instanceof J.AssignmentOperation ?
                                         "Float.valueOf((float) (#{any(double)}))" :

--- a/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
@@ -91,16 +91,19 @@ public class PrimitiveWrapperClassConstructorToValueOf extends Recipe {
                             valueOf = JavaTemplate.builder("Short.valueOf(#{any(short)})");
                             break;
                         case "java.lang.Float":
-                            if (arg instanceof J.Literal && JavaType.Primitive.Double == ((J.Literal) arg).getType()) {
-                                arg = ((J.Literal) arg).withType(JavaType.Primitive.String);
-                                arg = ((J.Literal) arg).withValueSource("\"" + ((J.Literal) arg).getValue() + "\"");
-                            }
-
                             JavaType argType = arg.getType();
                             if (TypeUtils.isOfClassType(argType, "java.lang.Double")) {
                                 valueOf = JavaTemplate.builder("Float.valueOf(#{any(java.lang.Double)}.floatValue())");
-                            } else if (JavaType.Primitive.Double == arg.getType()) {
-                                valueOf = JavaTemplate.builder("Float.valueOf((float) #{any(double)})");
+                            } else if (JavaType.Primitive.Double == argType) {
+                                // A cast binds tighter than these operators, so without parentheses it would cover
+                                // only the first operand. Depending on the argument that either fails to compile
+                                // (`Float.valueOf((float) a + b)` passes a `double`; `(float) d = 2.0` is not an
+                                // assignment target) or silently rounds to `float` one step too early
+                                // (`(float) d * 2`).
+                                valueOf = JavaTemplate.builder(arg instanceof J.Binary || arg instanceof J.Ternary ||
+                                        arg instanceof J.Assignment || arg instanceof J.AssignmentOperation ?
+                                        "Float.valueOf((float) (#{any(double)}))" :
+                                        "Float.valueOf((float) #{any(double)})");
                             } else {
                                 valueOf = JavaTemplate.builder("Float.valueOf(#{any(float)})");
                             }

--- a/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
+++ b/src/main/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOf.java
@@ -95,11 +95,9 @@ public class PrimitiveWrapperClassConstructorToValueOf extends Recipe {
                             if (TypeUtils.isOfClassType(argType, "java.lang.Double")) {
                                 valueOf = JavaTemplate.builder("Float.valueOf(#{any(java.lang.Double)}.floatValue())");
                             } else if (JavaType.Primitive.Double == argType) {
-                                // A cast binds tighter than these operators, so without parentheses it would cover
-                                // only the first operand. Depending on the argument that either fails to compile
-                                // (`Float.valueOf((float) a + b)` passes a `double`; `(float) d = 2.0` is not an
-                                // assignment target) or silently rounds to `float` one step too early
-                                // (`(float) d * 2`).
+                                // A cast binds tighter than these operators, so without parentheses it would cover only
+                                // the first operand, either failing to compile (`Float.valueOf((float) a + b)` passes
+                                // a `double`) or rounding to `float` one step too early (`(float) d * 2`).
                                 valueOf = JavaTemplate.builder(arg instanceof J.Binary || arg instanceof J.Ternary ||
                                         arg instanceof J.Assignment || arg instanceof J.AssignmentOperation ?
                                         "Float.valueOf((float) (#{any(double)}))" :

--- a/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
@@ -219,9 +219,8 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
 
     @Test
     void doubleLiteralToFloatKeepsBinary64Rounding() {
-        // `new Float(double)` is defined as `(float) value`, so the literal rounds to binary64 first and
-        // yields bits 0x3f800000; `Float.valueOf("1.0000000596046448")` rounds the decimal straight to
-        // binary32 and yields 0x3f800001, one ulp higher.
+        // `new Float(double)` is `(float) value`, rounding through binary64 to 0x3f800000, where
+        // `Float.valueOf(String)` rounds the decimal straight to binary32 and yields 0x3f800001
         rewriteRun(
           //language=java
           java(

--- a/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/PrimitiveWrapperClassConstructorToValueOfTest.java
@@ -203,7 +203,7 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
                   Double d1 = Double.valueOf(1.0);
                   double d2 = 2.0d;
                   void makeFloats() {
-                      Float f = Float.valueOf("2.0");
+                      Float f = Float.valueOf((float) 2.0d);
                       Float f2 = Float.valueOf(getD().floatValue());
                       Float f3 = Float.valueOf(d1.floatValue());
                       Float f4 = Float.valueOf((float) d2);
@@ -211,6 +211,128 @@ class PrimitiveWrapperClassConstructorToValueOfTest implements RewriteTest {
                   Double getD() {
                       return Double.valueOf(2.0d);
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doubleLiteralToFloatKeepsBinary64Rounding() {
+        // `new Float(double)` is defined as `(float) value`, so the literal rounds to binary64 first and
+        // yields bits 0x3f800000; `Float.valueOf("1.0000000596046448")` rounds the decimal straight to
+        // binary32 and yields 0x3f800001, one ulp higher.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  Float value = new Float(1.0000000596046448);
+              }
+              """,
+            """
+              class T {
+                  Float value = Float.valueOf((float) 1.0000000596046448);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doubleLiteralToFloatKeepsSourceForm() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  Float hex = new Float(0x1.0000002p0);
+                  Float suffixed = new Float(1.0000000596046448D);
+                  Float subnormal = new Float(4.9E-324);
+              }
+              """,
+            """
+              class T {
+                  Float hex = Float.valueOf((float) 0x1.0000002p0);
+                  Float suffixed = Float.valueOf((float) 1.0000000596046448D);
+                  Float subnormal = Float.valueOf((float) 4.9E-324);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doubleExpressionToFloatUsesCast() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  Float negativeZero = new Float(-0.0);
+                  Float overflowing = new Float(Double.MAX_VALUE);
+                  Float parenthesized = new Float((1.0000000596046448));
+              }
+              """,
+            """
+              class T {
+                  Float negativeZero = Float.valueOf((float) -0.0);
+                  Float overflowing = Float.valueOf((float) Double.MAX_VALUE);
+                  Float parenthesized = Float.valueOf((float) (1.0000000596046448));
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void compoundDoubleExpressionToFloatIsParenthesized() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  double d1 = 1.0;
+                  double d2 = 2.0;
+                  void makeFloats() {
+                      Float sum = new Float(d1 + d2);
+                      Float ternary = new Float(d1 > d2 ? d1 : d2);
+                      Float assigned = new Float(d1 = 2.0);
+                      Float compound = new Float(d1 += 2.0);
+                  }
+              }
+              """,
+            """
+              class T {
+                  double d1 = 1.0;
+                  double d2 = 2.0;
+                  void makeFloats() {
+                      Float sum = Float.valueOf((float) (d1 + d2));
+                      Float ternary = Float.valueOf((float) (d1 > d2 ? d1 : d2));
+                      Float assigned = Float.valueOf((float) (d1 = 2.0));
+                      Float compound = Float.valueOf((float) (d1 += 2.0));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void floatLiteralUnchangedByDoubleHandling() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class T {
+                  Float f = new Float(1.1f);
+                  Float hex = new Float(0x1.0000002p0f);
+              }
+              """,
+            """
+              class T {
+                  Float f = Float.valueOf(1.1f);
+                  Float hex = Float.valueOf(0x1.0000002p0f);
               }
               """
           )


### PR DESCRIPTION
**Suggested review order:** 29 of 52 (Score: 3.5)
**Review first:** https://github.com/openrewrite/rewrite/pull/8444

## What's changed?

When the argument of `new Float(...)` has the primitive type `double`, [`PrimitiveWrapperClassConstructorToValueOf`](https://docs.openrewrite.org/recipes/staticanalysis/primitivewrapperclassconstructortovalueof) now always emits `Float.valueOf((float) X)`, where `X` is the original argument with its source text unchanged, in parentheses of its own when it is a `J.Binary`, `J.Ternary`, `J.Assignment` or `J.AssignmentOperation`, the `double`-typed expression shapes that bind less tightly than a cast. A `double` literal is no longer rewritten into a `String` literal: it now takes the same branch a `double` variable already takes, keeping its source text, its suffix and its radix.

### Before

In which `d1` and `d2` are variables of the primitive type `double`.

```java
Float value = new Float(1.0000000596046448);
Float sum = new Float(d1 + d2);
```

### Actual after the recipe

Using main today.

```java
Float value = Float.valueOf("1.0000000596046448");
Float sum = Float.valueOf((float) d1 + d2);
```

### Expected after the recipe

The corrected result is shown below.

```java
Float value = Float.valueOf((float) 1.0000000596046448);
Float sum = Float.valueOf((float) (d1 + d2));
```

An argument typed as the boxed class `java.lang.Double` still becomes `Float.valueOf(boxed.floatValue())`, exactly as on main. The implementation change is ten added and seven removed lines in one method; the other 123 added lines are tests.

## What's your motivation?

**Recipe:** `org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf`.

For the compound arguments covered here whose static type remains `double`, today's output does not compile: `javac 21` reports `no suitable method found for valueOf(double)` for `d1 + d2` and `d1 > d2 ? d1 : d2`, and `required: variable` for an assignment argument. Where the cast in front of the first operand alone leaves the whole argument with the static type `float` it does compile instead, and then computes a different value. With `double huge = 1e39`, `new Float(huge * 0)` computes `0.0f`, because `huge * 0` is the `double` value `0.0` and the constructor narrows it. Main's output, `Float.valueOf((float) huge * 0)`, computes `NaN`, because `(float) huge` overflows to `Infinity` and `Infinity * 0` is `NaN`; it compiles because a `float` multiplied by an `int` has the static type `float`. This branch emits `Float.valueOf((float) (huge * 0))`, which computes `0.0f` again.

A `double` literal argument changes the computed value too. `Float(double value)` is specified as `this.value = (float) value`, so the literal is rounded to a `double` and then narrowed to a `float`, whereas `Float.valueOf(String)` rounds the text straight to a `float`. For `1.0000000596046448`, `Float.floatToRawIntBits` of the constructor's result is `0x3f800000` and of today's output `0x3f800001`, one ulp higher. The `String` form is also rebuilt from the parsed value, so a hexadecimal literal, a `D` suffix or digit separators all become plain decimal: on main `new Float(0x1.0000002p0)` becomes `Float.valueOf("1.0000000074505806")`. Reproduced on 2.40.0 and on 2.41.0-SNAPSHOT built from main `5785534a`.

### Confirmed real-world execution

- Project: [APKinspector](https://github.com/honeynet/apkinspector) (852 stars on 2026-08-16).
- Location: [`XMLPrinter.java` at `e6c32a6`](https://github.com/honeynet/apkinspector/blob/e6c32a6735d39eb6686cbf445ed65a4fe3f3d67b/ded/soot/soot-2.3.0/src/soot/xml/XMLPrinter.java#L226).
- Recipe release: `org.openrewrite.recipe:rewrite-static-analysis:2.41.0`.

The released recipe places the float cast around only the left operand of a multiplication by the `double` literal `100.0`. Binary numeric promotion makes the complete argument a `double`, so the generated `Float.valueOf(...)` call does not compile.

## Anything in particular you'd like reviewers to focus on?

`doubleToFloat` already existed on main, and this change alters an expectation that used to hold there. Its input `Float f = new Float(2.0d);` is unchanged; the expected output was `Float.valueOf("2.0")` and is now `Float.valueOf((float) 2.0d)`. Its other three assertions, for `f2`, `f3` and `f4`, are untouched.

Three limits this change does not address, all the same on main and on this branch:

- Comments outside the argument are dropped, for every wrapper class.
- In Groovy the type of a compound `double` argument is not resolved, so that argument gets no cast.
- `valueOf` may return a cached instance, so `==` on the result can behave differently from `==` on a constructor result. The recipe description already spells out this caching.

## Have you considered any alternatives or workarounds?

Parenthesizing in every case would be simpler: one template instead of a conditional, about six implementation lines, deleting the branch that rewrites a `double` literal into a `String` literal and changing the template `"Float.valueOf((float) #{any(double)})"` to `"Float.valueOf((float) (#{any(double)}))"`. I kept the form without parentheses for a simple argument because main already produces it for a `double` variable, it came in with #476 (closed), the issue that led to the `(float)` cast this change extends, and `doubleToFloat` asserts it in `Float f4 = Float.valueOf((float) d2);`, one of the three assertions this change leaves alone. That test is also the only existing one the alternative would touch: `Float f` and `Float f4` would become `Float.valueOf((float) (2.0d))` and `Float.valueOf((float) (d2))`. Say so in review and I will switch.

## Any additional context

Pre-existing tests changed: `PrimitiveWrapperClassConstructorToValueOfTest.java.doubleToFloat` (updated).

This change adds 5 tests to `PrimitiveWrapperClassConstructorToValueOfTest`. Without the code change in this pull request, these 4 tests fail:

- `compoundDoubleExpressionToFloatIsParenthesized`
- `doubleLiteralToFloatKeepsBinary64Rounding`
- `doubleLiteralToFloatKeepsSourceForm`
- the pre-existing `doubleToFloat`, with its updated expectation

These 2 new tests pass either way:

- `doubleExpressionToFloatUsesCast`
- `floatLiteralUnchangedByDoubleHandling`

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch