### PR TITLE
RemoveMethodsOnlyCallSuper: keep synchronized and deprecated overrides

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
@@ -23,6 +23,7 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
@@ -81,12 +82,14 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                     return md;
                 }
 
-                // Skip if method has annotations other than @Override or @Deprecated
-                for (J.Annotation annotation : md.getLeadingAnnotations()) {
+                // Skip if method has annotations other than @Override. `@Deprecated` is metadata owned by this
+                // declaration, so removing the declaration also removes the deprecation signal from the subclass.
+                // Annotations written after a modifier keyword are held by the modifier rather than by the method,
+                // so also consult the annotations held by each modifier and by an annotated return-type expression.
+                // Parameter, individual type-parameter and nested type-use annotations are still not covered.
+                for (J.Annotation annotation : service(AnnotationService.class).getAllAnnotations(getCursor())) {
                     JavaType annotationType = annotation.getAnnotationType().getType();
-                    if (annotationType == null ||
-                        !TypeUtils.isOfClassType(annotationType, "java.lang.Override") &&
-                        !TypeUtils.isOfClassType(annotationType, "java.lang.Deprecated")) {
+                    if (annotationType == null || !TypeUtils.isOfClassType(annotationType, "java.lang.Override")) {
                         return md;
                     }
                 }
@@ -100,6 +103,12 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
 
                 // Skip if method is final (prevents further overriding)
                 if (methodType.hasFlags(Flag.Final)) {
+                    return md;
+                }
+
+                // Skip if method is synchronized; removing it would drop acquisition of the receiver monitor
+                // before dispatching to a super method that need not be synchronized itself
+                if (md.hasModifier(J.Modifier.Type.Synchronized)) {
                     return md;
                 }
 

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
@@ -22,6 +22,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.*;
@@ -36,6 +37,8 @@ import static java.util.Collections.singleton;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class RemoveMethodsOnlyCallSuper extends Recipe {
+
+    private static final AnnotationMatcher OVERRIDE = new AnnotationMatcher("@java.lang.Override");
 
     String displayName = "Remove methods that only call super";
 
@@ -84,8 +87,7 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
 
                 // Skip if method has annotations other than @Override
                 for (J.Annotation annotation : service(AnnotationService.class).getAllAnnotations(getCursor())) {
-                    JavaType annotationType = annotation.getAnnotationType().getType();
-                    if (annotationType == null || !TypeUtils.isOfClassType(annotationType, "java.lang.Override")) {
+                    if (!OVERRIDE.matches(annotation)) {
                         return md;
                     }
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
@@ -82,11 +82,7 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                     return md;
                 }
 
-                // Skip if method has annotations other than @Override. `@Deprecated` is metadata owned by this
-                // declaration, so removing the declaration also removes the deprecation signal from the subclass.
-                // Annotations written after a modifier keyword are held by the modifier rather than by the method,
-                // so also consult the annotations held by each modifier and by an annotated return-type expression.
-                // Parameter, individual type-parameter and nested type-use annotations are still not covered.
+                // Skip if method has annotations other than @Override
                 for (J.Annotation annotation : service(AnnotationService.class).getAllAnnotations(getCursor())) {
                     JavaType annotationType = annotation.getAnnotationType().getType();
                     if (annotationType == null || !TypeUtils.isOfClassType(annotationType, "java.lang.Override")) {
@@ -106,8 +102,7 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                     return md;
                 }
 
-                // Skip if method is synchronized; removing it would drop acquisition of the receiver monitor
-                // before dispatching to a super method that need not be synchronized itself
+                // Skip if method is synchronized (the super method need not be synchronized itself)
                 if (md.hasModifier(J.Modifier.Type.Synchronized)) {
                     return md;
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
@@ -102,8 +102,9 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                     return md;
                 }
 
-                // Skip if method is synchronized (the super method need not be synchronized itself)
-                if (md.hasModifier(J.Modifier.Type.Synchronized)) {
+                // Skip if method is synchronized, unless the super method is synchronized too
+                if (md.hasModifier(J.Modifier.Type.Synchronized) &&
+                    (superCall.getMethodType() == null || !superCall.getMethodType().hasFlags(Flag.Synchronized))) {
                     return md;
                 }
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
@@ -286,6 +286,36 @@ class RemoveMethodsOnlyCallSuperTest implements RewriteTest {
     }
 
     @Test
+    void removeSynchronizedMethodWhenSuperIsSynchronizedToo() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Parent {
+                  synchronized void foo() {
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Child extends Parent {
+                  @Override
+                  synchronized void foo() {
+                      super.foo();
+                  }
+              }
+              """,
+            """
+              class Child extends Parent {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotChangeMethodWithJavadoc() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
@@ -123,7 +123,91 @@ class RemoveMethodsOnlyCallSuperTest implements RewriteTest {
     }
 
     @Test
-    void removeDeprecatedMethodOnlyCallingSuper() {
+    void removePlainOverrideAlongsideSynchronizedAndDeprecatedOverrides() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Parent {
+                  void foo() {
+                  }
+                  void bar() {
+                  }
+                  void baz() {
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Child extends Parent {
+                  @Override
+                  synchronized void foo() {
+                      super.foo();
+                  }
+
+                  @Deprecated
+                  @Override
+                  void bar() {
+                      super.bar();
+                  }
+
+                  @Override
+                  void baz() {
+                      super.baz();
+                  }
+              }
+              """,
+            """
+              class Child extends Parent {
+                  @Override
+                  synchronized void foo() {
+                      super.foo();
+                  }
+
+                  @Deprecated
+                  @Override
+                  void bar() {
+                      super.bar();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeMethodWithOverrideAnnotationAfterModifier() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Parent {
+                  public void foo() {
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Child extends Parent {
+                  public @Override void foo() {
+                      super.foo();
+                  }
+              }
+              """,
+            """
+              class Child extends Parent {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeDeprecatedMethod() {
         rewriteRun(
           //language=java
           java(
@@ -144,9 +228,58 @@ class RemoveMethodsOnlyCallSuperTest implements RewriteTest {
                       super.foo();
                   }
               }
-              """,
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeSynchronizedMethod() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Parent {
+                  void foo() {
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
             """
               class Child extends Parent {
+                  @Override
+                  synchronized void foo() {
+                      super.foo();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeDeprecatedMethodWithAnnotationAfterModifier() {
+        // An annotation written after a modifier keyword is held by the modifier, not by the method declaration
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Parent {
+                  public void foo() {
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Child extends Parent {
+                  @Override
+                  public @Deprecated void foo() {
+                      super.foo();
+                  }
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
@@ -261,7 +261,6 @@ class RemoveMethodsOnlyCallSuperTest implements RewriteTest {
 
     @Test
     void doNotChangeDeprecatedMethodWithAnnotationAfterModifier() {
-        // An annotation written after a modifier keyword is held by the modifier, not by the method declaration
         rewriteRun(
           //language=java
           java(


### PR DESCRIPTION
## What's changed?

[`RemoveMethodsOnlyCallSuper`](https://docs.openrewrite.org/recipes/staticanalysis/removemethodsonlycallsuper)
now keeps an override that is `synchronized`, and keeps an override that carries any annotation other
than `@Override`, including `@Deprecated`. It also reads the visited `J.MethodDeclaration`'s
annotations through `service(AnnotationService.class).getAllAnnotations(getCursor())` instead of
`J.MethodDeclaration#getLeadingAnnotations()`: an annotation written after a modifier keyword, as in
`public @Deprecated void foo()`, is held by the modifier rather than by the declaration, and only
`getAllAnnotations` reports it. `getAllAnnotations` itself is unchanged; only this call site is new.

Input, which main deletes, leaving an empty `Child`, and which this branch leaves unchanged:

```java
class Child extends Parent {
    @Override
    synchronized void foo() {
        super.foo();
    }
}
```

## What's your motivation?

The recipe decides that an override is redundant from its body: one statement, a call on `super` or a
`return` of one, the called method having the same name, and every argument an identifier naming the
override's own parameter in the same position. But a declaration can hold meaning that its body does
not.

Deleting a `synchronized` override drops the acquisition of the monitor on the receiver, and nothing
puts it back, because the parent method the override delegates to need not be `synchronized` itself:
in `doNotChangeSynchronizedMethod` the parent declares a plain `void foo()`. Acquiring and releasing
that monitor are the lock and unlock actions that the Java memory model orders between threads
([JLS 17.4.2](https://docs.oracle.com/javase/specs/jls/se21/html/jls-17.html#jls-17.4.2)), so once
the override is deleted `Thread.holdsLock(this)` inside the parent body is `false` where it was
`true`, and concurrent calls are no longer serialized.

Deleting a `@Deprecated` override removes the javac `-Xlint:deprecation` warning at call sites typed
as `Child`, and removes the annotation from `Child`'s declared methods, where `@Deprecated` is
retained at runtime and visible to reflection. Reproduced on 2.40.0 and on current main.

## Anything in particular you'd like reviewers to focus on?

This change alters an expectation that used to hold. Main asserted, in
`removeDeprecatedMethodOnlyCallingSuper`, that `@Deprecated @Override void foo() { super.foo(); }` is
deleted. That test name is gone. The same source is now the input of the new
`doNotChangeDeprecatedMethod`, which asserts that nothing changes, and the name is replaced by
`removePlainOverrideAlongsideSynchronizedAndDeprecatedOverrides`, which holds a `synchronized`
override, a `@Deprecated` override and a plain `@Override` side by side in one class and expects only
the plain one to be removed.

`removeMethodWithOverrideAnnotationAfterModifier` checks that `public @Override void foo()` is still
removed. What decides is which annotation it is, `@Override` or anything else, not where in the
declaration it is written.

Three limits. The first is new behaviour this change introduces; the other two are the same on main
and on this branch:

- `getAllAnnotations` also reports an annotation on an annotated return type, so an override declared
  as `public @Nullable String foo()` is now kept as well. That goes beyond the two motivating cases,
  and it is intended: any annotation other than `@Override`, in any position the recipe can see it,
  now stops the removal.
- Annotations on a parameter, on a type parameter, and nested type-use annotations are still not
  seen, so `void foo(@Nullable String s)` and `public String @Nullable [] foo()` are still removed.
- A `strictfp` override is still removed, which only matters on Java releases before 17.

## Have you considered any alternatives or workarounds?

An existing test asserted that a `@Deprecated` override is removed, so that behaviour was a choice
and not an oversight. Main lets an override be removed while it carries either of two annotation
types, `java.lang.Override` and `java.lang.Deprecated`, and this change narrows that set to
`java.lang.Override` alone. To go on removing `@Deprecated` overrides, restore the second condition
inside the loop over the method's annotations,
`!TypeUtils.isOfClassType(annotationType, "java.lang.Deprecated")`, and drop the `@Deprecated` cases
from the tests: `doNotChangeDeprecatedMethod`, `doNotChangeDeprecatedMethodWithAnnotationAfterModifier`,
and the `@Deprecated` override inside
`removePlainOverrideAlongsideSynchronizedAndDeprecatedOverrides`. The `synchronized` guard is
independent of that decision and works either way.

## Any additional context

This change adds 5 tests to `RemoveMethodsOnlyCallSuperTest` and removes the name
`removeDeprecatedMethodOnlyCallingSuper`, as described above. Without the code change in this pull
request, 4 of the added tests fail: `doNotChangeSynchronizedMethod`, `doNotChangeDeprecatedMethod`,
`doNotChangeDeprecatedMethodWithAnnotationAfterModifier` and
`removePlainOverrideAlongsideSynchronizedAndDeprecatedOverrides`. The fifth,
`removeMethodWithOverrideAnnotationAfterModifier`, passes either way: main sees no annotation there
at all, since the annotation follows a modifier, and an `@Override` does not stop the removal on
either side.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and
this description.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
