### PR TITLE
Remove null checks before `instanceof` only for side-effect-free expressions

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceof.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceof.java
@@ -91,19 +91,18 @@ public class RemoveRedundantNullCheckBeforeInstanceof extends Recipe {
             }
 
             private boolean isRedundantNullCheck(J.Binary nullCheck, J.InstanceOf instanceOf) {
-                // Dropping the null check evaluates the expression once where it was evaluated twice, so it is only
-                // equivalent when evaluating it has no side effects; `SemanticallyEqual` proves the two occurrences
-                // mean the same thing, not that evaluating them twice is the same as evaluating them once
-                if (nullCheck.getOperator() == J.Binary.Type.NotEqual &&
-                        !mayHaveSideEffects(instanceOf.getExpression())) {
-                    if (J.Literal.isLiteralValue(nullCheck.getLeft(), null)) {
-                        return SemanticallyEqual.areEqual(nullCheck.getRight(), instanceOf.getExpression());
-                    }
-                    if (J.Literal.isLiteralValue(nullCheck.getRight(), null)) {
-                        return SemanticallyEqual.areEqual(nullCheck.getLeft(), instanceOf.getExpression());
-                    }
+                if (nullCheck.getOperator() != J.Binary.Type.NotEqual) {
+                    return false;
                 }
-                return false;
+                Expression checked = J.Literal.isLiteralValue(nullCheck.getLeft(), null) ? nullCheck.getRight() :
+                        J.Literal.isLiteralValue(nullCheck.getRight(), null) ? nullCheck.getLeft() : null;
+                if (checked == null || !SemanticallyEqual.areEqual(checked, instanceOf.getExpression())) {
+                    return false;
+                }
+                // The rewrite evaluates the expression once where it was evaluated twice, so both occurrences must be
+                // side-effect free; they can differ, as `SemanticallyEqual` matches a static field access against its
+                // qualified form without comparing the qualifier.
+                return !mayHaveSideEffects(checked) && !mayHaveSideEffects(instanceOf.getExpression());
             }
         });
     }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceof.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceof.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static org.openrewrite.staticanalysis.SideEffects.mayHaveSideEffects;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -90,7 +91,11 @@ public class RemoveRedundantNullCheckBeforeInstanceof extends Recipe {
             }
 
             private boolean isRedundantNullCheck(J.Binary nullCheck, J.InstanceOf instanceOf) {
-                if (nullCheck.getOperator() == J.Binary.Type.NotEqual) {
+                // Dropping the null check evaluates the expression once where it was evaluated twice, so it is only
+                // equivalent when evaluating it has no side effects; `SemanticallyEqual` proves the two occurrences
+                // mean the same thing, not that evaluating them twice is the same as evaluating them once
+                if (nullCheck.getOperator() == J.Binary.Type.NotEqual &&
+                        !mayHaveSideEffects(instanceOf.getExpression())) {
                     if (J.Literal.isLiteralValue(nullCheck.getLeft(), null)) {
                         return SemanticallyEqual.areEqual(nullCheck.getRight(), instanceOf.getExpression());
                     }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceof.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceof.java
@@ -99,9 +99,8 @@ public class RemoveRedundantNullCheckBeforeInstanceof extends Recipe {
                 if (checked == null || !SemanticallyEqual.areEqual(checked, instanceOf.getExpression())) {
                     return false;
                 }
-                // The rewrite evaluates the expression once where it was evaluated twice, so both occurrences must be
-                // side-effect free; they can differ, as `SemanticallyEqual` matches a static field access against its
-                // qualified form without comparing the qualifier.
+                // The rewrite evaluates once what was evaluated twice, so both occurrences must be side-effect
+                // free; they can differ, as `SemanticallyEqual` matches a static field access against its qualified form
                 return !mayHaveSideEffects(checked) && !mayHaveSideEffects(instanceOf.getExpression());
             }
         });

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceofTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceofTest.java
@@ -88,8 +88,9 @@ class RemoveRedundantNullCheckBeforeInstanceofTest implements RewriteTest {
     }
 
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
     @Test
-    void removeRedundantNullCheckWithMethodInvocation() {
+    void doNotChangeWhenMethodInvocation() {
         rewriteRun(
           //language=java
           java(
@@ -105,17 +106,118 @@ class RemoveRedundantNullCheckBeforeInstanceofTest implements RewriteTest {
                       return "test";
                   }
               }
-              """,
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenMethodInvocationWithNullOnLeft() {
+        rewriteRun(
+          //language=java
+          java(
             """
               class A {
                   void foo() {
-                      if (getValue() instanceof String) {
+                      if (null != getValue() && getValue() instanceof String) {
                           System.out.println("String value");
                       }
                   }
 
                   String getValue() {
                       return "test";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantNullCheckInChainedCondition() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void foo(boolean enabled, Object obj) {
+                      if (enabled && obj != null && obj instanceof String) {
+                          System.out.println("String value");
+                      }
+                  }
+              }
+              """,
+            """
+              class A {
+                  void foo(boolean enabled, Object obj) {
+                      if (enabled && obj instanceof String) {
+                          System.out.println("String value");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenChainedConditionHasMethodInvocation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void foo(boolean enabled) {
+                      if (enabled && getValue() != null && getValue() instanceof String) {
+                          System.out.println("String value");
+                      }
+                  }
+
+                  String getValue() {
+                      return "test";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenConstructorCall() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void foo() {
+                      if (new StringBuilder() != null && new StringBuilder() instanceof CharSequence) {
+                          System.out.println("CharSequence value");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenArrayIndexHasSideEffect() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  Object[] values = new Object[2];
+                  int i;
+
+                  void foo() {
+                      if (values[i++] != null && values[i++] instanceof String) {
+                          System.out.println("String value");
+                      }
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceofTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceofTest.java
@@ -87,40 +87,25 @@ class RemoveRedundantNullCheckBeforeInstanceofTest implements RewriteTest {
         );
     }
 
-
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
     @Test
-    void doNotChangeWhenMethodInvocation() {
+    void doNotChangeWhenNullCheckedExpressionIsMethodInvocation() {
         rewriteRun(
           //language=java
           java(
             """
               class A {
-                  void foo() {
+                  void direct() {
                       if (getValue() != null && getValue() instanceof String) {
+                          System.out.println("String value");
+                      }
+                      if (null != getValue() && getValue() instanceof String) {
                           System.out.println("String value");
                       }
                   }
 
-                  String getValue() {
-                      return "test";
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
-    @Test
-    void doNotChangeWhenMethodInvocationWithNullOnLeft() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class A {
-                  void foo() {
-                      if (null != getValue() && getValue() instanceof String) {
+                  void chained(boolean enabled) {
+                      if (enabled && getValue() != null && getValue() instanceof String) {
                           System.out.println("String value");
                       }
                   }
@@ -154,29 +139,6 @@ class RemoveRedundantNullCheckBeforeInstanceofTest implements RewriteTest {
                       if (enabled && obj instanceof String) {
                           System.out.println("String value");
                       }
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
-    @Test
-    void doNotChangeWhenChainedConditionHasMethodInvocation() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              class A {
-                  void foo(boolean enabled) {
-                      if (enabled && getValue() != null && getValue() instanceof String) {
-                          System.out.println("String value");
-                      }
-                  }
-
-                  String getValue() {
-                      return "test";
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceofTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeInstanceofTest.java
@@ -225,6 +225,31 @@ class RemoveRedundantNullCheckBeforeInstanceofTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenOnlyTheNullCheckedOperandHasSideEffects() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  static Integer count = 1;
+
+                  A getInstance() {
+                      return this;
+                  }
+
+                  void foo() {
+                      if (getInstance().count != null && count instanceof Integer) {
+                          System.out.println("Integer value");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void removeRedundantNullCheckWithFieldAccess() {
         rewriteRun(


### PR DESCRIPTION
**Suggested review order:** 31 of 52 (Score: 3)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/996

## What's changed?

[`RemoveRedundantNullCheckBeforeInstanceof`](https://docs.openrewrite.org/recipes/staticanalysis/removeredundantnullcheckbeforeinstanceof) now makes no change when the expression tested by `instanceof` may have side effects. It still removes the null check for variables, fields and other expressions that only read a value.

The fix adds one condition to the `if` at the top of the helper method `isRedundantNullCheck`, whose first conjunct is unchanged from main:

```java
if (nullCheck.getOperator() == J.Binary.Type.NotEqual &&
        !mayHaveSideEffects(instanceOf.getExpression())) {
```

`visitBinary` calls `isRedundantNullCheck` for both of the shapes it handles, the direct `expr != null && expr instanceof T` and the chained `a && expr != null && expr instanceof T`, so the single condition covers both. `mayHaveSideEffects` is `SideEffects.mayHaveSideEffects`, a package-private helper added to main by #959 and reached here through a new static import; this change calls it and does not modify it. Four recipes on main already call it to avoid the same problem, dropping an expression whose evaluation may be observable: `RemoveDuplicateConditions`, `AllBranchesIdentical`, `RemoveUnconditionalValueOverwrite` and `SimplifyRedundantLogicalExpression`. Only the expression that `instanceof` tests is passed to it, not the null-checked one, which is enough: the recipe changes nothing unless those two are semantically equal, and `mayHaveSideEffects` answers the same for two semantically equal trees.

## What's your motivation?

**Recipe:** `org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeInstanceof`.

### Before

```java
return next() != null && next() instanceof String;
```

### Actual after the recipe

```java
return next() instanceof String;
```

### Expected after the recipe

(unchanged)

`expr != null && expr instanceof T` evaluates `expr` twice. The `expr instanceof T` left behind evaluates it once. Main uses `SemanticallyEqual.areEqual` alone to decide that the two occurrences are interchangeable, which proves that they mean the same thing, not that evaluating the expression twice is the same as evaluating it once.

The output that main produces still compiles, but the method it has rewritten can return a different value. Compiled and run with Java 21, `direct()` above returns `false` from the input source and `true` from the source main produces, because there `next()` is called once instead of twice. The lost evaluation reaches other observable behaviour too: when the tested expression throws on its second invocation and not on its first, the caller no longer sees that exception at all, because after the rewrite the second invocation never happens. Reproduced on 2.40.0 and on 2.41.0-SNAPSHOT built from main `5785534a`. The recipe is listed in `common-static-analysis.yml`, so it runs for everyone who applies `CommonStaticAnalysis`.

## Anything in particular you'd like reviewers to focus on?

This change alters an expectation that used to hold. Main's `removeRedundantNullCheckWithMethodInvocation` expected `getValue() != null && getValue() instanceof String` to become `getValue() instanceof String`. That name is gone: the same `before` source is now one of the three no-change scenarios in `doNotChangeWhenNullCheckedExpressionIsMethodInvocation`, with the `after` block removed.

Limits worth knowing:

- The recipe no longer removes the null check when the tested expression contains a method call, even a side-effect-free one such as `list.get(0)`. The Lossless Semantic Tree, OpenRewrite's representation of the parsed source, does not record whether a called method's body changes state, not even for a getter that only returns a field, so no invocation can be ruled harmless. The same applies to a constructor call (`doNotChangeWhenConstructorCall`) and to an assignment or increment inside the tested expression (`doNotChangeWhenArrayIndexHasSideEffect`).
- In Groovy, a property read such as `other.flag` parses as a field access, so the null check is still removed there. Same as on main.
- Two reads of a `volatile` field are two separate actions in the Java memory model ([JLS 17.4.2](https://docs.oracle.com/javase/specs/jls/se21/html/jls-17.html#jls-17.4.2)) and can return different values, and the null check is still removed in that case. Also the same as on main.

## Have you considered any alternatives or workarounds?

One alternative is to mention in the recipe's `description` field the new case in which the recipe declines to remove the null check. I left that text unchanged, because the existing description does not claim that the null check is always removed. If you would rather see that carve-out spelled out, it is a one-line edit.

## Any additional context

Pre-existing tests changed: `RemoveRedundantNullCheckBeforeInstanceofTest.java.removeRedundantNullCheckWithMethodInvocation` (removed).

This change adds 4 net test methods to `RemoveRedundantNullCheckBeforeInstanceofTest`, taking the focused class from 19 to 23 executions. They cover 7 new scenarios. Without the code change in this pull request, these 4 methods fail:

- `doNotChangeWhenNullCheckedExpressionIsMethodInvocation`, covering direct, null-on-left, and chained calls
- `doNotChangeWhenConstructorCall`
- `doNotChangeWhenArrayIndexHasSideEffect`
- `doNotChangeWhenOnlyTheNullCheckedOperandHasSideEffects`

`removeRedundantNullCheckInChainedCondition` passes either way and keeps the chained `&&` shape covered.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch