### PR TITLE
Remove null checks before literal equality only for side-effect-free expressions

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEquals.java
@@ -20,17 +20,13 @@ import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.openrewrite.staticanalysis.SideEffects.mayHaveSideEffects;
 
@@ -91,57 +87,29 @@ public class RemoveRedundantNullCheckBeforeLiteralEquals extends Recipe {
             }
 
             private boolean isRedundantNullCheck(J.Binary nullCheck, J.MethodInvocation equalsCall) {
-                if (nullCheck.getOperator() != J.Binary.Type.NotEqual) {
+                if (nullCheck.getOperator() != J.Binary.Type.NotEqual || !EQUALS_MATCHER.matches(equalsCall)) {
                     return false;
                 }
 
-                // Check if the method call is equals() on a literal string
-                if (!EQUALS_MATCHER.matches(equalsCall)) {
-                    return false;
-                }
-
-                // Check if the receiver is a literal string
                 Expression receiver = equalsCall.getSelect();
                 if (!(receiver instanceof J.Literal) || !(((J.Literal) receiver).getValue() instanceof String)) {
                     return false;
                 }
 
-                // Get the argument passed to equals()
                 if (equalsCall.getArguments().size() != 1) {
                     return false;
                 }
                 Expression equalsArg = equalsCall.getArguments().get(0);
 
-                // Dropping the null check evaluates the expression once where it was evaluated twice, so it is only
-                // equivalent when evaluating it has no side effects; `SemanticallyEqual` proves the two occurrences
-                // mean the same thing, not that evaluating them twice is the same as evaluating them once. A read of
-                // a field attributed as volatile is checked separately: it has no side effect of its own, which puts
-                // it outside what `SideEffects` reports, but it is a synchronization action that must not be elided.
-                if (mayHaveSideEffects(equalsArg) || readsVolatileField(equalsArg)) {
-                    return false;
-                }
+                Expression nullChecked = J.Literal.isLiteralValue(nullCheck.getLeft(), null) ? nullCheck.getRight() :
+                        J.Literal.isLiteralValue(nullCheck.getRight(), null) ? nullCheck.getLeft() : null;
 
-                // Check if the null check is for the same variable as the equals argument
-                if (J.Literal.isLiteralValue(nullCheck.getLeft(), null)) {
-                    return SemanticallyEqual.areEqual(nullCheck.getRight(), equalsArg);
-                }
-                if (J.Literal.isLiteralValue(nullCheck.getRight(), null)) {
-                    return SemanticallyEqual.areEqual(nullCheck.getLeft(), equalsArg);
-                }
-                return false;
-            }
-
-            private boolean readsVolatileField(Expression expression) {
-                return new JavaIsoVisitor<AtomicBoolean>() {
-                    @Override
-                    public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean result) {
-                        JavaType.Variable fieldType = identifier.getFieldType();
-                        if (fieldType != null && fieldType.hasFlags(Flag.Volatile)) {
-                            result.set(true);
-                        }
-                        return identifier;
-                    }
-                }.reduce(expression, new AtomicBoolean(false)).get();
+                // The rewrite evaluates the expression once where it was evaluated twice, so it is only equivalent
+                // when evaluating it is free of side effects; `SemanticallyEqual` proves the two occurrences mean the
+                // same thing, not that evaluating them twice is the same as evaluating them once.
+                return nullChecked != null &&
+                        SemanticallyEqual.areEqual(nullChecked, equalsArg) &&
+                        !mayHaveSideEffects(equalsArg);
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEquals.java
@@ -20,13 +20,19 @@ import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.SemanticallyEqual;
 import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.openrewrite.staticanalysis.SideEffects.mayHaveSideEffects;
 
 @EqualsAndHashCode(callSuper = false)
 @Value
@@ -106,6 +112,15 @@ public class RemoveRedundantNullCheckBeforeLiteralEquals extends Recipe {
                 }
                 Expression equalsArg = equalsCall.getArguments().get(0);
 
+                // Dropping the null check evaluates the expression once where it was evaluated twice, so it is only
+                // equivalent when evaluating it has no side effects; `SemanticallyEqual` proves the two occurrences
+                // mean the same thing, not that evaluating them twice is the same as evaluating them once. A read of
+                // a field attributed as volatile is checked separately: it has no side effect of its own, which puts
+                // it outside what `SideEffects` reports, but it is a synchronization action that must not be elided.
+                if (mayHaveSideEffects(equalsArg) || readsVolatileField(equalsArg)) {
+                    return false;
+                }
+
                 // Check if the null check is for the same variable as the equals argument
                 if (J.Literal.isLiteralValue(nullCheck.getLeft(), null)) {
                     return SemanticallyEqual.areEqual(nullCheck.getRight(), equalsArg);
@@ -114,6 +129,19 @@ public class RemoveRedundantNullCheckBeforeLiteralEquals extends Recipe {
                     return SemanticallyEqual.areEqual(nullCheck.getLeft(), equalsArg);
                 }
                 return false;
+            }
+
+            private boolean readsVolatileField(Expression expression) {
+                return new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean result) {
+                        JavaType.Variable fieldType = identifier.getFieldType();
+                        if (fieldType != null && fieldType.hasFlags(Flag.Volatile)) {
+                            result.set(true);
+                        }
+                        return identifier;
+                    }
+                }.reduce(expression, new AtomicBoolean(false)).get();
             }
         };
     }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEquals.java
@@ -104,9 +104,8 @@ public class RemoveRedundantNullCheckBeforeLiteralEquals extends Recipe {
                 Expression nullChecked = J.Literal.isLiteralValue(nullCheck.getLeft(), null) ? nullCheck.getRight() :
                         J.Literal.isLiteralValue(nullCheck.getRight(), null) ? nullCheck.getLeft() : null;
 
-                // The rewrite evaluates the expression once where it was evaluated twice, so it is only equivalent
-                // when evaluating it is free of side effects; `SemanticallyEqual` proves the two occurrences mean the
-                // same thing, not that evaluating them twice is the same as evaluating them once.
+                // The rewrite evaluates once what was evaluated twice; `SemanticallyEqual` proves the occurrences
+                // mean the same thing, not that evaluating them twice is the same as once
                 return nullChecked != null &&
                         SemanticallyEqual.areEqual(nullChecked, equalsArg) &&
                         !mayHaveSideEffects(equalsArg);

--- a/src/main/java/org/openrewrite/staticanalysis/SideEffects.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SideEffects.java
@@ -18,7 +18,9 @@ package org.openrewrite.staticanalysis;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -27,9 +29,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * delete an expression, or that stop evaluating one, are only correct when the answer is {@code false}.
  * <p>
  * Deliberately conservative: any method invocation, constructor call, assignment or increment counts, since
- * whether those are pure cannot be decided from the LST alone. {@link org.openrewrite.java.tree.Expression#getSideEffects()}
- * is not used here because it reports only the side effects of the expression's own node type, and so misses
- * those nested inside a ternary or a lambda.
+ * whether those are pure cannot be decided from the LST alone. A read of a field attributed as volatile counts
+ * too: it produces no side effect of its own, but it is a synchronization action that must not be elided.
+ * {@link org.openrewrite.java.tree.Expression#getSideEffects()} is not used here because it reports only the
+ * side effects of the expression's own node type, and so misses those nested inside a ternary or a lambda.
  */
 final class SideEffects {
 
@@ -77,6 +80,15 @@ final class SideEffects {
             public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean result) {
                 result.set(true);
                 return newClass;
+            }
+
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean result) {
+                JavaType.Variable fieldType = identifier.getFieldType();
+                if (fieldType != null && fieldType.hasFlags(Flag.Volatile)) {
+                    result.set(true);
+                }
+                return identifier;
             }
 
             @Override

--- a/src/main/java/org/openrewrite/staticanalysis/SideEffects.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SideEffects.java
@@ -25,14 +25,12 @@ import org.openrewrite.java.tree.JavaType;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Whether evaluating an expression might do something observable beyond producing its value. Recipes that
- * delete an expression, or that stop evaluating one, are only correct when the answer is {@code false}.
- * <p>
- * Deliberately conservative: any method invocation, constructor call, assignment or increment counts, since
- * whether those are pure cannot be decided from the LST alone. A read of a field attributed as volatile counts
- * too: it produces no side effect of its own, but it is a synchronization action that must not be elided.
- * {@link org.openrewrite.java.tree.Expression#getSideEffects()} is not used here because it reports only the
- * side effects of the expression's own node type, and so misses those nested inside a ternary or a lambda.
+ * Whether evaluating an expression might do something observable beyond producing its value; recipes deleting an
+ * expression, or evaluating one fewer times, are only correct when this is {@code false}. Deliberately
+ * conservative: any invocation, constructor call, assignment or increment counts, as does a {@code volatile} read,
+ * which is a synchronization action rather than a side effect. Not {@link
+ * org.openrewrite.java.tree.Expression#getSideEffects()}, which reports only the expression's own node type and so
+ * misses anything nested inside a ternary or a lambda.
  */
 final class SideEffects {
 

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantNullCheckBeforeLiteralEqualsTest.java
@@ -17,12 +17,13 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-@SuppressWarnings({"ConstantConditions", "ConditionCoveredByFurtherCondition"})
+@SuppressWarnings({"ConstantConditions", "ConditionCoveredByFurtherCondition", "NestedAssignment", "RedundantCast"})
 class RemoveRedundantNullCheckBeforeLiteralEqualsTest implements RewriteTest {
 
     @Override
@@ -86,33 +87,173 @@ class RemoveRedundantNullCheckBeforeLiteralEqualsTest implements RewriteTest {
     }
 
     @Test
-    void removeRedundantNullCheckWithMethodInvocation() {
+    void removeRedundantNullCheckWhenParenthesized() {
         rewriteRun(
           //language=java
           java(
             """
               class A {
-                  void foo() {
-                      if (getValue() != null && "expected".equals(getValue())) {
-                          System.out.println("Match");
+                  void foo(String s) {
+                      if ((s) != null && "test".equals(s)) {
+                          System.out.println("Parentheses around the null checked expression");
                       }
-                  }
-
-                  String getValue() {
-                      return "expected";
                   }
               }
               """,
             """
               class A {
+                  void foo(String s) {
+                      if ("test".equals(s)) {
+                          System.out.println("Parentheses around the null checked expression");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenNullCheckedExpressionIsMethodInvocation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  String next() {
+                      return "";
+                  }
+
+                  boolean direct() {
+                      return next() != null && "ok".equals(next());
+                  }
+
+                  boolean chained(boolean enabled) {
+                      return enabled && next() != null && "ok".equals(next());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenNullCheckedFieldIsVolatile() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  volatile String value;
+                  static volatile String shared;
+
                   void foo() {
-                      if ("expected".equals(getValue())) {
-                          System.out.println("Match");
+                      if (value != null && "test".equals(value)) {
+                          System.out.println("Volatile read must not be elided");
                       }
                   }
 
-                  String getValue() {
-                      return "expected";
+                  void qualified() {
+                      if (A.shared != null && "test".equals(A.shared)) {
+                          System.out.println("Nor a qualified volatile read");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenNullCheckedExpressionIsAssignment() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void assignment(String s, String t) {
+                      if ((s = t) != null && "test".equals(s = t)) {
+                          System.out.println("Assignment");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenArrayIndexHasSideEffect() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  String[] values = new String[2];
+                  int i;
+
+                  void foo() {
+                      if (values[i++] != null && "test".equals(values[i++])) {
+                          System.out.println("Array access with increment");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantNullCheckWithArrayAccess() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void foo(String[] values) {
+                      if (values[0] != null && "test".equals(values[0])) {
+                          System.out.println("Array access");
+                      }
+                  }
+              }
+              """,
+            """
+              class A {
+                  void foo(String[] values) {
+                      if ("test".equals(values[0])) {
+                          System.out.println("Array access");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantNullCheckWithCast() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void foo(Object o) {
+                      if ((String) o != null && "test".equals((String) o)) {
+                          System.out.println("Cast");
+                      }
+                  }
+              }
+              """,
+            """
+              class A {
+                  void foo(Object o) {
+                      if ("test".equals((String) o)) {
+                          System.out.println("Cast");
+                      }
                   }
               }
               """
@@ -143,6 +284,69 @@ class RemoveRedundantNullCheckBeforeLiteralEqualsTest implements RewriteTest {
                   void foo() {
                       if ("constant".equals(this.field)) {
                           System.out.println("Field matches");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeRedundantNullCheckWithStaticFieldAccess() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  static String field;
+
+                  static class Inner {
+                      static String nested;
+                  }
+
+                  void foo() {
+                      if (A.field != null && "constant".equals(A.field)) {
+                          System.out.println("Static field matches");
+                      }
+                  }
+
+                  void nested() {
+                      if (A.Inner.nested != null && "constant".equals(A.Inner.nested)) {
+                          System.out.println("Nested class field matches");
+                      }
+                  }
+
+                  void fullyQualified() {
+                      if (java.io.File.separator != null && "/".equals(java.io.File.separator)) {
+                          System.out.println("Separator matches");
+                      }
+                  }
+              }
+              """,
+            """
+              class A {
+                  static String field;
+
+                  static class Inner {
+                      static String nested;
+                  }
+
+                  void foo() {
+                      if ("constant".equals(A.field)) {
+                          System.out.println("Static field matches");
+                      }
+                  }
+
+                  void nested() {
+                      if ("constant".equals(A.Inner.nested)) {
+                          System.out.println("Nested class field matches");
+                      }
+                  }
+
+                  void fullyQualified() {
+                      if ("/".equals(java.io.File.separator)) {
+                          System.out.println("Separator matches");
                       }
                   }
               }

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyRedundantLogicalExpressionTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyRedundantLogicalExpressionTest.java
@@ -262,6 +262,25 @@ class SimplifyRedundantLogicalExpressionTest implements RewriteTest {
     }
 
     @Test
+    void doNotChangeVolatileFieldRead() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  volatile boolean flag;
+
+                  @SuppressWarnings("all")
+                  boolean test() {
+                      return flag && flag;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void simplifyLogicalAndKotlin() {
         rewriteRun(
           //language=kotlin

--- a/src/test/java/org/openrewrite/staticanalysis/groovy/RemoveRedundantNullCheckBeforeLiteralEqualsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/groovy/RemoveRedundantNullCheckBeforeLiteralEqualsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.staticanalysis.groovy;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeLiteralEquals;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.groovy.Assertions.groovy;
+
+class RemoveRedundantNullCheckBeforeLiteralEqualsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveRedundantNullCheckBeforeLiteralEquals());
+    }
+
+    @Test
+    void removeRedundantNullCheck() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+            """
+              class A {
+                  boolean parameter(String s) {
+                      s != null && "ok".equals(s)
+                  }
+              }
+              """,
+            """
+              class A {
+                  boolean parameter(String s) {
+                      "ok".equals(s)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void doNotChangeWhenNullCheckedExpressionIsMethodInvocation() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+            """
+              class A {
+                  String next() {
+                      ""
+                  }
+
+                  boolean direct() {
+                      next() != null && "ok".equals(next())
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
**Suggested review order:** 35 of 52 (Score: 2.5)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1191

## What's changed?

[`RemoveRedundantNullCheckBeforeLiteralEquals`](https://docs.openrewrite.org/recipes/staticanalysis/removeredundantnullcheckbeforeliteralequals) rewrites `expr != null && "literal".equals(expr)` into `"literal".equals(expr)`. With this change it makes no change at all when evaluating `expr` may have side effects.

`isRedundantNullCheck`, which decides whether a `!= null` test may be dropped, now returns `false`, meaning "keep the null check, change nothing", when either of two new checks fires on the argument of `equals`. Checking that one node is enough: the recipe removes nothing unless `SemanticallyEqual.areEqual` reports it to be the same expression as the null-checked one.

- `SideEffects.mayHaveSideEffects`, the package-private helper that pull request #959 added to this package; this change does not modify it.
- `readsVolatileField`, a new private method in this recipe's visitor. A volatile read is not a side effect, so `SideEffects` does not report it, but it is a synchronization action: [JLS 17.4.2](https://docs.oracle.com/javase/specs/jls/se21/html/jls-17.html#jls-17.4.2) lists a read of a volatile variable among them, so dropping one of two reads can change what another thread sees.

`visitBinary` matches a direct shape and a chained shape, `enabled && expr != null && "literal".equals(expr)`, and calls `isRedundantNullCheck` on both, so the guard covers both.

## What's your motivation?

**Recipe:** `org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeLiteralEquals`.

### Before

```java
return next() != null && "ok".equals(next());
```

### Actual after the recipe

```java
return "ok".equals(next());
```

### Expected after the recipe

(unchanged)

The input evaluates `expr` twice, the output evaluates it once. `SemanticallyEqual.areEqual` proves that the two occurrences of `expr` mean the same thing, not that evaluating it once is the same as evaluating it twice.

The output that main produces still compiles, but it can produce a different value at runtime. With a `next()` that returns `"no"` on its first call and `"ok"` on its second, the input returns `true`: the null check consumes the first call and `equals` compares `"ok"` with the `"ok"` of the second. The output returns `false`, because `equals` now sees the first call. The same applies to `values[i++]`, to an assignment such as `(s = t)` and to a volatile read.

A recipe must not stop evaluating an expression that may have side effects. Issue #953 describes this class of problem, and pull request #959 (merged as commit 70da6593) applied that rule to four other recipes and moved the side-effect check that `SimplifyRedundantLogicalExpression` already carried into the new shared `SideEffects` helper. Neither the issue nor that pull request mentions this recipe. Reproduced on v2.40.0 and on 2.41.0-SNAPSHOT from main 5785534a.

## Anything in particular you'd like reviewers to focus on?

One existing test is deleted, because this change reverses an expectation that held until now: `removeRedundantNullCheckWithMethodInvocation` asserted that `getValue() != null && "expected".equals(getValue())` becomes `"expected".equals(getValue())`. The new `doNotChangeWhenNullCheckedExpressionIsMethodInvocation` covers the same shape and asserts that it is now left unchanged.

Three limits, all with this change applied:

- A method call anywhere in the null-checked expression now stops the removal, including a simple getter such as `list.get(0)`: `SideEffects` cannot tell a read-only getter from one that changes state, so it reports every method call as possibly effectful.
- In Groovy only an explicit call is caught. A property read backed by a getter is written without parentheses and parses as a property access rather than a method invocation, so `SideEffects` sees no call and the null check in front of it is still removed. Groovy is partly fixed, not fully fixed.
- `readsVolatileField` asks every identifier in the argument of `equals` whether its `JavaType.Variable` field type carries `Flag.Volatile`. An LST parsed without type attribution has no such field type, so the check misses that case.

An array access such as `values[0]` and a cast such as `(String) o` are still simplified: neither evaluates anything that may have side effects.

## Have you considered any alternatives or workarounds?

One alternative is to put the volatile check in `SideEffects` instead of in this recipe. Four other recipes call `SideEffects.mayHaveSideEffects`: `AllBranchesIdentical`, `RemoveDuplicateConditions`, `RemoveUnconditionalValueOverwrite` and `SimplifyRedundantLogicalExpression`. Moving the check into the shared helper would therefore change their runtime behaviour too, not only this recipe's.

The opposite option is to drop the volatile check entirely, leaving this change the same shape as the fixes in #959: a call to `mayHaveSideEffects` and nothing else.

Either option is about ten lines: the private `readsVolatileField` method and its call inside `isRedundantNullCheck`, plus the test `doNotChangeWhenNullCheckedFieldIsVolatile`. That test would then belong with the shared helper, which has no test class of its own today, or be deleted along with the check.

## Any additional context

Pre-existing tests changed: `RemoveRedundantNullCheckBeforeLiteralEqualsTest.java.removeRedundantNullCheckWithMethodInvocation` (removed).

This change adds 8 tests to `RemoveRedundantNullCheckBeforeLiteralEqualsTest` and deletes the test named above, taking that class from 16 tests to 23. Without the code change in this pull request, these 4 new tests fail:

- `doNotChangeWhenArrayIndexHasSideEffect`
- `doNotChangeWhenNullCheckedExpressionIsAssignment`
- `doNotChangeWhenNullCheckedExpressionIsMethodInvocation`
- `doNotChangeWhenNullCheckedFieldIsVolatile`

The other 4 new tests assert that expressions without side effects are still simplified.

It also adds a new Groovy test class of the same name, in `org.openrewrite.staticanalysis.groovy`, with 2 tests. Without the code change in this pull request, 1 of them fails: `doNotChangeWhenNullCheckedExpressionIsMethodInvocation`. The other, `removeRedundantNullCheck`, asserts that the null check in front of a Groovy parameter is still removed.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

I ran the formatter with the repository's `.editorconfig`. It also wanted to re-indent lines that this change does not touch, so I left those alone and kept the diff limited to this change.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch