### PR TITLE
UnwrapElseAfterReturn: only unwrap when else declarations do not collide

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
@@ -22,6 +22,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.Repeat;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.J;
@@ -30,8 +31,13 @@ import org.openrewrite.java.tree.Statement;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.singletonList;
 
 public class UnwrapElseAfterReturn extends Recipe {
 
@@ -52,10 +58,11 @@ public class UnwrapElseAfterReturn extends Recipe {
             public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
                 J.Block b = visitAndCast(block, ctx, super::visitBlock);
                 AtomicReference<@Nullable Space> endWhitespace = new AtomicReference<>(null);
-                J.Block alteredBlock = b.withStatements(ListUtils.flatMap(b.getStatements(), statement -> {
+                J.Block alteredBlock = b.withStatements(ListUtils.flatMap(b.getStatements(), (index, statement) -> {
                     if (statement instanceof J.If) {
                         J.If ifStatement = (J.If) statement;
                         if (ifStatement.getElsePart() != null && endsWithReturnOrThrow(ifStatement.getThenPart())) {
+                            List<Statement> laterStatements = b.getStatements().subList(index + 1, b.getStatements().size());
                             Statement elsePart = ifStatement.getElsePart().getBody();
                             if (elsePart instanceof J.If) {
                                 // Else-if chain: find and unwrap the innermost else
@@ -65,11 +72,13 @@ public class UnwrapElseAfterReturn extends Recipe {
                                         endsWithReturnOrThrow(innermost.getThenPart()) &&
                                         !(innermost.getElsePart().getBody() instanceof J.If)) {
                                     // Unwrap the innermost else
-                                    J.If modifiedChain = removeInnermostElse(ifStatement);
                                     Statement innermostElseBody = innermost.getElsePart().getBody();
-                                    return flatten(innermost, innermostElseBody, endWhitespace, modifiedChain);
+                                    if (!collidesWithLaterScope(innermostElseBody, laterStatements)) {
+                                        J.If modifiedChain = removeInnermostElse(ifStatement);
+                                        return flatten(innermost, innermostElseBody, endWhitespace, modifiedChain);
+                                    }
                                 }
-                            } else {
+                            } else if (!collidesWithLaterScope(elsePart, laterStatements)) {
                                 // Plain else block: unwrap directly
                                 J.If newIf = ifStatement.withElsePart(null);
                                 return flatten(ifStatement, elsePart, endWhitespace, newIf);
@@ -103,6 +112,97 @@ public class UnwrapElseAfterReturn extends Recipe {
                     }));
                 }
                 return Arrays.asList(ifWithoutElse, tailElse.withPrefix(tailIf.getElsePart().getPrefix()));
+            }
+
+            /**
+             * Statements hoisted out of the else block move into the enclosing block, where the names they
+             * declare stay in scope until the end of that block. Unwrapping is therefore skipped when that
+             * larger scope could change how a name in the statements after the {@code if} resolves:
+             * <ul>
+             * <li>A hoisted name that is declared again in a later statement, at any nesting depth, would
+             * usually no longer compile, since Java does not allow local variables or local classes of a
+             * method to shadow each other; that covers later locals, loop variables, catch parameters,
+             * resources, lambda parameters, pattern variables and local types.</li>
+             * <li>A later unqualified use of a hoisted name currently resolves to something else, such as
+             * a field or a statically imported member, and would be captured by the hoisted declaration,
+             * silently changing semantics or breaking compilation. Uses whose resolution cannot be
+             * affected by a local variable or local class coming into scope, such as method invocation
+             * names, qualified field accesses and labels, are exempt.</li>
+             * </ul>
+             * The names a hoisted statement introduces are its declared variables and local types, plus
+             * every {@code instanceof} pattern variable anywhere inside it: flow scoping (JLS 6.3.2) can
+             * extend a pattern variable past its statement once that statement sits directly in the
+             * enclosing block, e.g. {@code if (!(o instanceof String s)) return;} leaves {@code s} in
+             * scope for the rest of the block. Not every pattern variable escapes its statement, so this
+             * errs on the side of keeping the else block.
+             */
+            private boolean collidesWithLaterScope(Statement elseBody, List<Statement> laterStatements) {
+                if (laterStatements.isEmpty()) {
+                    return false;
+                }
+                Set<String> hoistedNames = new HashSet<>();
+                JavaIsoVisitor<Set<String>> patternVariableCollector = new JavaIsoVisitor<Set<String>>() {
+                    @Override
+                    public J.InstanceOf visitInstanceOf(J.InstanceOf instanceOf, Set<String> names) {
+                        if (instanceOf.getPattern() instanceof J.Identifier) {
+                            names.add(((J.Identifier) instanceOf.getPattern()).getSimpleName());
+                        }
+                        return super.visitInstanceOf(instanceOf, names);
+                    }
+
+                    @Override
+                    public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Set<String> names) {
+                        // The bindings of a record deconstruction pattern are variable declarations nested inside the pattern
+                        if (getCursor().firstEnclosing(J.DeconstructionPattern.class) != null) {
+                            names.add(variable.getSimpleName());
+                        }
+                        return super.visitVariable(variable, names);
+                    }
+                };
+                List<Statement> hoistedStatements = elseBody instanceof J.Block ? ((J.Block) elseBody).getStatements() : singletonList(elseBody);
+                for (Statement hoisted : hoistedStatements) {
+                    if (hoisted instanceof J.VariableDeclarations) {
+                        for (J.VariableDeclarations.NamedVariable variable : ((J.VariableDeclarations) hoisted).getVariables()) {
+                            hoistedNames.add(variable.getSimpleName());
+                        }
+                    } else if (hoisted instanceof J.ClassDeclaration) {
+                        hoistedNames.add(((J.ClassDeclaration) hoisted).getSimpleName());
+                    }
+                    patternVariableCollector.visit(hoisted, hoistedNames);
+                }
+                if (hoistedNames.isEmpty()) {
+                    return false;
+                }
+
+                AtomicBoolean collides = new AtomicBoolean(false);
+                JavaIsoVisitor<AtomicBoolean> nameScanner = new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
+                        if (hoistedNames.contains(identifier.getSimpleName())) {
+                            // Both declarations and unqualified uses appear as identifiers; only identifiers
+                            // that resolve in another namespace or through a qualifier are unaffected
+                            Object parent = getCursor().getParentTreeCursor().getValue();
+                            boolean unaffected = parent instanceof J.MethodInvocation && identifier == ((J.MethodInvocation) parent).getName() ||
+                                    parent instanceof J.FieldAccess && identifier == ((J.FieldAccess) parent).getName() ||
+                                    parent instanceof J.MemberReference && identifier == ((J.MemberReference) parent).getReference() ||
+                                    parent instanceof J.MethodDeclaration && identifier == ((J.MethodDeclaration) parent).getName() ||
+                                    parent instanceof J.Label ||
+                                    parent instanceof J.Break ||
+                                    parent instanceof J.Continue;
+                            if (!unaffected) {
+                                found.set(true);
+                            }
+                        }
+                        return super.visitIdentifier(identifier, found);
+                    }
+                };
+                for (Statement laterStatement : laterStatements) {
+                    nameScanner.visit(laterStatement, collides);
+                    if (collides.get()) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             private J.@Nullable If findInnermostIfWithElse(J.If ifStatement) {

--- a/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
@@ -115,26 +115,18 @@ public class UnwrapElseAfterReturn extends Recipe {
             }
 
             /**
-             * Statements hoisted out of the else block move into the enclosing block, where the names they
-             * declare stay in scope until the end of that block. Unwrapping is therefore skipped when that
-             * larger scope could change how a name in the statements after the {@code if} resolves:
-             * <ul>
-             * <li>A hoisted name that is declared again in a later statement, at any nesting depth, would
-             * usually no longer compile, since Java does not allow local variables or local classes of a
-             * method to shadow each other; that covers later locals, loop variables, catch parameters,
-             * resources, lambda parameters, pattern variables and local types.</li>
-             * <li>A later unqualified use of a hoisted name currently resolves to something else, such as
-             * a field or a statically imported member, and would be captured by the hoisted declaration,
-             * silently changing semantics or breaking compilation. Uses whose resolution cannot be
-             * affected by a local variable or local class coming into scope, such as method invocation
-             * names, qualified field accesses and labels, are exempt.</li>
-             * </ul>
-             * The names a hoisted statement introduces are its declared variables and local types, plus
-             * every {@code instanceof} pattern variable anywhere inside it: flow scoping (JLS 6.3.2) can
-             * extend a pattern variable past its statement once that statement sits directly in the
-             * enclosing block, e.g. {@code if (!(o instanceof String s)) return;} leaves {@code s} in
-             * scope for the rest of the block. Not every pattern variable escapes its statement, so this
-             * errs on the side of keeping the else block.
+             * Statements hoisted out of the else block move into the enclosing block, where the names they declare
+             * stay in scope until the end of that block. Unwrapping is skipped when that larger scope could change
+             * how a name in the statements after the {@code if} resolves: a later redeclaration no longer compiles
+             * (JLS 6.4 forbids local variables and local classes of a method shadowing each other), and a later
+             * unqualified use that resolves to a field or a statically imported member would be captured by the
+             * hoisted declaration instead. Uses a local cannot capture, such as method invocation names, qualified
+             * field accesses and labels, are exempt.
+             * <p>
+             * Every {@code instanceof} pattern variable inside a hoisted statement counts as a hoisted name, because
+             * flow scoping (JLS 6.3.2) can extend one past its statement once that statement sits directly in the
+             * enclosing block, as in {@code if (!(o instanceof String s)) return;}. Not every pattern variable
+             * escapes, so this errs on the side of keeping the else block.
              */
             private boolean collidesWithLaterScope(Statement elseBody, List<Statement> laterStatements) {
                 if (laterStatements.isEmpty()) {
@@ -179,8 +171,8 @@ public class UnwrapElseAfterReturn extends Recipe {
                     @Override
                     public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
                         if (hoistedNames.contains(identifier.getSimpleName())) {
-                            // Both declarations and unqualified uses appear as identifiers; only identifiers
-                            // that resolve in another namespace or through a qualifier are unaffected
+                            // Declarations and unqualified uses both appear as identifiers; only those resolving in
+                            // another namespace or through a qualifier are unaffected
                             Object parent = getCursor().getParentTreeCursor().getValue();
                             boolean unaffected = parent instanceof J.MethodInvocation && identifier == ((J.MethodInvocation) parent).getName() ||
                                     parent instanceof J.FieldAccess && identifier == ((J.FieldAccess) parent).getName() ||

--- a/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturn.java
@@ -115,18 +115,12 @@ public class UnwrapElseAfterReturn extends Recipe {
             }
 
             /**
-             * Statements hoisted out of the else block move into the enclosing block, where the names they declare
-             * stay in scope until the end of that block. Unwrapping is skipped when that larger scope could change
-             * how a name in the statements after the {@code if} resolves: a later redeclaration no longer compiles
-             * (JLS 6.4 forbids local variables and local classes of a method shadowing each other), and a later
-             * unqualified use that resolves to a field or a statically imported member would be captured by the
-             * hoisted declaration instead. Uses a local cannot capture, such as method invocation names, qualified
-             * field accesses and labels, are exempt.
-             * <p>
-             * Every {@code instanceof} pattern variable inside a hoisted statement counts as a hoisted name, because
-             * flow scoping (JLS 6.3.2) can extend one past its statement once that statement sits directly in the
-             * enclosing block, as in {@code if (!(o instanceof String s)) return;}. Not every pattern variable
-             * escapes, so this errs on the side of keeping the else block.
+             * Hoisting the else block widens the scope of the names it declares to the end of the enclosing block,
+             * so unwrapping is skipped where that could change how a later name resolves: a later redeclaration no
+             * longer compiles (JLS 6.4), and a later unqualified use of a field or statically imported member would
+             * be captured instead. Names a local cannot capture, such as invocation names and labels, are exempt.
+             * Every {@code instanceof} pattern variable counts as hoisted, since flow scoping (JLS 6.3.2) can carry
+             * one past its own statement; not all of them do, so this errs towards keeping the else block.
              */
             private boolean collidesWithLaterScope(Statement elseBody, List<Statement> laterStatements) {
                 if (laterStatements.isEmpty()) {
@@ -144,7 +138,7 @@ public class UnwrapElseAfterReturn extends Recipe {
 
                     @Override
                     public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Set<String> names) {
-                        // The bindings of a record deconstruction pattern are variable declarations nested inside the pattern
+                        // A record deconstruction pattern nests its bindings as variable declarations
                         if (getCursor().firstEnclosing(J.DeconstructionPattern.class) != null) {
                             names.add(variable.getSimpleName());
                         }
@@ -171,8 +165,8 @@ public class UnwrapElseAfterReturn extends Recipe {
                     @Override
                     public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
                         if (hoistedNames.contains(identifier.getSimpleName())) {
-                            // Declarations and unqualified uses both appear as identifiers; only those resolving in
-                            // another namespace or through a qualifier are unaffected
+                            // Declarations and unqualified uses are both identifiers; only another namespace or a
+                            // qualifier makes one safe
                             Object parent = getCursor().getParentTreeCursor().getValue();
                             boolean unaffected = parent instanceof J.MethodInvocation && identifier == ((J.MethodInvocation) parent).getName() ||
                                     parent instanceof J.FieldAccess && identifier == ((J.FieldAccess) parent).getName() ||

--- a/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
@@ -947,6 +947,22 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
                       }
                       System.out.println(value());
                   }
+
+                  void labelUse(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          String value = "1";
+                          System.out.println(value);
+                      }
+                      value:
+                      for (int i = 0; i < 2; i++) {
+                          if (i == 1) {
+                              break value;
+                          }
+                          continue value;
+                      }
+                  }
               }
               """,
             """
@@ -973,6 +989,21 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
                       String value = "1";
                       System.out.println(value);
                       System.out.println(value());
+                  }
+
+                  void labelUse(boolean stop) {
+                      if (stop) {
+                          return;
+                      }
+                      String value = "1";
+                      System.out.println(value);
+                      value:
+                      for (int i = 0; i < 2; i++) {
+                          if (i == 1) {
+                              break value;
+                          }
+                          continue value;
+                      }
                   }
               }
               """

--- a/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnwrapElseAfterReturnTest.java
@@ -16,13 +16,16 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
 
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings({"ConstantConditions", "unused"})
 class UnwrapElseAfterReturnTest implements RewriteTest {
 
     @Override
@@ -643,6 +646,520 @@ class UnwrapElseAfterReturnTest implements RewriteTest {
                           return 1; // end 1
                       }
                       return 2; // end 2
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotUnwrapWhenElseDeclarationCollidesWithLaterLocalVariable() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void plain(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          int value = 1;
+                          System.out.println(value);
+                      }
+                      int value = 2;
+                      System.out.println(value);
+                  }
+
+                  void chain(boolean first, boolean second) {
+                      if (first) {
+                          return;
+                      } else if (second) {
+                          return;
+                      } else {
+                          int value = 1;
+                          System.out.println(value);
+                      }
+                      int value = 2;
+                      System.out.println(value);
+                  }
+
+                  void afterThrow(boolean stop) {
+                      if (stop) {
+                          throw new IllegalStateException();
+                      } else {
+                          String value = "1";
+                          System.out.println(value);
+                      }
+                      long value = 2;
+                      System.out.println(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotUnwrapWhenElseDeclarationCollidesWithNestedScope() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.IOException;
+              import java.io.StringReader;
+              import java.util.List;
+
+              class Test {
+                  void catchVariable(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          int value = 1;
+                          System.out.println(value);
+                      }
+                      try {
+                          System.out.println("try");
+                      } catch (RuntimeException value) {
+                          System.out.println(value);
+                      }
+                  }
+
+                  void resourceVariable(boolean stop) throws IOException {
+                      if (stop) {
+                          return;
+                      } else {
+                          int reader = 1;
+                          System.out.println(reader);
+                      }
+                      try (StringReader reader = new StringReader("")) {
+                          System.out.println(reader.read());
+                      }
+                  }
+
+                  void lambdaParameter(boolean stop, List<String> values) {
+                      if (stop) {
+                          return;
+                      } else {
+                          int element = 1;
+                          System.out.println(element);
+                      }
+                      values.forEach(element -> System.out.println(element));
+                  }
+
+                  void loopVariable(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          int index = 1;
+                          System.out.println(index);
+                      }
+                      for (int index = 0; index < 2; index++) {
+                          System.out.println(index);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotUnwrapWhenElseLocalClassCollidesWithLaterLocalClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void foo(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          class Helper {
+                          }
+                          System.out.println(new Helper());
+                      }
+                      class Helper {
+                      }
+                      System.out.println(new Helper());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotUnwrapWhenElseDeclarationCollidesWithLaterPatternVariable() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                class Test {
+                    void foo(boolean stop, Object o) {
+                        if (stop) {
+                            return;
+                        } else {
+                            String text = "1";
+                            System.out.println(text);
+                        }
+                        if (o instanceof String text) {
+                            System.out.println(text);
+                        }
+                    }
+                }
+                """
+            ), 17
+          )
+        );
+    }
+
+    @Test
+    void doNotUnwrapWhenEscapedPatternVariableCollidesWithLaterDeclaration() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                class Test {
+                    void plain(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        } else {
+                            if (!(o instanceof String s)) {
+                                return;
+                            }
+                            System.out.println(s);
+                        }
+                        String s = "later";
+                        System.out.println(s);
+                    }
+
+                    void chain(Object o, boolean first, boolean second) {
+                        if (first) {
+                            return;
+                        } else if (second) {
+                            return;
+                        } else {
+                            if (!(o instanceof String s)) {
+                                return;
+                            }
+                            System.out.println(s);
+                        }
+                        String s = "later";
+                        System.out.println(s);
+                    }
+
+                    void singleStatementElse(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        } else
+                            while (!(o instanceof String s))
+                                o = o.toString();
+                        String s = "later";
+                        System.out.println(s);
+                    }
+                }
+                """
+            ), 17
+          )
+        );
+    }
+
+    @Test
+    void doNotUnwrapWhenElseDeclarationShadowsNameUsedLater() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  int value;
+
+                  void plain(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          String value = "1";
+                          System.out.println(value);
+                      }
+                      int doubled = value * 2;
+                      System.out.println(doubled);
+                  }
+
+                  void chain(boolean first, boolean second) {
+                      if (first) {
+                          return;
+                      } else if (second) {
+                          return;
+                      } else {
+                          String value = "1";
+                          System.out.println(value);
+                      }
+                      int doubled = value * 2;
+                      System.out.println(doubled);
+                  }
+
+                  int sameType(boolean stop) {
+                      if (stop) {
+                          return -1;
+                      } else {
+                          int value = 1;
+                          System.out.println(value);
+                      }
+                      return value;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void unwrapWhenLaterUsesAreNotCapturedByHoistedNames() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  int value;
+
+                  int value() {
+                      return 42;
+                  }
+
+                  void qualifiedFieldUse(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          String value = "1";
+                          System.out.println(value);
+                      }
+                      System.out.println(this.value);
+                  }
+
+                  void methodNameUse(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          String value = "1";
+                          System.out.println(value);
+                      }
+                      System.out.println(value());
+                  }
+              }
+              """,
+            """
+              class Test {
+                  int value;
+
+                  int value() {
+                      return 42;
+                  }
+
+                  void qualifiedFieldUse(boolean stop) {
+                      if (stop) {
+                          return;
+                      }
+                      String value = "1";
+                      System.out.println(value);
+                      System.out.println(this.value);
+                  }
+
+                  void methodNameUse(boolean stop) {
+                      if (stop) {
+                          return;
+                      }
+                      String value = "1";
+                      System.out.println(value);
+                      System.out.println(value());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void unwrapWhenEscapedPatternVariableDoesNotCollide() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                class Test {
+                    void foo(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        } else {
+                            if (!(o instanceof String s)) {
+                                return;
+                            }
+                            System.out.println(s);
+                        }
+                        System.out.println("done");
+                    }
+                }
+                """,
+              """
+                class Test {
+                    void foo(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        }
+                        if (!(o instanceof String s)) {
+                            return;
+                        }
+                        System.out.println(s);
+                        System.out.println("done");
+                    }
+                }
+                """
+            ), 17
+          )
+        );
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    void unwrapOnlyWhenDeconstructionPatternBindingsDoNotCollide() {
+        rewriteRun(
+          version(
+            //language=java
+            java(
+              """
+                class Test {
+                    record Point(int x, int y) {}
+
+                    void collides(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        } else {
+                            if (!(o instanceof Point(int x, int y))) {
+                                return;
+                            }
+                            System.out.println(x + y);
+                        }
+                        int x = 5;
+                        System.out.println(x);
+                    }
+
+                    void doesNotCollide(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        } else {
+                            if (!(o instanceof Point(int x, int y))) {
+                                return;
+                            }
+                            System.out.println(x + y);
+                        }
+                        Point p = new Point(1, 2);
+                        System.out.println(p);
+                    }
+                }
+                """,
+              """
+                class Test {
+                    record Point(int x, int y) {}
+
+                    void collides(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        } else {
+                            if (!(o instanceof Point(int x, int y))) {
+                                return;
+                            }
+                            System.out.println(x + y);
+                        }
+                        int x = 5;
+                        System.out.println(x);
+                    }
+
+                    void doesNotCollide(Object o, boolean stop) {
+                        if (stop) {
+                            return;
+                        }
+                        if (!(o instanceof Point(int x, int y))) {
+                            return;
+                        }
+                        System.out.println(x + y);
+                        Point p = new Point(1, 2);
+                        System.out.println(p);
+                    }
+                }
+                """
+            ), 21
+          )
+        );
+    }
+
+    @Test
+    void unwrapWhenElseDeclarationsDoNotCollide() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void foo(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          int value = 1;
+                          System.out.println(value);
+                      }
+                      int other = 2;
+                      System.out.println(other);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void foo(boolean stop) {
+                      if (stop) {
+                          return;
+                      }
+                      int value = 1;
+                      System.out.println(value);
+                      int other = 2;
+                      System.out.println(other);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void unwrapWhenCollidingDeclarationRemainsNestedInTheElseBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void foo(boolean stop) {
+                      if (stop) {
+                          return;
+                      } else {
+                          for (int value = 0; value < 2; value++) {
+                              System.out.println(value);
+                          }
+                      }
+                      int value = 2;
+                      System.out.println(value);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void foo(boolean stop) {
+                      if (stop) {
+                          return;
+                      }
+                      for (int value = 0; value < 2; value++) {
+                          System.out.println(value);
+                      }
+                      int value = 2;
+                      System.out.println(value);
                   }
               }
               """


### PR DESCRIPTION
**Suggested review order:** 23 of 52 (Score: 5)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1193

## What's changed?

[`UnwrapElseAfterReturn`](https://docs.openrewrite.org/recipes/staticanalysis/unwrapelseafterreturn) now checks, before it moves the statements of an `else` body out into the enclosing block, whether that move changes how a name resolves further down that block. It collects every name the moved statements would add to the enclosing block, then looks at the statements that follow the `if` as written. If any of those declares one of those names, or uses one of them in a position where a newly visible local variable or local class captures it, the `if` and its `else` are left exactly as they are. Otherwise the recipe unwraps the `else` as it did before. The check is a new private method of the visitor, `collidesWithLaterScope`.

## What's your motivation?

**Recipe:** `org.openrewrite.staticanalysis.UnwrapElseAfterReturn`.

Moving an `else` body into its enclosing block widens the scope of every name declared in that body. This causes two distinct defects: the generated source fails to compile when a later local declaration has the same name, or it compiles with different behavior when the moved local captures a later field or statically imported member reference.

### Case 1: later local declaration

#### Before

This source compiles because the two `value` variables are in separate scopes:

```java
void plain(boolean stop) {
    if (stop) {
        return;
    } else {
        int value = 1;
        System.out.println(value);
    }
    int value = 2;
    System.out.println(value);
}
```

#### Actual after the recipe

The moved declaration and the later declaration now occupy the same scope:

```java
void plain(boolean stop) {
    if (stop) {
        return;
    }
    int value = 1;
    System.out.println(value);
    int value = 2;
    System.out.println(value);
}
```

```text
error: variable value is already defined in method plain(boolean)
```

#### Expected after the recipe

`(unchanged)`

The recipe turns compiling code into non-compiling code because Java forbids declaring a local variable or local class inside the scope of another local variable or local class with the same name ([JLS 6.4](https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.4)).

### Case 2: later field reference

#### Before

The final `return value;` reads the field:

```java
class Test {
    int value;

    int sameType(boolean stop) {
        if (stop) {
            return -1;
        } else {
            int value = 1;
            System.out.println(value);
        }
        return value;
    }
}
```

#### Actual after the recipe

The moved local variable now captures the final reference, so the method returns the local value `1` instead of the field:

```java
class Test {
    int value;

    int sameType(boolean stop) {
        if (stop) {
            return -1;
        }
        int value = 1;
        System.out.println(value);
        return value;
    }
}
```

#### Expected after the recipe

`(unchanged)`

The recipe silently changes the method to return the local value `1` instead of the field.

Before this change, the recipe did not inspect names declared by the moved statements or references after the `if`. Both plain `else` blocks and `else if` chains are affected. Reproduced on 2.40.0 and on current `main`.

## Anything in particular you'd like reviewers to focus on?

No existing test expectation changed; the one line of existing test code this change edits is the class level `@SuppressWarnings("ConstantConditions")`, widened to `@SuppressWarnings({"ConstantConditions", "unused"})`, because the new tests declare locals that are never read. Everything else in the test file is added lines, the new tests and the imports they need.

Three limitations:

- The check compares names and does not work out which scope each later name belongs to, so it also blocks some safe moves. For example, a local class declared after the `if` with a field named like a variable declared in the `else` body: that field is a member of the local class and cannot be captured by the moved local variable, but the matching name blocks the move anyway.
- Every `instanceof` pattern variable declared anywhere inside the `else` body is treated as if its scope reached the end of the enclosing block. Under the flow scoping rules of JLS 6.3.2 that holds for the `s` in `if (!(o instanceof String s)) { return; }`, which stays in scope for the rest of the enclosing block, but not for the `s` in `if (o instanceof String s) { ... }`, which is in scope only inside that `if` statement. The check does not tell the two apart, so an `else` body of `{ if (o instanceof String s) { ... } }` blocks the unwrap when a later statement in the same block declares `String s`, even though the move would have compiled.
- A comment written before the `else` keyword is still dropped. That happens on `main` too.

## Have you considered any alternatives or workarounds?

The alternative to leaving the `if` and its `else` as written is to remove the `else` anyway and wrap the moved statements in a bare block, `{ ... }`, placed after the `if`, which keeps their names out of the enclosing block. That would be a small change inside `flatten`, the private method that already exists in this recipe and that builds the list of statements replacing the `if`; it would decide when to add the bare block from the same `collidesWithLaterScope` check this branch adds. I did not pick it because a bare block adds nesting back, which is the opposite of what the recipe is for, but I will make that change if you prefer it.

## Any additional context

This change adds 11 tests to `UnwrapElseAfterReturnTest`. Without the code change in this pull request, these 7 tests fail:

- `doNotUnwrapWhenElseDeclarationCollidesWithLaterLocalVariable`
- `doNotUnwrapWhenElseDeclarationCollidesWithLaterPatternVariable`
- `doNotUnwrapWhenElseDeclarationCollidesWithNestedScope`
- `doNotUnwrapWhenElseDeclarationShadowsNameUsedLater`
- `doNotUnwrapWhenElseLocalClassCollidesWithLaterLocalClass`
- `doNotUnwrapWhenEscapedPatternVariableCollidesWithLaterDeclaration`
- `unwrapOnlyWhenDeconstructionPatternBindingsDoNotCollide`

The other 4 tests pass either way. Each covers a safe move that this branch still performs, so the new check does not block it. They do not prove that the check is never too broad; the first 2 limitations above describe where it is.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

I ran the formatter with the repository's `.editorconfig`. It also wanted to re-indent lines that this change does not touch, so I left those alone and kept the diff limited to this change.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch