### PR TITLE
Make sure ModifierOrder doesn't alter Python's def quasi-modifier

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ModifierOrder.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ModifierOrder.java
@@ -72,9 +72,15 @@ public class ModifierOrder extends Recipe {
 
     public static List<J.Modifier> sortModifiers(List<J.Modifier> modifiers) {
         for (J.Modifier mod : modifiers) {
-            if (mod.getType() == J.Modifier.Type.LanguageExtension) {
-                // avoid harmful changes with modifiers not seen in Java
-                return modifiers;
+            switch (mod.getType()) {
+                case LanguageExtension:
+                case Async:
+                case Reified:
+                case Inline:
+                    // avoid harmful changes with modifiers not seen in Java
+                    return modifiers;
+                default:
+                    break;
             }
         }
 

--- a/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ModifierOrderTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.python.Assertions.python;
 
 @Issue("https://github.com/openrewrite/rewrite/issues/466")
 @SuppressWarnings("UnnecessaryModifier")
@@ -144,6 +145,22 @@ class ModifierOrderTest implements RewriteTest {
                       public override fun draw() {
                       }
                   }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
+    class PythonTest {
+        @Test
+        void dontChangeAsyncDef() {
+            rewriteRun(
+              python(
+                """
+                  class Foo:
+                      async def bar(self):
+                          pass
                   """
               )
             );


### PR DESCRIPTION
## What's changed?

Changing the implementation of `ModifierOrder` recipe not to alter Python's `def` which is modelled as a custom quasi-modifier.

## What's your motivation?

Otherwise we get this invalid change:
```diff
- async def on_event(self):
+ def async on_event(self):
```