### PR TITLE
`FallThrough` to work only for Java files

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FallThrough.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThrough.java
@@ -17,8 +17,10 @@ package org.openrewrite.staticanalysis;
 
 import lombok.Getter;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
 import java.time.Duration;
 import java.util.Set;
@@ -44,6 +46,6 @@ public class FallThrough extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new FallThroughVisitor<>();
+        return Preconditions.check(new JavaFileChecker<>(), new FallThroughVisitor<>());
     }
 }


### PR DESCRIPTION
## What's changed?

Adding a "is Java" precondition to the `FallThrough` recipe.

## What's your motivation?

Otherwise it corrupts golang code with invalid changes, e.g.
```diff
                        switch unit.Rarity {
                        case 1:
-                           albumSeries.HighestLovePerUnit = 50
+                           albumSeries.HighestLovePerUnit = 50break
                        case 2:
-                           albumSeries.HighestLovePerUnit = 200
+                           albumSeries.HighestLovePerUnit = 200break
                        case 3:
                            albumSeries.HighestLovePerUnit = 500
                        }
```