### PR TITLE
Make `DefaultComesLast` apply only to Java

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/DefaultComesLast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/DefaultComesLast.java
@@ -17,8 +17,10 @@ package org.openrewrite.staticanalysis;
 
 import lombok.Getter;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
 import java.util.Set;
 
@@ -38,6 +40,6 @@ public class DefaultComesLast extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new DefaultComesLastVisitor<>();
+        return Preconditions.check(new JavaFileChecker<>(), new DefaultComesLastVisitor<>());
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.javascript.Assertions.typescript;
 
 @SuppressWarnings({"ConstantConditions", "EnhancedSwitchMigration", "SwitchStatementWithTooFewBranches", "DefaultNotLastCaseInSwitch"})
 class DefaultComesLastTest implements RewriteTest {
@@ -772,6 +773,26 @@ class DefaultComesLastTest implements RewriteTest {
                       System.out.println();
                   }
                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNonJavaLanguages() {
+        rewriteRun(
+          typescript(
+            """
+              function test(n) {
+                  switch (n) {
+                      default:
+                          console.log("default");
+                          break;
+                      case 1:
+                          console.log("one");
+                          break;
+                  }
               }
               """
           )


### PR DESCRIPTION
## What's changed?

Making the `DefaultComesLast` recipe apply only to Java sources.

## What's your motivation?

It would crash for Golang with:
```
Recipe execution error
Index 0 out of bounds for length 0
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0 java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) java.base/java.util.Objects.checkIndex(Objects.java:365) java.base/java.util.ArrayList.get(ArrayList.java:428) org.openrewrite.staticanalysis.DefaultComesLastVisitor.isDefaultCase(DefaultComesLastVisitor.java:237) 
```

And the switches & cases work differently in other languages - either no fall-through or no J.Switch ever produced for some languages.