### PR TITLE
Retry a failed npx warm, and survive a machine without Node

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,20 +67,42 @@ val warmJavaScriptRpcCache by tasks.registering {
 
     inputs.files(rewriteJavaScriptJars)
     outputs.file(marker)
+    // The marker records an install that succeeded. Gradle counts a declared output that was absent
+    // last time and is absent now as up to date, so without asking explicitly, an install that failed
+    // once is never retried.
+    outputs.upToDateWhen { marker.get().asFile.isFile }
 
     doLast {
+        val markerFile = marker.get().asFile
+        markerFile.delete()
         val jar = rewriteJavaScriptJars.get().singleOrNull() ?: return@doLast
         val version = zipTree(jar).matching { include("META-INF/rewrite-javascript-version.txt") }
             .singleFile.readText().trim()
-        val result = execOperations.exec {
-            commandLine(npx, "--yes", "--package=@openrewrite/rewrite@$version", "rewrite-rpc")
-            standardInput = InputStream.nullInputStream()
-            isIgnoreExitValue = true
+        if (version.endsWith("-SNAPSHOT")) {
+            // A locally built rewrite-javascript, resolved from mavenLocal, spawns an `npm link`ed
+            // rewrite-rpc from its working copy rather than a published package. Nothing to install.
+            markerFile.parentFile.mkdirs()
+            markerFile.writeText(version)
+            return@doLast
         }
-        if (result.exitValue != 0) {
+        val exitValue = try {
+            execOperations.exec {
+                commandLine(npx, "--yes", "--package=@openrewrite/rewrite@$version", "rewrite-rpc")
+                standardInput = InputStream.nullInputStream()
+                isIgnoreExitValue = true
+            }.exitValue
+        } catch (e: Exception) {
+            // isIgnoreExitValue covers a process that exits non-zero, not one that never starts,
+            // which is what an absent npx looks like. Running the Java tests should not require Node.
+            logger.warn("Could not run $npx (${e.message}); JavaScript RPC tests may be flaky.")
+            return@doLast
+        }
+        if (exitValue != 0) {
             logger.warn("Could not pre-install @openrewrite/rewrite@$version; JavaScript RPC tests may be flaky.")
+            return@doLast
         }
-        marker.get().asFile.writeText(version)
+        markerFile.parentFile.mkdirs()
+        markerFile.writeText(version)
     }
 }
 


### PR DESCRIPTION
- Follow-up to #956, which has kept this repo's TypeScript tests green since 2026-07-31. I hit the same flake in [moderneinc/rewrite-prethink](https://github.com/moderneinc/rewrite-prethink/pull/122) and copied `warmJavaScriptRpcCache` over wholesale; these are the three gaps that showed up while testing the copy. All verified against Gradle 9.3.1.

### A failed install was cached as done

The marker was written unconditionally, after the `exitValue != 0` warning. One bad install — offline, a registry hiccup — and the task reports `UP-TO-DATE` on every later build until the jar version changes, so the flake returns with the warning long since scrolled away.

Writing the marker only on success turns out to be necessary but not sufficient: Gradle counts a declared output that was absent last time and is absent now as up to date, and skips the task anyway. I confirmed that with a task that deliberately never writes its output — second run, `UP-TO-DATE`. So the task now also asks explicitly via `outputs.upToDateWhen { marker.isFile }`, and deletes the marker before each attempt. Fail → fail again (re-runs) → succeed → `UP-TO-DATE`.

### An absent npx failed the build outright

`isIgnoreExitValue` covers a process that exits non-zero, not one that never starts:

```
* What went wrong:
Execution failed for task ':warmJavaScriptRpcCache'.
> A problem occurred starting process 'command 'npx-does-not-exist''
```

Since every `Test` task depends on this one, `./gradlew test` on a machine without Node now dies here before running a single test — including for someone who only wanted the Java tests. Caught and warned about, like the other failures in this task.

### A locally built rewrite-javascript has nothing to install

`mavenLocal()` is on the dependency repositories here, so a `publishToMavenLocal`'d rewrite-javascript shadows the remote snapshot — that is what I get on this machine today. Such a jar reports `8.89.0-SNAPSHOT` in `META-INF/rewrite-javascript-version.txt` rather than a timestamped npm version, and `JavaScriptRewriteRpc` responds by dropping `--package` and spawning a plain `npx rewrite-rpc`, expecting an `npm link`ed working copy. There is no published `@openrewrite/rewrite@8.89.0-SNAPSHOT`, so the warm only bought an npm 404 and a "JavaScript RPC tests may be flaky" warning that misdescribes what is going on. Skipped now.

### Testing

- `warmJavaScriptRpcCache` succeeds and goes `UP-TO-DATE` on re-run
- with the npx command pointed at a nonexistent binary: warns, build succeeds, no marker written, and the next run re-runs rather than reporting `UP-TO-DATE`
- with the `-SNAPSHOT` skip: no npx call, marker written, `UP-TO-DATE` on re-run