### PR TITLE
Do not index into J collections a non-Java parser can leave empty

### DIFF
--- a/recipe-writing-lessons.md
+++ b/recipe-writing-lessons.md
@@ -353,3 +353,28 @@ scoping construct `JavaType` and fails to compile ("scoping construct cannot be 
 type-use annotation"), which crashes the whole Lombok annotation-processing round and produces a
 misleading cascade of "does not override abstract method getDescription()" errors across every
 Lombok-annotated recipe.
+
+## Cross-language LST invariants
+
+### `J` collections the Java parser guarantees non-empty can be empty in other languages
+`JavaVisitor` recipes run against every `J`-based LST, not just Java, and non-Java parsers do not
+always insert the placeholder elements the Java parser does. Two shapes seen in production:
+
+* `J.ForLoop.Control#getInit()` / `#getUpdate()` — Java inserts a `J.Empty` sentinel for an omitted
+  clause, so `for (; cond ;)` still has one element in each list. Go has no `while`, so its
+  condition-only `for cond {}` maps to a `J.ForLoop` whose init and update lists are genuinely
+  **empty**, and any `.get(0)` throws `IndexOutOfBoundsException`.
+* `J.Case#getCaseLabels()` — Java models `default:` as a single `J.Identifier` named `"default"`.
+  Go emits a `J.Case` with **no** labels at all, so `.get(0)` throws.
+
+Guard with `isEmpty()` rather than assuming the Java shape. Note that "no crash" and "should
+transform" are different questions: `WhileInsteadOfFor` deliberately keys on the `J.Empty` sentinel
+rather than treating an empty list as equivalent, because rewriting Go's `for cond {}` would emit a
+`J.WhileLoop` that Go cannot represent.
+
+### Fields the Java parser always populates can be null elsewhere
+`J.ForLoop#getBody()` dereferences its `JRightPadded` without a null check. The Groovy parser maps an
+empty for-loop body (`for (; port < 1024; port = next());`) to a right-padded element of `null`, which
+`JavaVisitor#visitRightPadded` then collapses to a null `body`, so `super.visitForLoop(...)` returns a
+loop whose `getBody()` throws `NullPointerException`. That one is a parser bug rather than a recipe
+bug — the fix belongs in `GroovyParserVisitor`, which should emit `J.Empty` the way the Java parser does.

--- a/src/main/java/org/openrewrite/staticanalysis/DefaultComesLastVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/DefaultComesLastVisitor.java
@@ -234,8 +234,12 @@ public class DefaultComesLastVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     private boolean isDefaultCase(J.Case case_) {
-        J elem = case_.getCaseLabels().get(0);
-        return elem instanceof J.Identifier && "default".equals(((J.Identifier) elem).getSimpleName());
+        // Go models `default:` as a case with no labels at all rather than with the `default` identifier the
+        // Java parser inserts; treating that as "not the default case" leaves such a switch untouched, which is
+        // what we want since the reordering below is written against Java's fallthrough semantics.
+        List<J> caseLabels = case_.getCaseLabels();
+        return !caseLabels.isEmpty() && caseLabels.get(0) instanceof J.Identifier &&
+                "default".equals(((J.Identifier) caseLabels.get(0)).getSimpleName());
     }
 
 }

--- a/src/main/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdate.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdate.java
@@ -56,9 +56,9 @@ public class ForLoopIncrementInUpdate extends Recipe {
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitForLoop(J.ForLoop forLoop, ExecutionContext ctx) {
-                Statement init = forLoop.getControl().getInit().get(0);
-                if (init instanceof J.VariableDeclarations) {
-                    J.VariableDeclarations initVars = (J.VariableDeclarations) init;
+                List<Statement> init = forLoop.getControl().getInit();
+                if (!init.isEmpty() && init.get(0) instanceof J.VariableDeclarations) {
+                    J.VariableDeclarations initVars = (J.VariableDeclarations) init.get(0);
 
                     Statement body = forLoop.getBody();
                     Statement lastStatement;

--- a/src/main/java/org/openrewrite/staticanalysis/WhileInsteadOfFor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/WhileInsteadOfFor.java
@@ -22,7 +22,9 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
 
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
@@ -48,8 +50,13 @@ public class WhileInsteadOfFor extends Recipe {
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitForLoop(J.ForLoop forLoop, ExecutionContext ctx) {
-                if (forLoop.getControl().getInit().get(0) instanceof J.Empty &&
-                    forLoop.getControl().getUpdate().get(0) instanceof J.Empty &&
+                List<Statement> init = forLoop.getControl().getInit();
+                List<Statement> update = forLoop.getControl().getUpdate();
+                // A language whose loops have no init/update clause at all (Go's `for cond {}`) leaves these
+                // lists empty rather than holding the `J.Empty` sentinel the Java parser inserts. Such a loop
+                // is already that language's `while`, so only the sentinel form is rewritten here.
+                if (!init.isEmpty() && init.get(0) instanceof J.Empty &&
+                    !update.isEmpty() && update.get(0) instanceof J.Empty &&
                     !(forLoop.getControl().getCondition() instanceof J.Empty)
                 ) {
                     J.WhileLoop w = JavaTemplate.apply("while(#{any(boolean)}) {}", getCursor(), forLoop.getCoordinates().replace(), forLoop.getControl().getCondition());

--- a/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/DefaultComesLastTest.java
@@ -19,10 +19,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.Tree;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.style.DefaultComesLastStyle;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -31,6 +37,8 @@ import org.openrewrite.test.SourceSpec;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings({"ConstantConditions", "EnhancedSwitchMigration", "SwitchStatementWithTooFewBranches", "DefaultNotLastCaseInSwitch"})
@@ -776,5 +784,40 @@ class DefaultComesLastTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void doNotChangeCasesWithoutLabels() {
+        // Go models `default:` as a J.Case with no labels at all, where the Java parser inserts a `default`
+        // identifier. Such a tree cannot be printed by the Java printer, so drive the visitor directly.
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build()
+          .parse(
+            //language=java
+            """
+              class A {
+                  void test(int state) {
+                      switch (state) {
+                          default:
+                              System.out.println();
+                          case 1:
+                              System.out.println();
+                      }
+                  }
+              }
+              """
+          )
+          .map(J.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        J withoutCaseLabels = new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.Case visitCase(J.Case case_, Integer p) {
+                return case_.getPadding().withCaseLabels(JContainer.build(Space.EMPTY, emptyList(), Markers.EMPTY));
+            }
+        }.visit(cu, 0);
+
+        assertThat(new DefaultComesLast().getVisitor().visit(withoutCaseLabels, new InMemoryExecutionContext()))
+          .isSameAs(withoutCaseLabels);
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdateTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdateTest.java
@@ -17,9 +17,12 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Collections.emptyList;
 import static org.openrewrite.java.Assertions.java;
 
 class ForLoopIncrementInUpdateTest implements RewriteTest {
@@ -54,6 +57,30 @@ class ForLoopIncrementInUpdateTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeLoopWithoutInitOrUpdateClause() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void test(int n) {
+                      for (; n > 0 ;) {
+                          n--;
+                      }
+                  }
+              }
+              """,
+            spec -> spec.mapBeforeRecipe(cu -> (J.CompilationUnit) new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.ForLoop visitForLoop(J.ForLoop forLoop, Integer p) {
+                    return forLoop.withControl(forLoop.getControl().withInit(emptyList()).withUpdate(emptyList()));
+                }
+            }.visit(cu, 0))
           )
         );
     }

--- a/src/test/java/org/openrewrite/staticanalysis/WhileInsteadOfForTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/WhileInsteadOfForTest.java
@@ -17,9 +17,12 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Collections.emptyList;
 import static org.openrewrite.java.Assertions.java;
 
 class WhileInsteadOfForTest implements RewriteTest {
@@ -70,6 +73,30 @@ class WhileInsteadOfForTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWhenTheLoopHasNoInitOrUpdateClauseAtAll() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class A {
+                  void m(int n) {
+                      for (; n > 0 ;) {
+                          n--;
+                      }
+                  }
+              }
+              """,
+            spec -> spec.mapBeforeRecipe(cu -> (J.CompilationUnit) new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.ForLoop visitForLoop(J.ForLoop forLoop, Integer p) {
+                    return forLoop.withControl(forLoop.getControl().withInit(emptyList()).withUpdate(emptyList()));
+                }
+            }.visit(cu, 0))
           )
         );
     }


### PR DESCRIPTION
## What

Three recipes crashed with `IndexOutOfBoundsException` when run against a Go LST, because they index position 0 of a `J` collection that only the **Java** parser guarantees to be non-empty. This guards all three call sites.

Reported from the Moderne SaaS flagship run of *Common static analysis issues* (2026-08-11, dev, org "Netflix + Spring", changeset `20260811034304-hV7qa`), which produced 5 ERROR markers on `github.com/Netflix/bettertls`. **This PR removes all 5.**

| # | File | Marker | Frame |
|---|---|---|---|
| 1 | `test-suites/certutil/cert_util.go` | `Index: 0` | `ForLoopIncrementInUpdate$1.visitForLoop:59` |
| 2 | `test-suites/certutil/cert_util.go` | `Index: 0` | `WhileInsteadOfFor$1.visitForLoop:51` |
| 3 | `test-suites/cmd/bettertls/export_tests.go` | `Index 0 out of bounds for length 0` | `DefaultComesLastVisitor.isDefaultCase:237` |
| 4 | `test-suites/pathbuilding/generate_certs.go` | `Index 0 out of bounds for length 0` | `DefaultComesLastVisitor.isDefaultCase:237` |
| 5 | `test-suites/test-case/test_case.go` | `Index 0 out of bounds for length 0` | `DefaultComesLastVisitor.isDefaultCase:237` |

The two divergences:

* **`J.ForLoop.Control#getInit()` / `#getUpdate()`** — Java inserts a `J.Empty` sentinel for an omitted clause, so `for (; cond ;)` still has one element in each list. Go has no `while`, so its condition-only `for cond {}` (`cert_util.go:123`) maps to a `J.ForLoop` whose init and update lists are genuinely **empty**.
* **`J.Case#getCaseLabels()`** — Java models `default:` as a single `J.Identifier` named `"default"`. Go emits a `J.Case` with **no** labels at all.

## Where the fix belongs — recipes, not the Go mapping

The task framing offered a second fix location: make the Go mapping emit the same placeholders the Java parser does, so `J` keeps one contract across languages, on the theory that otherwise these recipes silently *skip* Go code they should transform. I went to look — the mapping is reachable and open source, `rewrite-go` in `openrewrite/rewrite` (not closed-source Moderne code as assumed) — and concluded **the recipes are the only correct fix location here**, for reasons specific to what each recipe does:

**`WhileInsteadOfFor` must not fire on Go.** Go has no `while` keyword; `for cond {}` *is* Go's while loop, already in its idiomatic form. There is nothing to transform. Worse, transforming it would produce a `J.WhileLoop`, and `grep -r WhileLoop rewrite-go/pkg rewrite-go/cmd` returns **zero hits** — no tree type, no RPC receiver case, no printer visitor. The recipe would emit a node Go cannot represent, print, or round-trip. So this PR deliberately does **not** treat "empty list" as equivalent to "single `J.Empty`" (contra the suggested step 2); it keeps keying on the sentinel and treats the empty list as a no-op. That is the behaviour that is correct in both languages, and the code carries a comment saying why.

**`DefaultComesLast` would emit bad Go.** Reordering `default` last is semantically safe in Go, but the recipe's machinery around it is written against Java's fallthrough semantics: `addBreakToLastCase` inserts `J.Break` into any case not ending in break/continue/return/throw/yield — which in Go is nearly every case, since Go cases do not fall through. Enabling it on Go would sprinkle redundant `break` statements through Go switches.

**And the mapping change is not free.** `rewrite-go`'s printer uses the very emptiness in question as its syntactic discriminator — `GoPrinter.VisitForControl` keys on `control.Init != nil` to tell `for cond {}` from `for ; cond ; {}`, and `VisitCase` keys on `len(c.Expressions.Elements) > 0` to tell `case` from `default`. Inserting placeholders means inventing a new discriminator (a marker) for both, with printing round-trip risk, to unlock two transforms that should not run on Go anyway.

The "every future visitor inherits the same trap" concern is real and I have not dismissed it — I filed it upstream (linked below) so the contract question gets decided on its own merits rather than as a side effect of a crash fix.

## Tests

Each test builds the exact LST shape the Go parser produces and asserts the recipe leaves it alone. All three fail on `main` with the same exception and frame as the production marker, and pass with the fix.

* `ForLoopIncrementInUpdateTest.doNotChangeLoopWithoutInitOrUpdateClause` and `WhileInsteadOfForTest.noChangeWhenTheLoopHasNoInitOrUpdateClauseAtAll` use `mapBeforeRecipe` to strip init/update after parsing; the `J.Empty` sentinels contribute no output, so the source still round-trips and the standard no-change assertion applies.
* `DefaultComesLastTest.doNotChangeCasesWithoutLabels` drives the visitor directly, because a `J.Case` with no labels **cannot be printed by the Java printer** — `JavaPrinter.visitCase` does the same unguarded `getCaseLabels().get(0)` at line 500.

## No change to Java behaviour

`./gradlew test` is green (full suite). All three changes are pure guards on a condition unreachable in Java: `getInit()`/`getUpdate()` always hold the `J.Empty` sentinel, and `getCaseLabels()` always holds at least one label. `WhileInsteadOfFor`'s matching condition is unchanged for every LST the Java parser produces.

## Audit — other unguarded indexing into parser-guaranteed collections

Swept `src/main` for `.get(0)` / `.get(size - 1)` on collections whose non-emptiness is a parser guarantee rather than a checked invariant (187 `.get(0)` sites total, narrowed to `getInit`, `getUpdate`, `getCaseLabels`, `getArguments`, `getAlternatives`, `getTypeParameters`, `getDimensions`).

**One more of the same family, unfixed:**

- * `CombineSemanticallyEqualCatchBlocks.java:599` — `_case.getCaseLabels().get(0)` is unguarded. It compares statement counts before indexing but never label counts. Not reachable from these 5 markers (Go has no try/catch, and this comparator only descends into catch bodies), but reachable from any `J`-based language that has both try/catch and a label-less case. The natural fix — compare label *counts*, then all labels — also closes a latent Java bug, since today only label 0 is compared and `case 1, 2:` is treated as equal to `case 1, 3:`. That is a behaviour change deserving its own tests, so I left it out of this crash-fix PR: openrewrite/rewrite-static-analysis#985

**Checked and safe:**

* `NoEqualityInForCondition.java:59` — `control.getUpdate().get(0)` is guarded by `getUpdate().size() == 1`.
* `CombineSemanticallyEqualCatchBlocks.java:954/957` — `getInit()`/`getUpdate()` indexing is inside `for (int i = 0; i < size(); i++)` loops, after a size-equality check.
* `ForLoopControlVariablePostfixOperators.java:41` and `ForLoopIncrementInUpdate.java:82` use `ListUtils.map` over `getUpdate()`, which is empty-safe.
* `DefaultComesLastVisitor.addBreak:180` — `getCases().getStatements().get(0)` is only reached once a case has been found.
* The remaining `getArguments().get(n)` sites are all gated by a `MethodMatcher` that fixes arity.

**Upstream, outside this repo:**

* `JavaPrinter.visitCase:500` does the same unguarded `getCaseLabels().get(0)`. Harmless today (Go prints with its own printer) but it means a label-less `J.Case` is unprintable by the Java printer — noted in the upstream issue below.

## Adjacent Groovy case — confirmed *not* the same change, filed separately

The same run produced a 6th ERROR marker, `NullPointerException` at `J$ForLoop.getBody` from `NeedBraces.visitForLoop:256`, on `Netflix/metacat`'s `AbstractThriftServerTest.groovy`. I verified rather than folded it in, and it is a **different bug with a different owner**:

I pulled the file — line 43 is `for (; port < 1024; port = rand.nextInt(65536));`, a for loop with an **empty statement body**. Feeding exactly that to `GroovyParser` reproduces the production NPE verbatim. Root cause: `GroovyParserVisitor.visitForLoop` maps the body with `JRightPadded.build(doVisit(forLoop.getLoopBlock()))`, which yields a right-padded element of `null` for an `EmptyStatement`; `JavaVisitor#visitRightPadded` then collapses that to a null `body` field, so `super.visitForLoop(...)` returns a loop whose `getBody()` throws. Java's parser emits `J.Empty` here. `rewrite-test` won't even accept the parse ("non-whitespace characters in its whitespace"), which is independent confirmation this is a parser bug.

- So: same *character* (a non-Java parser not honouring an implicit `J` invariant), but a null field rather than an empty collection, in a different repository, and none of the guards in this PR touch it. Filed at openrewrite/rewrite#8459.

## Related issues

- * openrewrite/rewrite#8461 — `rewrite-go` `J.Case`/`J.ForLoop.Control` contract divergence
- * openrewrite/rewrite#8459 — Groovy parser leaves `J.ForLoop.body` null for an empty for-loop body
- * openrewrite/rewrite-static-analysis#985 — `CombineSemanticallyEqualCatchBlocks` case-label indexing
