### PR TITLE
Keep annotated and `strictfp` overrides that only call super

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
@@ -23,6 +23,7 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
@@ -135,10 +136,9 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
             }
 
             private boolean hasSemanticAnnotation(J.MethodDeclaration method) {
-                AtomicBoolean found = new AtomicBoolean();
-                new JavaVisitor<AtomicBoolean>() {
+                return new JavaIsoVisitor<AtomicBoolean>() {
                     @Override
-                    public J.Annotation visitAnnotation(J.Annotation annotation, AtomicBoolean ignored) {
+                    public J.Annotation visitAnnotation(J.Annotation annotation, AtomicBoolean found) {
                         if (!OVERRIDE.matches(annotation)) {
                             found.set(true);
                         }
@@ -146,11 +146,10 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                     }
 
                     @Override
-                    public J.Block visitBlock(J.Block block, AtomicBoolean ignored) {
+                    public J.Block visitBlock(J.Block block, AtomicBoolean found) {
                         return block;
                     }
-                }.visit(method, found);
-                return found.get();
+                }.reduce(method, new AtomicBoolean()).get();
             }
 
             private boolean argumentsMatchParameters(List<Statement> parameters, List<Expression> arguments) {

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuper.java
@@ -24,13 +24,13 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.singleton;
 
@@ -85,11 +85,8 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                     return md;
                 }
 
-                // Skip if method has annotations other than @Override
-                for (J.Annotation annotation : service(AnnotationService.class).getAllAnnotations(getCursor())) {
-                    if (!OVERRIDE.matches(annotation)) {
-                        return md;
-                    }
+                if (hasSemanticAnnotation(md)) {
+                    return md;
                 }
 
                 // Skip if method has Javadoc comments
@@ -107,6 +104,11 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                 // Skip if method is synchronized, unless the super method is synchronized too
                 if (md.hasModifier(J.Modifier.Type.Synchronized) &&
                     (superCall.getMethodType() == null || !superCall.getMethodType().hasFlags(Flag.Synchronized))) {
+                    return md;
+                }
+
+                if (md.hasModifier(J.Modifier.Type.Strictfp) &&
+                    (superCall.getMethodType() == null || !superCall.getMethodType().hasFlags(Flag.Strictfp))) {
                     return md;
                 }
 
@@ -130,6 +132,25 @@ public class RemoveMethodsOnlyCallSuper extends Recipe {
                     }
                 }
                 return null;
+            }
+
+            private boolean hasSemanticAnnotation(J.MethodDeclaration method) {
+                AtomicBoolean found = new AtomicBoolean();
+                new JavaVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Annotation visitAnnotation(J.Annotation annotation, AtomicBoolean ignored) {
+                        if (!OVERRIDE.matches(annotation)) {
+                            found.set(true);
+                        }
+                        return annotation;
+                    }
+
+                    @Override
+                    public J.Block visitBlock(J.Block block, AtomicBoolean ignored) {
+                        return block;
+                    }
+                }.visit(method, found);
+                return found.get();
             }
 
             private boolean argumentsMatchParameters(List<Statement> parameters, List<Expression> arguments) {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
@@ -419,29 +419,47 @@ class RemoveMethodsOnlyCallSuperTest implements RewriteTest {
     }
 
     @Test
-    void handlesStrictfpAccordingToTheSuperMethod() {
+    void doNotChangeStrictfpMethod() {
         rewriteRun(
           //language=java
           java(
             """
-              class OrdinaryParent {
+              class Parent {
                   void foo() {
                   }
               }
-
-              class OrdinaryChild extends OrdinaryParent {
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Child extends Parent {
                   @Override
                   strictfp void foo() {
                       super.foo();
                   }
               }
+              """
+          )
+        );
+    }
 
-              class StrictParent {
+    @Test
+    void removeStrictfpMethodWhenSuperIsStrictfpToo() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Parent {
                   strictfp void foo() {
                   }
               }
-
-              class StrictChild extends StrictParent {
+              """
+          ),
+          //language=java
+          java(
+            """
+              class Child extends Parent {
                   @Override
                   strictfp void foo() {
                       super.foo();
@@ -449,24 +467,7 @@ class RemoveMethodsOnlyCallSuperTest implements RewriteTest {
               }
               """,
             """
-              class OrdinaryParent {
-                  void foo() {
-                  }
-              }
-
-              class OrdinaryChild extends OrdinaryParent {
-                  @Override
-                  strictfp void foo() {
-                      super.foo();
-                  }
-              }
-
-              class StrictParent {
-                  strictfp void foo() {
-                  }
-              }
-
-              class StrictChild extends StrictParent {
+              class Child extends Parent {
               }
               """
           )

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveMethodsOnlyCallSuperTest.java
@@ -382,6 +382,98 @@ class RemoveMethodsOnlyCallSuperTest implements RewriteTest {
     }
 
     @Test
+    void doNotChangeMethodsWithSignatureAnnotations() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.lang.annotation.ElementType;
+              import java.lang.annotation.Target;
+
+              @Target({ElementType.PARAMETER, ElementType.TYPE_USE})
+              @interface Nullable {}
+
+              class Parent {
+                  void foo(String s) {
+                  }
+
+                  String[] bar() {
+                      return new String[0];
+                  }
+              }
+
+              class Child extends Parent {
+                  @Override
+                  void foo(@Nullable String s) {
+                      super.foo(s);
+                  }
+
+                  @Override
+                  String @Nullable [] bar() {
+                      return super.bar();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handlesStrictfpAccordingToTheSuperMethod() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class OrdinaryParent {
+                  void foo() {
+                  }
+              }
+
+              class OrdinaryChild extends OrdinaryParent {
+                  @Override
+                  strictfp void foo() {
+                      super.foo();
+                  }
+              }
+
+              class StrictParent {
+                  strictfp void foo() {
+                  }
+              }
+
+              class StrictChild extends StrictParent {
+                  @Override
+                  strictfp void foo() {
+                      super.foo();
+                  }
+              }
+              """,
+            """
+              class OrdinaryParent {
+                  void foo() {
+                  }
+              }
+
+              class OrdinaryChild extends OrdinaryParent {
+                  @Override
+                  strictfp void foo() {
+                      super.foo();
+                  }
+              }
+
+              class StrictParent {
+                  strictfp void foo() {
+                  }
+              }
+
+              class StrictChild extends StrictParent {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotChangeMethodThatWidensVisibility() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
**Suggested review order:** 8 of 52 (Score: 8)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1205

## What's changed?

Updates `RemoveMethodsOnlyCallSuper` to preserve forwarding overrides when a parameter or any nested part of the method signature carries an annotation other than `@Override`.

The change also preserves a `strictfp` override when the invoked super method is not `strictfp`. It still removes the override when both methods are `strictfp`, matching the recipe's existing handling of `synchronized`.

The three former failing reproductions are now passing regression tests, and a positive control verifies the safe `strictfp` removal. All 20 tests in `RemoveMethodsOnlyCallSuperTest` pass.

## What's your motivation?

**Recipe:** [`org.openrewrite.staticanalysis.RemoveMethodsOnlyCallSuper`](https://docs.openrewrite.org/recipes/staticanalysis/removemethodsonlycallsuper).

#971 taught this recipe to keep overrides that add declaration annotations or the `synchronized` modifier. Its method-level annotation query does not include annotations on parameters or type-use annotations nested inside the return type, so the recipe still deletes overrides that carry those contracts.

### Case 1: parameter annotation

#### Before

```java
class Child extends Parent {
    @Override
    void foo(@Nullable String s) {
        super.foo(s);
    }
}
```

#### Actual after the recipe

```java
class Child extends Parent {
}
```

#### Expected after the recipe

`(unchanged)`

Removing the method silently removes the parameter contract read by annotation processors and static-analysis tools. The same loss occurs for a nested type-use annotation such as `public String @Nullable [] foo()`.

### Case 2: `strictfp` modifier

#### Before

```java
class Child extends Parent {
    @Override
    strictfp void foo() {
        super.foo();
    }
}
```

#### Actual after the recipe

The override is deleted, leaving the same empty `Child` class shown in Case 1.

#### Expected after the recipe

`(unchanged)` when the super method is not `strictfp`.

The previous transformation drops a reflection-visible modifier. Before Java 17, it also changes floating-point semantics. When the super method is already `strictfp`, removing this forwarding override remains safe and the recipe still removes it.

### Confirmed real-world execution

- Project: [Hibernate Validator](https://github.com/hibernate/hibernate-validator) (1,267 stars on 2026-08-16).
- Location: [`MethodOverridingTests.java` at `e1f271a7`](https://github.com/hibernate/hibernate-validator/blob/e1f271a7ad429690fd18b0f4cbb7ea40dd8af575/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/overriding/MethodOverridingTests.java) and its [integration test](https://github.com/hibernate/hibernate-validator/blob/e1f271a7ad429690fd18b0f4cbb7ea40dd8af575/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorIT.java).
- Recipe release: `org.openrewrite.recipe:rewrite-static-analysis:2.41.0`.

The released recipe deletes a delegating override whose parameter annotations intentionally create the invalid constraint declaration tested by Hibernate Validator. The deletion removes the diagnostic condition and weakens the test.

### Affected code in real projects

- [`didi/DoKit` `CpuMainPageFragment.java`](https://github.com/didi/DoKit/blob/626827cddb2feb2f3aee87a52a064b4e5ca2bed4/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/parameter/cpu/CpuMainPageFragment.java#L24-L28): an `onViewCreated` override that only forwards to super but carries `@NonNull` and `@Nullable` parameter annotations. The recipe from main deletes the whole override, silently dropping the parameter nullability contracts it declares.
- [`Justson/AgentWeb` `AgentActionFragment.java`](https://github.com/Justson/AgentWeb/blob/e683a5c31acdd17a86c3e92b4b3790770ec016c3/agentweb-core/src/main/java/com/just/agentweb/AgentActionFragment.java#L88-L91): the same shape in a library fragment, `super.onViewCreated(view, savedInstanceState)` with `@NonNull`/`@Nullable` annotated parameters. The recipe from main removes the method together with those annotations.

## Anything in particular you'd like reviewers to focus on?

Please review the conservative signature traversal, which intentionally stops before the method body, and the decision to mirror the existing `synchronized` parent-method comparison for `strictfp`.

## Have you considered any alternatives or workarounds?

One alternative is to enumerate specific signature locations. Traversing the complete signature is safer because an override carrying annotation metadata is not redundant, regardless of whether the annotation is attached to a parameter, type parameter, return type, or nested type use.

For `strictfp`, preserving every marked override would also retain behavior. Comparing the super method retains the recipe's cleanup when the modifier is redundant.

## Any additional context

Pre-existing tests changed: None.

Related: #971 added the `synchronized` guard and the declaration-level annotation guard. This change extends the same behavior to the remaining signature locations and to `strictfp`.

This change was prepared with AI assistance. I reviewed the implementation, regression tests, focused test results, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
