### PR TITLE
Keep Java `Runtime.exec` replacements out of non-Java sources

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceDeprecatedRuntimeExecMethods.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceDeprecatedRuntimeExecMethods.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Javadoc;
+import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -48,7 +49,9 @@ public class ReplaceDeprecatedRuntimeExecMethods extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesJavaVersion<>(18), new JavaIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(
+                Preconditions.and(new UsesJavaVersion<>(18), new JavaFileChecker<>()),
+                new JavaIsoVisitor<ExecutionContext>() {
             @Override
             protected JavadocVisitor<ExecutionContext> getJavadocVisitor() {
                 return new JavadocVisitor<ExecutionContext>(this) {

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceDeprecatedRuntimeExecMethodsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceDeprecatedRuntimeExecMethodsTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class ReplaceDeprecatedRuntimeExecMethodsTest implements RewriteTest {
     @Override
@@ -294,6 +295,23 @@ class ReplaceDeprecatedRuntimeExecMethodsTest implements RewriteTest {
                 }
                 """
             ), 17)
+        );
+    }
+
+    @Test
+    void doNotChangeKotlinFiles() {
+        rewriteRun(
+          version(
+            //language=kotlin
+            kotlin(
+              """
+                class A {
+                    fun method() {
+                        val process = Runtime.getRuntime().exec("ls -a")
+                    }
+                }
+                """
+            ), 18)
         );
     }
 


### PR DESCRIPTION
**Suggested review order:** 10 of 52 (Score: 8)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/1006

## What's changed?

Restricts `ReplaceDeprecatedRuntimeExecMethods` to Java compilation units by combining its Java 18 precondition with `JavaFileChecker`.

The Kotlin regression test is now a passing no-change test. The complete `ReplaceDeprecatedRuntimeExecMethodsTest` class has 10 passing tests, including the existing Java transformations.

## What's your motivation?

**Recipe:** [`org.openrewrite.staticanalysis.ReplaceDeprecatedRuntimeExecMethods`](https://docs.openrewrite.org/recipes/staticanalysis/replacedeprecatedruntimeexecmethods).

`ReplaceDeprecatedRuntimeExecMethods.getVisitor()` previously checked only for Java 18. That version marker also exists on Kotlin source, so the `JavaIsoVisitor` applied a Java template to Kotlin.

### Before

```kotlin
class A {
    fun method() {
        val process = Runtime.getRuntime().exec("ls -a")
    }
}
```

### Actual after the recipe

```kotlin
class A {
    fun method() {
        val process = Runtime.getRuntime().exec(new String[] {"ls", "-a"})
    }
}
```

`new String[] {...}` is Java syntax and does not compile as Kotlin.

### Expected after the recipe

`(unchanged)`

The recipe MUST NOT apply Java-only templates to non-Java compilation units.

I found this while preparing #976, which fixes a separate defect in the same recipe. Its description disclosed this Kotlin failure but does not fix it.

### Confirmed real-world execution

- Project: [IntelliJ Community](https://github.com/JetBrains/intellij-community) (20,456 stars on 2026-08-16).
- Location: [`MacCustomAppIcon.kt` at `516da0ac`](https://github.com/JetBrains/intellij-community/blob/516da0aca26150b7f5a5b240bda5e73e88259a6d/platform/platform-impl/src/com/intellij/ui/MacCustomAppIcon.kt).
- Recipe release: `org.openrewrite.recipe:rewrite-static-analysis:2.41.0`.

The project uses JDK 25. The released recipe changes its Kotlin `Runtime.exec(String)` call to Java `new String[] {...}` syntax, which is invalid Kotlin.

## Anything in particular you'd like reviewers to focus on?

Please review the positive `JavaFileChecker` guard. It keeps the existing Java 18 requirement and excludes Kotlin and other non-Java compilation units from the Java-specific implementation.

## Have you considered any alternatives or workarounds?

A Kotlin-specific implementation can use `arrayOf("ls", "-a")`. That expands the recipe's supported languages and requires separate Kotlin transformation logic. This change instead preserves the recipe's existing Java behavior and prevents invalid output in other languages.

## Any additional context

Pre-existing tests changed: None.

- Related PR touching the same recipe: #976
- Focused result: all 10 `ReplaceDeprecatedRuntimeExecMethodsTest` tests pass

This change was prepared with AI assistance. I reviewed the implementation, Kotlin output, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch