### PR TITLE
Fix crashes on Go `for` loops and `select` statements

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdate.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdate.java
@@ -56,9 +56,10 @@ public class ForLoopIncrementInUpdate extends Recipe {
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitForLoop(J.ForLoop forLoop, ExecutionContext ctx) {
-                Statement init = forLoop.getControl().getInit().get(0);
-                if (init instanceof J.VariableDeclarations) {
-                    J.VariableDeclarations initVars = (J.VariableDeclarations) init;
+                // Go for loops have no init element at all, where Java has a J.Empty placeholder
+                List<Statement> init = forLoop.getControl().getInit();
+                if (!init.isEmpty() && init.get(0) instanceof J.VariableDeclarations) {
+                    J.VariableDeclarations initVars = (J.VariableDeclarations) init.get(0);
 
                     Statement body = forLoop.getBody();
                     Statement lastStatement;

--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -215,14 +215,16 @@ public class MinimumSwitchCases extends Recipe {
                 if (switch_.getCases().getStatements().size() > 2) {
                     return false;
                 }
-                // Don't transform switches that use Java 21 pattern matching (e.g. `case Foo.Bar b ->`),
-                // as those case labels are not simple expressions and cannot be converted to `==`/`equals` checks
                 for (Statement statement : switch_.getCases().getStatements()) {
-                    if (statement instanceof J.Case) {
-                        for (J label : ((J.Case) statement).getCaseLabels()) {
-                            if (!(label instanceof Expression)) {
-                                return false;
-                            }
+                    // Go's `select` holds clauses that are not J.Case
+                    if (!(statement instanceof J.Case)) {
+                        return false;
+                    }
+                    // Don't transform switches that use Java 21 pattern matching (e.g. `case Foo.Bar b ->`),
+                    // as those case labels are not simple expressions and cannot be converted to `==`/`equals` checks
+                    for (J label : ((J.Case) statement).getCaseLabels()) {
+                        if (!(label instanceof Expression)) {
+                            return false;
                         }
                     }
                 }

--- a/src/main/java/org/openrewrite/staticanalysis/WhileInsteadOfFor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/WhileInsteadOfFor.java
@@ -48,11 +48,13 @@ public class WhileInsteadOfFor extends Recipe {
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitForLoop(J.ForLoop forLoop, ExecutionContext ctx) {
-                if (forLoop.getControl().getInit().get(0) instanceof J.Empty &&
-                    forLoop.getControl().getUpdate().get(0) instanceof J.Empty &&
-                    !(forLoop.getControl().getCondition() instanceof J.Empty)
+                // Go for loops have no init or update elements at all, and are already while loops
+                J.ForLoop.Control control = forLoop.getControl();
+                if (!control.getInit().isEmpty() && control.getInit().get(0) instanceof J.Empty &&
+                    !control.getUpdate().isEmpty() && control.getUpdate().get(0) instanceof J.Empty &&
+                    !(control.getCondition() instanceof J.Empty)
                 ) {
-                    J.WhileLoop w = JavaTemplate.apply("while(#{any(boolean)}) {}", getCursor(), forLoop.getCoordinates().replace(), forLoop.getControl().getCondition());
+                    J.WhileLoop w = JavaTemplate.apply("while(#{any(boolean)}) {}", getCursor(), forLoop.getCoordinates().replace(), control.getCondition());
                     return w.withBody(forLoop.getBody());
                 }
                 return super.visitForLoop(forLoop, ctx);

--- a/src/test/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdateTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ForLoopIncrementInUpdateTest.java
@@ -17,9 +17,18 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 class ForLoopIncrementInUpdateTest implements RewriteTest {
@@ -56,5 +65,22 @@ class ForLoopIncrementInUpdateTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void forLoopWithoutInitElements() {
+        // Simulate Go, whose for loops have no init or update elements at all
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        SourceFile before = (SourceFile) requireNonNull(new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.ForLoop.Control visitForControl(J.ForLoop.Control control, Integer p) {
+                return control.withInit(emptyList()).withUpdate(emptyList());
+            }
+        }.visit(JavaParser.fromJavaVersion().build()
+          .parse(ctx, "class A { void m() { for (int i = 0; i < 10; i++) { i++; } } }")
+          .findFirst().orElseThrow(), 0));
+
+        SourceFile after = (SourceFile) requireNonNull(new ForLoopIncrementInUpdate().getVisitor().visit(before, ctx));
+        assertThat(after.printAll()).isEqualTo(before.printAll());
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -17,10 +17,19 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.internal.ListUtils.map;
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings({"SwitchStatementWithTooFewBranches", "EnhancedSwitchMigration"})
@@ -1186,5 +1195,23 @@ class MinimumSwitchCasesTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void switchWithClausesThatAreNotCases() {
+        // Simulate Go's `select`, whose clauses are not J.Case
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        SourceFile before = (SourceFile) requireNonNull(new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.Switch visitSwitch(J.Switch switch_, Integer p) {
+                return switch_.withCases(switch_.getCases().withStatements(
+                  map(switch_.getCases().getStatements(), s -> new J.Empty(s.getId(), s.getPrefix(), s.getMarkers()))));
+            }
+        }.visit(JavaParser.fromJavaVersion().build()
+          .parse(ctx, "class A { void m(int i) { switch (i) { case 1: System.out.println(1); break; } } }")
+          .findFirst().orElseThrow(), 0));
+
+        SourceFile after = (SourceFile) requireNonNull(new MinimumSwitchCases().getVisitor().visit(before, ctx));
+        assertThat(after.printAll()).isEqualTo(before.printAll());
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/WhileInsteadOfForTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/WhileInsteadOfForTest.java
@@ -17,9 +17,18 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 class WhileInsteadOfForTest implements RewriteTest {
@@ -72,5 +81,22 @@ class WhileInsteadOfForTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void forLoopWithoutInitOrUpdateElements() {
+        // Simulate Go, whose for loops have no init or update elements at all
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        SourceFile before = (SourceFile) requireNonNull(new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.ForLoop.Control visitForControl(J.ForLoop.Control control, Integer p) {
+                return control.withInit(emptyList()).withUpdate(emptyList());
+            }
+        }.visit(JavaParser.fromJavaVersion().build()
+          .parse(ctx, "class A { void m() { for (int i = 0; i < 10; i++) { System.out.println(i); } } }")
+          .findFirst().orElseThrow(), 0));
+
+        SourceFile after = (SourceFile) requireNonNull(new WhileInsteadOfFor().getVisitor().visit(before, ctx));
+        assertThat(after.printAll()).isEqualTo(before.printAll());
     }
 }


### PR DESCRIPTION
## Motivation

Three recipes crash outright when they visit LSTs produced by the Go parser. Both `for` loop recipes index into the loop control's init and update lists, which Go leaves genuinely empty — Java's parser always puts a `J.Empty` placeholder there, so `get(0)` looked safe. `MinimumSwitchCases` casts every clause of a switch to `J.Case`, which holds for Java but not for Go's `select` statement, whose clauses are `Go.CommClause`.

These showed up as `SourcesFileErrors` on real repositories:

```
java.lang.IndexOutOfBoundsException: Index: 0
  org.openrewrite.staticanalysis.ForLoopIncrementInUpdate$1.visitForLoop(ForLoopIncrementInUpdate.java:59)

java.lang.IndexOutOfBoundsException: Index: 0
  org.openrewrite.staticanalysis.WhileInsteadOfFor$1.visitForLoop(WhileInsteadOfFor.java:51)

java.lang.ClassCastException: class org.openrewrite.golang.tree.Go$CommClause cannot be cast to class org.openrewrite.java.tree.J$Case
  org.openrewrite.staticanalysis.MinimumSwitchCases$1.lambda$doRewrite$2(MinimumSwitchCases.java:235)
```

In each case skipping is the right outcome, not just the safe one: a Go `for cond { }` is already a `while` loop, and Go has no `while` keyword to convert it to.

## Summary

- `ForLoopIncrementInUpdate` checks that the init list is non-empty before reading its first element.
- `WhileInsteadOfFor` checks that the init and update lists are non-empty before reading their first elements, so a loop that has no init/update elements at all is left alone.
- `MinimumSwitchCases.doRewrite` returns `false` when the switch holds a clause that is not a `J.Case`, which also protects the `J.Case[]` collection further down `visitSwitch`.

## Test plan

- [x] Added a regression test per recipe. No parser on the test classpath produces these LST shapes, so each test parses Java and then reshapes the result — emptying the `for` control's init/update lists, or replacing the switch clauses with statements that are not `J.Case` — and asserts the recipe leaves the tree untouched instead of throwing.
- [x] Confirmed each new test fails with exactly the production exception above before its fix, and passes after.
- [x] `./gradlew test` — the only failures are the JavaScript/Python RPC tests (`RPC process shut down early with exit code 1`), which fail identically on an untouched tree in this environment and are unrelated to these recipes.
