### PR TITLE
UnnecessaryExplicitTypeArguments: retain witness when enclosing method has dependent type parameters

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArguments.java
@@ -22,8 +22,10 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class UnnecessaryExplicitTypeArguments extends Recipe {
@@ -70,6 +72,13 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                         }
                         // Cannot remove type parameters if it would introduce ambiguity about which method should be called
                         if (enclosingMethod.getMethodType() == null) {
+                            return m;
+                        }
+                        // The enclosing method's type parameters may be interdependent (e.g. `<T, S extends T>`).
+                        // Inference then resolves them jointly against the target type, so this argument's witness
+                        // can be load-bearing even though this call's own type variables are inferable from its
+                        // arguments. Retain it rather than reason about the enclosing method's inference.
+                        if (hasInterdependentTypeParameters(enclosingMethod.getMethodType())) {
                             return m;
                         }
                         if (!(enclosingMethod.getMethodType().getDeclaringType() instanceof JavaType.Class)) {
@@ -172,16 +181,44 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                 if (declared == null) {
                     return false;
                 }
-                Set<String> returnTypeVariables = new HashSet<>();
-                collectGenericTypeVariableNames(declared.getReturnType(), returnTypeVariables);
+                Map<String, JavaType.GenericTypeVariable> returnTypeVariables = new HashMap<>();
+                collectGenericTypeVariables(declared.getReturnType(), returnTypeVariables);
                 if (returnTypeVariables.isEmpty()) {
                     return true;
                 }
-                Set<String> parameterTypeVariables = new HashSet<>();
+                Map<String, JavaType.GenericTypeVariable> parameterTypeVariables = new HashMap<>();
                 for (JavaType paramType : declared.getParameterTypes()) {
-                    collectGenericTypeVariableNames(paramType, parameterTypeVariables);
+                    collectGenericTypeVariables(paramType, parameterTypeVariables);
                 }
-                return parameterTypeVariables.containsAll(returnTypeVariables);
+                return parameterTypeVariables.keySet().containsAll(returnTypeVariables.keySet());
+            }
+
+            private boolean hasInterdependentTypeParameters(JavaType.Method methodType) {
+                JavaType.Method declared = findDeclaredSignature(methodType);
+                if (declared == null) {
+                    return false;
+                }
+                Map<String, JavaType.GenericTypeVariable> typeVariables = new HashMap<>();
+                collectGenericTypeVariables(declared.getReturnType(), typeVariables);
+                for (JavaType paramType : declared.getParameterTypes()) {
+                    collectGenericTypeVariables(paramType, typeVariables);
+                }
+                for (Map.Entry<String, JavaType.GenericTypeVariable> typeVariable : typeVariables.entrySet()) {
+                    Set<String> boundNames = new HashSet<>();
+                    for (JavaType bound : typeVariable.getValue().getBounds()) {
+                        Map<String, JavaType.GenericTypeVariable> inBound = new HashMap<>();
+                        collectGenericTypeVariables(bound, inBound);
+                        boundNames.addAll(inBound.keySet());
+                    }
+                    // A self-referential F-bound such as `<E extends Enum<E>>` is not a dependency on
+                    // another type parameter, and is far too common to retain witnesses for.
+                    boundNames.remove(typeVariable.getKey());
+                    boundNames.retainAll(typeVariables.keySet());
+                    if (!boundNames.isEmpty()) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             private JavaType.@Nullable Method findDeclaredSignature(JavaType.Method methodType) {
@@ -202,15 +239,15 @@ public class UnnecessaryExplicitTypeArguments extends Recipe {
                 return match;
             }
 
-            private void collectGenericTypeVariableNames(@Nullable JavaType type, Set<String> names) {
+            private void collectGenericTypeVariables(@Nullable JavaType type, Map<String, JavaType.GenericTypeVariable> into) {
                 if (type instanceof JavaType.GenericTypeVariable) {
-                    names.add(((JavaType.GenericTypeVariable) type).getName());
+                    into.putIfAbsent(((JavaType.GenericTypeVariable) type).getName(), (JavaType.GenericTypeVariable) type);
                 } else if (type instanceof JavaType.Parameterized) {
                     for (JavaType typeParameter : ((JavaType.Parameterized) type).getTypeParameters()) {
-                        collectGenericTypeVariableNames(typeParameter, names);
+                        collectGenericTypeVariables(typeParameter, into);
                     }
                 } else if (type instanceof JavaType.Array) {
-                    collectGenericTypeVariableNames(((JavaType.Array) type).getElemType(), names);
+                    collectGenericTypeVariables(((JavaType.Array) type).getElemType(), into);
                 }
             }
         });

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryExplicitTypeArgumentsTest.java
@@ -358,6 +358,57 @@ class UnnecessaryExplicitTypeArgumentsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/783")
+    @Test
+    void retainsWitnessOnNoArgArgumentToMethodWithDependentTypeParameters() {
+        // naturalOrder() takes no arguments, so T is only inferable from lexicographical's target type.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Comparator;
+
+              class Test {
+                  static <T, S extends T> Comparator<Iterable<S>> lexicographical(Comparator<T> comparator) {
+                      return null;
+                  }
+
+                  static final Comparator<Iterable<Integer>> COMPARATOR =
+                      lexicographical(Comparator.<Integer>naturalOrder());
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/783")
+    @Test
+    void retainsWitnessWhenEnclosingMethodHasDependentTypeParameters() {
+        // S depends on T, so lexicographical resolves both jointly against its target type. Without the
+        // witness, U infers as Comparable rather than Integer and the enclosing call no longer compiles.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Comparator;
+
+              class Test {
+                  static <T, S extends T> Comparator<Iterable<S>> lexicographical(Comparator<T> comparator) {
+                      return null;
+                  }
+
+                  static <U> Comparator<U> reverse(Comparator<U> comparator) {
+                      return null;
+                  }
+
+                  static final Comparator<Iterable<Integer>> COMPARATOR =
+                      lexicographical(Test.<Integer>reverse(Comparator.naturalOrder()));
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void removesWitnessOnInstanceMethodArgumentWhenInferableFromOwnArguments() {
         // Unlike above, T is inferable from identity()'s own argument, so it's still removable.


### PR DESCRIPTION
- Fixes #783

## What I found

- The reproduction as filed in #783 no longer reproduces on `main`. `Comparator.naturalOrder()` takes no arguments, so it is already caught by the no-argument check in `canInferTypeArgumentsFromArguments`, and the witness is retained. That case appears to have been fixed incidentally rather than deliberately, and there was no regression test pinning it, which is likely why the issue stayed open.

The case @timtebeek described in the issue thread is still open though:

> Now we need to figure out how to recognize that case and avoid removing the explicit type arguments when used as an argument to such a method.

Nothing in the recipe looks at any method's declared type-parameter *bounds*. The existing checks only compare which type variables appear in the inner call's own return type against those in its own parameter types. So once the inner call takes arguments, the no-argument check no longer fires and the witness is removed even though the enclosing method's dependent type parameters still need it:

```java
static <T, S extends T> Comparator<Iterable<S>> lexicographical(Comparator<T> comparator) { ... }
static <U> Comparator<U> reverse(Comparator<U> comparator) { ... }

// witness removed, no longer compiles
static final Comparator<Iterable<Integer>> COMPARATOR =
    lexicographical(Test.<Integer>reverse(Comparator.naturalOrder()));
```

Verified against `javac` rather than assumed — with the witness it compiles, without it:

```
error: method reverse in class Test cannot be applied to given types;
  - required: Comparator<U#1>
  - found:    Comparator<T#1>
  reason: inferred type does not conform to equality constraint(s)
    - inferred: T#2
    - equality constraints(s): U#2
```

## The change

In the argument-position branch, retain the witness when the enclosing method's declared signature has a type parameter whose bound references a **different** type parameter of that same method. Inference resolves those jointly against the target type, so the witness can be load-bearing regardless of what the inner call's own arguments pin down.

Self-referential F-bounds such as `<E extends Enum<E>>` and `<T extends Comparable<T>>` are deliberately excluded. They express no dependency on another type parameter and are common enough that counting them would cause widespread over-retention.

`collectGenericTypeVariableNames` is generalised to `collectGenericTypeVariables`, collecting into a map so the bounds are reachable, rather than adding a second parallel walker. `findDeclaredSignature` is reused as-is.

## Tests

- Two tests added, both tagged to #783: the original reproduction as a regression guard, and the variant that does still reproduce.

Full suite run locally on JDK 21: 2242 tests, 0 failures, 0 errors. In particular `removesWitnessOnInstanceMethodArgumentWhenInferableFromOwnArguments` still passes, so witnesses that genuinely are redundant are still removed, and `retainsWitnessOnInstanceMethodPassedAsArgumentToGenericMethod` covers the F-bound exclusion.

Happy to adjust the naming or fold the check in differently if you'd prefer it structured another way.