### PR TITLE
Do not remove `catch (Exception e)` covering a checked exception

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCatch.java
@@ -203,10 +203,13 @@ public class UnnecessaryCatch extends Recipe {
                 // For example, if IOException is thrown, don't remove catch for ZipException
                 Set<JavaType> toKeep = new HashSet<>();
                 for (JavaType caughtException : unnecessaryExceptions) {
-                    if (isGenericTypeRemovableByOption(caughtException)) {
-                        continue;
-                    }
+                    // `Exception` and `Throwable` are only removable by option because they also cover
+                    // unchecked exceptions; any checked exception they cover still has to be caught.
+                    boolean checkedOnly = isGenericTypeRemovableByOption(caughtException);
                     for (JavaType thrownException : thrownExceptions) {
+                        if (checkedOnly && !requiresCatching(thrownException)) {
+                            continue;
+                        }
                         if (TypeUtils.isAssignableTo(thrownException, caughtException) ||
                                 TypeUtils.isAssignableTo(caughtException, thrownException)) {
                             toKeep.add(caughtException);
@@ -217,6 +220,16 @@ public class UnnecessaryCatch extends Recipe {
                 unnecessaryExceptions.removeAll(toKeep);
 
                 return unnecessaryExceptions;
+            }
+
+            /**
+             * Unlike {@link #isCheckedException(JavaType)} this also covers {@code Exception} and
+             * {@code Throwable} themselves, as those too have to be caught or declared when thrown.
+             */
+            private boolean requiresCatching(JavaType type) {
+                return TypeUtils.isAssignableTo(JAVA_LANG_THROWABLE, type) &&
+                        !TypeUtils.isAssignableTo(JAVA_LANG_RUNTIME_EXCEPTION, type) &&
+                        !TypeUtils.isAssignableTo(JAVA_LANG_ERROR, type);
             }
 
             private boolean isGenericTypeRemovableByOption(JavaType type) {

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryThrows.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryThrows.java
@@ -167,7 +167,9 @@ public class UnnecessaryThrows extends Recipe {
                                 return super.visitMethodInvocation(invocation, ctx);
                             }
                         });
-                        doAfterVisit(new UnnecessaryCatch(true, false).getVisitor());
+                        // Only catches that no longer compile are removed; `catch (Exception e)` and
+                        // `catch (Throwable t)` remain valid, and removing those would alter behavior.
+                        doAfterVisit(new UnnecessaryCatch(false, false).getVisitor());
                     }
                 }
 

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryCatchTest.java
@@ -311,6 +311,54 @@ class UnnecessaryCatchTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1002")
+    @Test
+    void doNotRemoveJavaLangExceptionCoveringCheckedException() {
+        rewriteRun(
+          spec -> spec.recipe(new UnnecessaryCatch(true, false)),
+          //language=java
+          java(
+            """
+              import java.io.FileInputStream;
+
+              class Scratch {
+                  void method() {
+                      try {
+                          new FileInputStream("something");
+                      } catch (Exception e) {
+                          System.out.println("an exception!");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1002")
+    @Test
+    void doNotRemoveJavaLangThrowableCoveringCheckedException() {
+        rewriteRun(
+          spec -> spec.recipe(new UnnecessaryCatch(false, true)),
+          //language=java
+          java(
+            """
+              import java.io.FileInputStream;
+
+              class Scratch {
+                  void method() {
+                      try {
+                          new FileInputStream("something");
+                      } catch (Throwable t) {
+                          System.out.println("an exception!");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void doNotRemoveJavaLangThrowable() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UnnecessaryThrowsTest.java
@@ -716,4 +716,83 @@ class UnnecessaryThrowsTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1002")
+    @Test
+    void retainCatchOfExceptionInUnrelatedMethod() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileInputStream;
+              import java.io.IOException;
+
+              class A {
+                  private void handleException() {
+                      try {
+                          new FileInputStream("something");
+                      } catch (Exception e) {
+                      }
+                  }
+
+                  private void doSomething() throws IOException {
+                  }
+              }
+              """,
+            """
+              import java.io.FileInputStream;
+
+              class A {
+                  private void handleException() {
+                      try {
+                          new FileInputStream("something");
+                      } catch (Exception e) {
+                      }
+                  }
+
+                  private void doSomething() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1002")
+    @Test
+    void retainCatchOfExceptionAroundUncheckedExceptions() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.IOException;
+
+              class A {
+                  private void handleException() {
+                      try {
+                          throw new IllegalStateException();
+                      } catch (Exception e) {
+                      }
+                  }
+
+                  private void doSomething() throws IOException {
+                  }
+              }
+              """,
+            """
+              class A {
+                  private void handleException() {
+                      try {
+                          throw new IllegalStateException();
+                      } catch (Exception e) {
+                      }
+                  }
+
+                  private void doSomething() {
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Fixes #1002

`UnnecessaryCatch` skipped the assignability check entirely for `Exception`/`Throwable` when their respective options were enabled, so `catch (Exception e)` was removed even when the try block threw a checked exception, producing uncompilable code; it now only ignores thrown types that do not require catching. `UnnecessaryThrows` additionally no longer passes `includeJavaLangException` when it runs `UnnecessaryCatch`, since only catches that stop compiling need removing, while `catch (Exception e)` remains valid and removing it alters behavior — which is how an unrelated method's try/catch got deleted in the reported issue.

Covered by two new `UnnecessaryThrowsTest` cases (both failing before the fix, including the issue's exact repro) and two new `UnnecessaryCatchTest` cases pinning the standalone behavior with the options explicitly enabled.