### PR TITLE
Preserve escaped backslash-newline text in `UsePortableNewlines`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UsePortableNewlines.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UsePortableNewlines.java
@@ -29,6 +29,8 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
@@ -93,11 +95,95 @@ public class UsePortableNewlines extends Recipe {
             if (literal.getValue() instanceof String && literal.getValueSource() != null) {
                 String source = literal.getValueSource();
                 String value = (String) literal.getValue();
-                // Check if the source contains the escape sequence \n
-                if (source.contains("\\n")) {
-                    return literal
-                            .withValue(value.replace("\n", "%n"))
-                            .withValueSource(source.replace("\\n", "%n"));
+                StringBuilder translatedSource = new StringBuilder(source.length());
+                List<Integer> rawStarts = new ArrayList<>();
+                List<Integer> rawEnds = new ArrayList<>();
+                int translatedBackslashes = 0;
+                for (int i = 0; i < source.length();) {
+                    int rawStart = i;
+                    char translated = source.charAt(i++);
+                    if (translated == '\\') {
+                        int unicode = i;
+                        while (unicode < source.length() && source.charAt(unicode) == 'u') {
+                            unicode++;
+                        }
+                        if (translatedBackslashes % 2 == 0 && unicode > i && unicode + 4 <= source.length()) {
+                            try {
+                                translated = (char) Integer.parseInt(source.substring(unicode, unicode + 4), 16);
+                                i = unicode + 4;
+                            } catch (NumberFormatException ignored) {
+                                // Keep the raw backslash; an invalid Unicode escape is not valid Java source.
+                            }
+                        }
+                    }
+                    translatedSource.append(translated);
+                    translatedBackslashes = translated == '\\' ? translatedBackslashes + 1 : 0;
+                    rawStarts.add(rawStart);
+                    rawEnds.add(i);
+                }
+
+                List<int[]> replacements = new ArrayList<>();
+                List<Integer> replacedNewlines = new ArrayList<>();
+                boolean textBlock = translatedSource.toString().startsWith("\"\"\"");
+                boolean openingTextBlockLine = textBlock;
+                int newlineIndex = 0;
+                int consecutiveBackslashes = 0;
+                for (int i = textBlock ? 3 : 1; i < translatedSource.length(); i++) {
+                    char current = translatedSource.charAt(i);
+                    if (current == '\\') {
+                        consecutiveBackslashes++;
+                        continue;
+                    }
+                    if (current == 'n' && consecutiveBackslashes % 2 == 1) {
+                        replacements.add(new int[]{rawStarts.get(i - 1), rawEnds.get(i)});
+                        replacedNewlines.add(newlineIndex++);
+                    } else if (consecutiveBackslashes % 2 == 1 && current >= '0' && current <= '7') {
+                        int octal = current - '0';
+                        int maxDigits = current <= '3' ? 3 : 2;
+                        int digits = 1;
+                        while (digits < maxDigits && i + 1 < translatedSource.length()) {
+                            char next = translatedSource.charAt(i + 1);
+                            if (next < '0' || next > '7') {
+                                break;
+                            }
+                            octal = octal * 8 + next - '0';
+                            digits++;
+                            i++;
+                        }
+                        if (octal == '\n') {
+                            newlineIndex++;
+                        }
+                    } else if (textBlock && (current == '\n' || current == '\r')) {
+                        boolean crlf = current == '\r' && i + 1 < translatedSource.length() &&
+                                translatedSource.charAt(i + 1) == '\n';
+                        if (openingTextBlockLine) {
+                            openingTextBlockLine = false;
+                        } else if (consecutiveBackslashes % 2 == 0) {
+                            newlineIndex++;
+                        }
+                        if (crlf) {
+                            i++;
+                        }
+                    }
+                    consecutiveBackslashes = 0;
+                }
+                if (!replacedNewlines.isEmpty()) {
+                    StringBuilder transformedSource = new StringBuilder(source);
+                    for (int i = replacements.size() - 1; i >= 0; i--) {
+                        int[] replacement = replacements.get(i);
+                        transformedSource.replace(replacement[0], replacement[1], "%n");
+                    }
+                    StringBuilder transformedValue = new StringBuilder(value.length());
+                    newlineIndex = 0;
+                    for (int i = 0; i < value.length(); i++) {
+                        char current = value.charAt(i);
+                        if (current == '\n' && replacedNewlines.contains(newlineIndex++)) {
+                            transformedValue.append("%n");
+                        } else {
+                            transformedValue.append(current);
+                        }
+                    }
+                    return literal.withValue(transformedValue.toString()).withValueSource(transformedSource.toString());
                 }
             }
         }

--- a/src/main/java/org/openrewrite/staticanalysis/UsePortableNewlines.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UsePortableNewlines.java
@@ -39,6 +39,13 @@ import static java.util.Collections.singleton;
 @EqualsAndHashCode(callSuper = false)
 public class UsePortableNewlines extends Recipe {
 
+    private static final String PORTABLE_NEWLINE = "%n";
+    private static final String TEXT_BLOCK_DELIMITER = "\"\"\"";
+    private static final String STRING_DELIMITER = "\"";
+    private static final int UNICODE_ESCAPE_HEX_DIGITS = 4;
+    private static final int HEX_RADIX = 16;
+    private static final int OCTAL_RADIX = 8;
+
     private static final MethodMatcher STRING_FORMATTED = new MethodMatcher("java.lang.String formatted(..)");
 
     private static final MethodMatcher STRING_FORMAT = new MethodMatcher("java.lang.String format(java.lang.String, ..)");
@@ -103,14 +110,15 @@ public class UsePortableNewlines extends Recipe {
                     int rawStart = i;
                     char translated = source.charAt(i++);
                     if (translated == '\\') {
-                        int unicode = i;
-                        while (unicode < source.length() && source.charAt(unicode) == 'u') {
-                            unicode++;
+                        int hexStart = i;
+                        while (hexStart < source.length() && source.charAt(hexStart) == 'u') {
+                            hexStart++;
                         }
-                        if (translatedBackslashes % 2 == 0 && unicode > i && unicode + 4 <= source.length()) {
+                        // JLS 3.3: a backslash starts a Unicode escape only when preceded by an even number of backslashes
+                        if (translatedBackslashes % 2 == 0 && hexStart > i && hexStart + UNICODE_ESCAPE_HEX_DIGITS <= source.length()) {
                             try {
-                                translated = (char) Integer.parseInt(source.substring(unicode, unicode + 4), 16);
-                                i = unicode + 4;
+                                translated = (char) Integer.parseInt(source.substring(hexStart, hexStart + UNICODE_ESCAPE_HEX_DIGITS), HEX_RADIX);
+                                i = hexStart + UNICODE_ESCAPE_HEX_DIGITS;
                             } catch (NumberFormatException ignored) {
                                 // Keep the raw backslash; an invalid Unicode escape is not valid Java source.
                             }
@@ -124,29 +132,31 @@ public class UsePortableNewlines extends Recipe {
 
                 List<int[]> replacements = new ArrayList<>();
                 List<Integer> replacedNewlines = new ArrayList<>();
-                boolean textBlock = translatedSource.toString().startsWith("\"\"\"");
+                boolean textBlock = translatedSource.toString().startsWith(TEXT_BLOCK_DELIMITER);
                 boolean openingTextBlockLine = textBlock;
                 int newlineIndex = 0;
                 int consecutiveBackslashes = 0;
-                for (int i = textBlock ? 3 : 1; i < translatedSource.length(); i++) {
+                for (int i = (textBlock ? TEXT_BLOCK_DELIMITER : STRING_DELIMITER).length(); i < translatedSource.length(); i++) {
                     char current = translatedSource.charAt(i);
                     if (current == '\\') {
                         consecutiveBackslashes++;
                         continue;
                     }
-                    if (current == 'n' && consecutiveBackslashes % 2 == 1) {
+                    // An odd run of preceding backslashes means the current character is escaped
+                    boolean escaped = consecutiveBackslashes % 2 == 1;
+                    if (current == 'n' && escaped) {
                         replacements.add(new int[]{rawStarts.get(i - 1), rawEnds.get(i)});
                         replacedNewlines.add(newlineIndex++);
-                    } else if (consecutiveBackslashes % 2 == 1 && current >= '0' && current <= '7') {
+                    } else if (escaped && isOctalDigit(current)) {
                         int octal = current - '0';
-                        int maxDigits = current <= '3' ? 3 : 2;
+                        int maxDigits = maxOctalEscapeDigits(current);
                         int digits = 1;
                         while (digits < maxDigits && i + 1 < translatedSource.length()) {
                             char next = translatedSource.charAt(i + 1);
-                            if (next < '0' || next > '7') {
+                            if (!isOctalDigit(next)) {
                                 break;
                             }
-                            octal = octal * 8 + next - '0';
+                            octal = octal * OCTAL_RADIX + next - '0';
                             digits++;
                             i++;
                         }
@@ -158,7 +168,8 @@ public class UsePortableNewlines extends Recipe {
                                 translatedSource.charAt(i + 1) == '\n';
                         if (openingTextBlockLine) {
                             openingTextBlockLine = false;
-                        } else if (consecutiveBackslashes % 2 == 0) {
+                        } else if (!escaped) {
+                            // An escaped line terminator is a text-block continuation, which produces no newline
                             newlineIndex++;
                         }
                         if (crlf) {
@@ -171,14 +182,14 @@ public class UsePortableNewlines extends Recipe {
                     StringBuilder transformedSource = new StringBuilder(source);
                     for (int i = replacements.size() - 1; i >= 0; i--) {
                         int[] replacement = replacements.get(i);
-                        transformedSource.replace(replacement[0], replacement[1], "%n");
+                        transformedSource.replace(replacement[0], replacement[1], PORTABLE_NEWLINE);
                     }
                     StringBuilder transformedValue = new StringBuilder(value.length());
                     newlineIndex = 0;
                     for (int i = 0; i < value.length(); i++) {
                         char current = value.charAt(i);
                         if (current == '\n' && replacedNewlines.contains(newlineIndex++)) {
-                            transformedValue.append("%n");
+                            transformedValue.append(PORTABLE_NEWLINE);
                         } else {
                             transformedValue.append(current);
                         }
@@ -188,5 +199,14 @@ public class UsePortableNewlines extends Recipe {
             }
         }
         return maybeLiteral;
+    }
+
+    private static boolean isOctalDigit(char c) {
+        return '0' <= c && c <= '7';
+    }
+
+    // JLS 3.10.6: octal escapes are at most \377, so a third digit is only allowed after a leading 0-3
+    private static int maxOctalEscapeDigits(char firstOctalDigit) {
+        return firstOctalDigit <= '3' ? 3 : 2;
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/UsePortableNewlines.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UsePortableNewlines.java
@@ -45,6 +45,11 @@ public class UsePortableNewlines extends Recipe {
     private static final int UNICODE_ESCAPE_HEX_DIGITS = 4;
     private static final int HEX_RADIX = 16;
     private static final int OCTAL_RADIX = 8;
+    private static final char BACKSLASH = '\\';
+    private static final char UNICODE_ESCAPE_MARKER = 'u';
+    private static final char NEWLINE_ESCAPE_LETTER = 'n';
+    private static final char LINE_FEED = '\n';
+    private static final char CARRIAGE_RETURN = '\r';
 
     private static final MethodMatcher STRING_FORMATTED = new MethodMatcher("java.lang.String formatted(..)");
 
@@ -109,9 +114,9 @@ public class UsePortableNewlines extends Recipe {
                 for (int i = 0; i < source.length();) {
                     int rawStart = i;
                     char translated = source.charAt(i++);
-                    if (translated == '\\') {
+                    if (translated == BACKSLASH) {
                         int hexStart = i;
-                        while (hexStart < source.length() && source.charAt(hexStart) == 'u') {
+                        while (hexStart < source.length() && source.charAt(hexStart) == UNICODE_ESCAPE_MARKER) {
                             hexStart++;
                         }
                         // JLS 3.3: a backslash starts a Unicode escape only when preceded by an even number of backslashes
@@ -125,7 +130,7 @@ public class UsePortableNewlines extends Recipe {
                         }
                     }
                     translatedSource.append(translated);
-                    translatedBackslashes = translated == '\\' ? translatedBackslashes + 1 : 0;
+                    translatedBackslashes = translated == BACKSLASH ? translatedBackslashes + 1 : 0;
                     rawStarts.add(rawStart);
                     rawEnds.add(i);
                 }
@@ -138,13 +143,13 @@ public class UsePortableNewlines extends Recipe {
                 int consecutiveBackslashes = 0;
                 for (int i = (textBlock ? TEXT_BLOCK_DELIMITER : STRING_DELIMITER).length(); i < translatedSource.length(); i++) {
                     char current = translatedSource.charAt(i);
-                    if (current == '\\') {
+                    if (current == BACKSLASH) {
                         consecutiveBackslashes++;
                         continue;
                     }
                     // An odd run of preceding backslashes means the current character is escaped
                     boolean escaped = consecutiveBackslashes % 2 == 1;
-                    if (current == 'n' && escaped) {
+                    if (current == NEWLINE_ESCAPE_LETTER && escaped) {
                         replacements.add(new int[]{rawStarts.get(i - 1), rawEnds.get(i)});
                         replacedNewlines.add(newlineIndex++);
                     } else if (escaped && isOctalDigit(current)) {
@@ -160,12 +165,12 @@ public class UsePortableNewlines extends Recipe {
                             digits++;
                             i++;
                         }
-                        if (octal == '\n') {
+                        if (octal == LINE_FEED) {
                             newlineIndex++;
                         }
-                    } else if (textBlock && (current == '\n' || current == '\r')) {
-                        boolean crlf = current == '\r' && i + 1 < translatedSource.length() &&
-                                translatedSource.charAt(i + 1) == '\n';
+                    } else if (textBlock && (current == LINE_FEED || current == CARRIAGE_RETURN)) {
+                        boolean crlf = current == CARRIAGE_RETURN && i + 1 < translatedSource.length() &&
+                                translatedSource.charAt(i + 1) == LINE_FEED;
                         if (openingTextBlockLine) {
                             openingTextBlockLine = false;
                         } else if (!escaped) {
@@ -188,7 +193,7 @@ public class UsePortableNewlines extends Recipe {
                     newlineIndex = 0;
                     for (int i = 0; i < value.length(); i++) {
                         char current = value.charAt(i);
-                        if (current == '\n' && replacedNewlines.contains(newlineIndex++)) {
+                        if (current == LINE_FEED && replacedNewlines.contains(newlineIndex++)) {
                             transformedValue.append(PORTABLE_NEWLINE);
                         } else {
                             transformedValue.append(current);

--- a/src/test/java/org/openrewrite/staticanalysis/UsePortableNewlinesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UsePortableNewlinesTest.java
@@ -291,4 +291,165 @@ class UsePortableNewlinesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotCorruptEscapedBackslashNewlineInFormattedTextBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String script(String payload) {
+                      return \"""
+                          printf '%%s\\\\n' '%s'
+                          \""".formatted(payload);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceNewlineWithoutChangingEscapedBackslashNewline() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String message(String value) {
+                      return String.format("line=%s\\nscript=printf '%%s\\\\n'", value);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  String message(String value) {
+                      return String.format("line=%s%nscript=printf '%%s\\\\n'", value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void accountForUnicodeEscapedBackslash() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String message() {
+                      return String.format("\\u005c\\\\n");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  String message() {
+                      return String.format("\\u005c\\%n");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void accountForCrLfTextBlockContinuation() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String message() {
+                      return \"""
+                          foo\\
+                          bar\\n
+                          \""".formatted();
+                  }
+              }
+              """.replace("\n", "\r\n"),
+            """
+              class Test {
+                  String message() {
+                      return \"""
+                          foo\\
+                          bar%n
+                          \""".formatted();
+                  }
+              }
+              """.replace("\n", "\r\n")
+          )
+        );
+    }
+
+    @Test
+    void accountForOctalLineFeedBeforeNewlineEscape() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String message() {
+                      return String.format("\\12\\n");
+                  }
+              }
+              """,
+            """
+              class Test {
+                  String message() {
+                      return String.format("\\12%n");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void detectUnicodeEscapedTextBlockDelimiter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String message() {
+                      return String.format(\\u0022\\u0022\\u0022
+                          first line
+                          second line\\n
+                          \\u0022\\u0022\\u0022);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  String message() {
+                      return String.format(\\u0022\\u0022\\u0022
+                          first line
+                          second line%n
+                          \\u0022\\u0022\\u0022);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void accountForUnicodeEligibilityAfterTranslatedBackslashes() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String message() {
+                      return String.format("§u005c§§§u006e");
+                  }
+              }
+              """.replace("§", "\\")
+          )
+        );
+    }
 }


### PR DESCRIPTION
**Suggested review order:** 9 of 52 (Score: 8)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/988

## What's changed?

Updates `UsePortableNewlines` to distinguish a Java newline escape from an escaped backslash followed by `n`. The recipe keeps `J.Literal.value` and `J.Literal.valueSource` aligned for ordinary strings and text blocks, including Unicode escapes, octal line feeds, CRLF input, and text-block continuations.

## What's your motivation?

**Recipe:** [`org.openrewrite.staticanalysis.UsePortableNewlines`](https://docs.openrewrite.org/recipes/staticanalysis/useportablenewlines).

I found this by running `org.openrewrite.staticanalysis.UsePortableNewlines` from `org.openrewrite.recipe:rewrite-static-analysis:2.39.0` on [`CodexModelDefaultsResolverTest.java` in Symphony-Trello at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/setup/CodexModelDefaultsResolverTest.java). I reproduced the same result with the latest released recipe artifact, `org.openrewrite.recipe:rewrite-static-analysis:2.41.0`. `./mvnw -DskipTests test-compile` then fails with `illegal escape character` in this file and three other affected test files.

### Before

```java
printf '%%s\\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
```

### Actual after the recipe

```java
printf '%%s\%n' '{"jsonrpc":"2.0","id":1,"result":{}}'
```

### Expected after the recipe

`(unchanged)`

The source contains data for a generated shell script: two Java backslashes encode one runtime backslash. Replacing the `n` creates the invalid Java escape `\%`, so the transformed checkout no longer compiles.

### Confirmed real-world execution

- Project: [Symphony-Trello](https://github.com/martin-francois/symphony-trello).
- Location: [`CodexModelDefaultsResolverTest.java` at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/setup/CodexModelDefaultsResolverTest.java).
- Discovery checkout: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d).

## Anything in particular you'd like reviewers to focus on?

Please review the source-to-runtime newline mapping. A formatter newline such as `"line=%s\\n"` remains eligible, while escaped backslash-newline data remains unchanged.

## Have you considered any alternatives or workarounds?

Counting only consecutive raw backslashes does not account for Unicode escapes or text-block continuations and leaves the literal's semantic value inconsistent with its printed source in those cases.

## Any additional context

Pre-existing tests changed: None.

- Target commit: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d)
- Discovery release: `org.openrewrite.recipe:rewrite-static-analysis:2.39.0`
- Latest verification release: `org.openrewrite.recipe:rewrite-static-analysis:2.41.0`
- Focused test: `UsePortableNewlinesTest.doesNotCorruptEscapedBackslashNewlineInFormattedTextBlock`
- Upstream reproduction commit: [`openrewrite/rewrite-static-analysis@43b51de2`](https://github.com/openrewrite/rewrite-static-analysis/commit/43b51de212545049050a87c9701caf9a5111fb48)

This change was prepared with AI assistance. I reviewed the target execution evidence, implementation, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch