### PR TITLE
Skip declaration-site variance for invariant storage

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVariance.java
+++ b/src/main/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVariance.java
@@ -27,6 +27,7 @@ import org.openrewrite.marker.Markers;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.java.tree.J.Wildcard.Bound.Extends;
@@ -95,7 +96,7 @@ public class DeclarationSiteTypeVariance extends Recipe {
                         if (varParam.getTypeExpression() instanceof J.ParameterizedType) {
                             J.ParameterizedType pt = (J.ParameterizedType) varParam.getTypeExpression();
                             for (VariantTypeSpec variantTypeSpec : variantTypeSpecs) {
-                                if (variantTypeSpec.hasType(pt)) {
+                                if (variantTypeSpec.hasType(pt) && !isStoredInvariantly(m, varParam)) {
                                     return varParam.withTypeExpression(useDeclarationSiteVariance(pt, variantTypeSpec));
                                 }
                             }
@@ -104,6 +105,72 @@ public class DeclarationSiteTypeVariance extends Recipe {
                     }
                     return param;
                 }));
+            }
+
+            private boolean isStoredInvariantly(J.MethodDeclaration method, J.VariableDeclarations parameter) {
+                if (method.getBody() == null || parameter.getVariables().size() != 1) {
+                    return false;
+                }
+                JavaType.Variable parameterType = parameter.getVariables().get(0).getVariableType();
+                if (parameterType == null) {
+                    return false;
+                }
+                return new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean stored) {
+                        J.Assignment visitedAssignment = super.visitAssignment(assignment, stored);
+                        if (TypeUtils.isOfType(visitedAssignment.getVariable().getType(), parameterType.getType()) &&
+                            !references(visitedAssignment.getVariable(), parameterType) &&
+                            directlyReferences(visitedAssignment.getAssignment(), parameterType)) {
+                            stored.set(true);
+                        }
+                        return visitedAssignment;
+                    }
+
+                    @Override
+                    public J.VariableDeclarations.NamedVariable visitVariable(
+                            J.VariableDeclarations.NamedVariable variable, AtomicBoolean stored) {
+                        J.VariableDeclarations.NamedVariable visitedVariable = super.visitVariable(variable, stored);
+                        J.VariableDeclarations declarations = getCursor().firstEnclosing(J.VariableDeclarations.class);
+                        boolean explicitlyTyped = declarations != null &&
+                                !(declarations.getTypeExpression() instanceof J.Identifier &&
+                                  "var".equals(((J.Identifier) declarations.getTypeExpression()).getSimpleName()));
+                        if (explicitlyTyped && visitedVariable.getInitializer() != null &&
+                            TypeUtils.isOfType(visitedVariable.getType(), parameterType.getType()) &&
+                            directlyReferences(visitedVariable.getInitializer(), parameterType)) {
+                            stored.set(true);
+                        }
+                        return visitedVariable;
+                    }
+                }.reduce(method.getBody(), new AtomicBoolean()).get();
+            }
+
+            private boolean references(Expression expression, JavaType.Variable parameterType) {
+                return new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.Lambda visitLambda(J.Lambda lambda, AtomicBoolean found) {
+                        return lambda;
+                    }
+
+                    @Override
+                    public J.MemberReference visitMemberReference(J.MemberReference memberRef, AtomicBoolean found) {
+                        return memberRef;
+                    }
+
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
+                        if (parameterType.equals(identifier.getFieldType())) {
+                            found.set(true);
+                        }
+                        return identifier;
+                    }
+                }.reduce(expression, new AtomicBoolean()).get();
+            }
+
+            private boolean directlyReferences(Expression expression, JavaType.Variable parameterType) {
+                Expression unwrapped = expression.unwrap();
+                return unwrapped instanceof J.Identifier &&
+                       parameterType.equals(((J.Identifier) unwrapped).getFieldType());
             }
 
             private J.ParameterizedType useDeclarationSiteVariance(J.ParameterizedType pt, VariantTypeSpec spec) {

--- a/src/test/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVarianceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVarianceTest.java
@@ -235,4 +235,220 @@ class DeclarationSiteTypeVarianceTest implements RewriteTest {
           )
         );
     }
+    @Test
+    void doesNotAddVarianceToParameterStoredInvariantly() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class FieldTest<Input, Output> {
+                  private final Function<Input, Output> mapper;
+
+                  FieldTest(Function<Input, Output> mapper) {
+                      this.mapper = mapper;
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class LocalTest<Input, Output> {
+                  void test(Function<Input, Output> mapper) {
+                      Function<Input, Output> stored = mapper;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsVarianceWhenFieldAcceptsIt() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  private final Function<? super Input, ? extends Output> mapper;
+
+                  Test(Function<Input, Output> mapper) {
+                      this.mapper = mapper;
+                  }
+              }
+              """,
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  private final Function<? super Input, ? extends Output> mapper;
+
+                  Test(Function<? super Input, ? extends Output> mapper) {
+                      this.mapper = mapper;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsVarianceWhenInvariantFieldStoresAdapter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  private Function<Input, Output> mapper;
+
+                  void set(Function<Input, Output> mapper) {
+                      this.mapper = input -> mapper.apply(input);
+                  }
+
+                  void forward(Function<Input, Output> mapper) {
+                      set(mapper);
+                  }
+              }
+              """,
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  private Function<Input, Output> mapper;
+
+                  void set(Function<? super Input, ? extends Output> mapper) {
+                      this.mapper = input -> mapper.apply(input);
+                  }
+
+                  void forward(Function<? super Input, ? extends Output> mapper) {
+                      set(mapper);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsVarianceWhenParameterIsNormalizedInPlace() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Objects;
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  void use(Function<Input, Output> mapper) {
+                      mapper = Objects.requireNonNull(mapper);
+                  }
+
+                  void forward(Function<Input, Output> mapper) {
+                      use(mapper);
+                  }
+              }
+              """,
+            """
+              import java.util.Objects;
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  void use(Function<? super Input, ? extends Output> mapper) {
+                      mapper = Objects.requireNonNull(mapper);
+                  }
+
+                  void forward(Function<? super Input, ? extends Output> mapper) {
+                      use(mapper);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsVarianceWhenParameterIsStoredInVar() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  void use(Function<Input, Output> mapper) {
+                      var stored = mapper;
+                  }
+
+                  void forward(Function<Input, Output> mapper) {
+                      use(mapper);
+                  }
+              }
+              """,
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  void use(Function<? super Input, ? extends Output> mapper) {
+                      var stored = mapper;
+                  }
+
+                  void forward(Function<? super Input, ? extends Output> mapper) {
+                      use(mapper);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addsVarianceWhenInvariantLocalStoresAdapterResult() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  Function<Input, Output> adapt(Function<? super Input, ? extends Output> mapper) {
+                      return input -> mapper.apply(input);
+                  }
+
+                  void use(Function<Input, Output> mapper) {
+                      Function<Input, Output> stored = adapt(mapper);
+                  }
+
+                  void forward(Function<Input, Output> mapper) {
+                      use(mapper);
+                  }
+              }
+              """,
+            """
+              import java.util.function.Function;
+
+              class Test<Input, Output> {
+                  Function<Input, Output> adapt(Function<? super Input, ? extends Output> mapper) {
+                      return input -> mapper.apply(input);
+                  }
+
+                  void use(Function<? super Input, ? extends Output> mapper) {
+                      Function<Input, Output> stored = adapt(mapper);
+                  }
+
+                  void forward(Function<? super Input, ? extends Output> mapper) {
+                      use(mapper);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
**Suggested review order:** 11 of 52 (Score: 7.5)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/990

## What's changed?

Leaves a declaration-site type unchanged when the parameter is stored directly in an invariant field or explicitly typed local variable. Parameters remain eligible when their destination already accepts the proposed variance or when an adapter expression is stored instead.

## What's your motivation?

**Recipe:** [`org.openrewrite.staticanalysis.CommonDeclarationSiteTypeVariances`](https://docs.openrewrite.org/recipes/staticanalysis/declarationsitetypevariance).

I found this by running `org.openrewrite.staticanalysis.CommonDeclarationSiteTypeVariances`, which configures `DeclarationSiteTypeVariance`, from `org.openrewrite.recipe:rewrite-static-analysis:2.39.0` on [`ConfigResolver.java` in Symphony-Trello at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/main/java/ch/fmartin/symphony/trello/config/ConfigResolver.java). I reproduced the same result with the latest released recipe artifact, `org.openrewrite.recipe:rewrite-static-analysis:2.41.0`. The recipe changed 18 files, and `./mvnw -DskipTests compile` then reported four incompatible-type errors.

### Before

```java
private final Function<String, Optional<String>> environmentResolver;

public ConfigResolver(Function<String, Optional<String>> environmentResolver) {
    this.environmentResolver = environmentResolver;
}
```

### Actual after the recipe

```java
private final Function<String, Optional<String>> environmentResolver;

public ConfigResolver(Function<? super String, ? extends Optional<String>> environmentResolver) {
    this.environmentResolver = environmentResolver;
}
```

### Expected after the recipe

`(unchanged)`

The wildcarded parameter is not assignable to the invariant field. The recipe therefore turns compiling production code into code that does not compile.

### Confirmed real-world execution

- Project: [Symphony-Trello](https://github.com/martin-francois/symphony-trello).
- Location: [`ConfigResolver.java` at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/main/java/ch/fmartin/symphony/trello/config/ConfigResolver.java).
- Discovery checkout: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d).

## Anything in particular you'd like reviewers to focus on?

Please review the direct-storage boundary. Tim te Beek preferred this approach: skip variance where direct invariant storage makes it invalid, while retaining valid conversions instead of widening unrelated fields.

## Have you considered any alternatives or workarounds?

Widening the destination field would expand the recipe beyond declaration-site parameter variance and change APIs and later uses. Skipping only the invalid parameter conversion keeps the change local.

## Any additional context

Pre-existing tests changed: None.

- Target commit: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martinfrancois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d)
- Discovery release: `org.openrewrite.recipe:rewrite-static-analysis:2.39.0`
- Latest verification release: `org.openrewrite.recipe:rewrite-static-analysis:2.41.0`
- Latest-release compile failures: `ConfigResolver`, `TrelloBoardSetup`, `GitHubConfigurator`, and `SetupSystemProperties`
- Focused tests: `DeclarationSiteTypeVarianceTest`

This change was prepared with AI assistance. I reviewed the target execution evidence, implementation, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch