### PR TITLE
FallThrough: don't add a break after a guarded early exit

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FallThroughVisitor.java
@@ -156,9 +156,32 @@ public class FallThroughVisitor<P> extends JavaIsoVisitor<P> {
                 return trees.stream()
                         .reduce((s1, s2) -> s2) // last statement
                         .map(s -> breaks(s) || // https://github.com/openrewrite/rewrite-static-analysis/issues/173
+                                guardsWithEarlyExit(s) || // https://github.com/openrewrite/rewrite-static-analysis/issues/460
                                 s.getComments().stream().anyMatch(HAS_RELIEF_PATTERN_COMMENT) ||
                                 s instanceof J.Block && ((J.Block) s).getEnd().getComments().stream().anyMatch(HAS_RELIEF_PATTERN_COMMENT)
                         ).orElse(false);
+            }
+
+            /**
+             * An {@code if} without an {@code else} whose then part completes abruptly guards the statements
+             * after it, so a fall-through past it is deliberate rather than an omission and adding a
+             * {@code break} would change behavior. Only blocks and labels are unwrapped; constructs such as
+             * {@code try} and {@code switch} are deliberately not, because they can complete normally even
+             * when every {@code if} they contain completes abruptly.
+             */
+            private static boolean guardsWithEarlyExit(Statement s) {
+                if (s instanceof J.Block) {
+                    List<Statement> statements = ((J.Block) s).getStatements();
+                    return !statements.isEmpty() && guardsWithEarlyExit(statements.get(statements.size() - 1));
+                }
+                if (s instanceof J.Label) {
+                    return guardsWithEarlyExit(((J.Label) s).getStatement());
+                }
+                if (s instanceof J.If) {
+                    J.If iff = (J.If) s;
+                    return iff.getElsePart() == null && breaks(iff.getThenPart());
+                }
+                return false;
             }
 
             private static boolean breaks(Statement s) {

--- a/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FallThroughTest.java
@@ -452,6 +452,116 @@ class FallThroughTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/460")
+    @Test
+    void doNotAddBreakAfterGuardedEarlyExit() {
+        // Reduced from quarkus JavadocToAsciidocTransformer.appendEscapedAsciiDoc; the `]` case
+        // deliberately falls through to the shared escaping branch when not in inline macro mode.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void escape(String text, boolean inlineMacroMode) {
+                      StringBuilder sb = new StringBuilder();
+                      boolean escaping = false;
+                      for (int i = 0; i < text.length(); i++) {
+                          char ch = text.charAt(i);
+                          switch (ch) {
+                              case ']':
+                                  if (inlineMacroMode) {
+                                      sb.append("&#93;");
+                                      break;
+                                  }
+                              case '#':
+                              case '*':
+                                  if (!escaping) {
+                                      sb.append("++");
+                                      escaping = true;
+                                  }
+                                  sb.append(ch);
+                                  break;
+                              default:
+                                  sb.append(ch);
+                          }
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/460")
+    @Test
+    void doNotAddBreakAfterGuardedEarlyExitInsideBlock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void n(int i, boolean b) {
+                      switch (i) {
+                          case 0: {
+                              if (b) {
+                                  System.out.println("zero");
+                                  break;
+                              }
+                          }
+                          case 1:
+                              System.out.println("one");
+                              break;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/460")
+    @Test
+    void addBreakWhenCodeFollowsGuardedEarlyExit() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              public class A {
+                  public void n(int i, boolean b) {
+                      switch (i) {
+                          case 0:
+                              if (b) {
+                                  break;
+                              }
+                              System.out.println("zero");
+                          case 1:
+                              System.out.println("one");
+                              break;
+                      }
+                  }
+              }
+              """,
+            """
+              public class A {
+                  public void n(int i, boolean b) {
+                      switch (i) {
+                          case 0:
+                              if (b) {
+                                  break;
+                              }
+                              System.out.println("zero");
+                              break;
+                          case 1:
+                              System.out.println("one");
+                              break;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void addBreaksFallthroughCasesComprehensive() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #460

Per your call in the issue — the recipe should leave this shape alone.

## What was happening

`FallThrough` treated a case ending in an `if` without an `else` as an unintentional fall-through and appended a `break`, which changed behavior:

```java
case ']':
    if (inlineMacroMode) {
        - sb.append("&#93;");
        break;
    }
    break;   // <-- added; `]` is no longer escaped when !inlineMacroMode
case '#':
case '*':
    if (!escaping) {
        sb.append("++");
        escaping = true;
    }
    sb.append(ch);
    break;
```

`breaks(Statement)` returned `false` for an `if` with no `else`, no relief comment was present, so a `break` was appended.

## The change

An `if` without an `else` whose then part completes abruptly is a guarded early exit — the statements after it are reachable only when the guard is false, so a fall-through past it is deliberate rather than an omission.

I added this as a separate `guardsWithEarlyExit` check rather than relaxing `breaks(..)`, because the two mean different things. `breaks(..)` answers "does this always complete abruptly", and it is used recursively for `try`, `switch` and blocks. Loosening it there regressed `nestedBlocks`, where

```java
try {
    if (true) {
        return 1;
    }
} catch (Exception e) {
    ...
}
```

can still complete normally and so genuinely does need the `break`. `guardsWithEarlyExit` therefore unwraps only blocks and labels, and deliberately does not descend into `try` or `switch`.

The trade-off is that the same shape can be a real omission, so some detection is lost. That seemed to be the intent of "not making any change here makes most sense", but happy to narrow it further if you'd rather.

## Tests

- Three added, all tagged to #460: the reduced quarkus case, the block-wrapped variant that reaches the check through the block recursion, and a negative case confirming a `break` is still added when unguarded code follows the guard.

Full suite locally on JDK 21: 2277 tests, 0 failures.