### PR TITLE
BooleanChecksNotInverted not to alter Python chained comparisons

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/BooleanChecksNotInverted.java
+++ b/src/main/java/org/openrewrite/staticanalysis/BooleanChecksNotInverted.java
@@ -55,6 +55,9 @@ public class BooleanChecksNotInverted extends Recipe {
                     J.Parentheses<?> expr = (J.Parentheses<?>) unary.getExpression();
                     if (expr.getTree() instanceof J.Binary) {
                         J.Binary binary = (J.Binary) expr.getTree();
+                        if (isComparison(binary.getLeft()) || isComparison(binary.getRight())) {
+                            return super.visitUnary(unary, ctx);
+                        }
                         switch (binary.getOperator()) {
                             case LessThan:
                                 return super.visit(binary.withOperator(J.Binary.Type.GreaterThanOrEqual), ctx).withPrefix(unary.getPrefix());
@@ -77,6 +80,21 @@ public class BooleanChecksNotInverted extends Recipe {
                     }
                 }
                 return super.visitUnary(unary, ctx);
+            }
+
+            private boolean isComparison(J expr) {
+                if (expr instanceof J.Binary) {
+                    switch (((J.Binary) expr).getOperator()) {
+                        case LessThan:
+                        case GreaterThan:
+                        case LessThanOrEqual:
+                        case GreaterThanOrEqual:
+                        case Equal:
+                        case NotEqual:
+                            return true;
+                    }
+                }
+                return false;
             }
         };
     }

--- a/src/test/java/org/openrewrite/staticanalysis/BooleanChecksNotInvertedTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/BooleanChecksNotInvertedTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.python.Assertions.python;
 
 @SuppressWarnings("DoubleNegation")
 class BooleanChecksNotInvertedTest implements RewriteTest {
@@ -81,6 +82,20 @@ class BooleanChecksNotInvertedTest implements RewriteTest {
                       return b;
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangePythonChainedComparison() {
+        rewriteRun(
+          //language=python
+          python(
+            """
+              def test(value):
+                  if not (1 <= value <= 6):
+                      pass
               """
           )
         );


### PR DESCRIPTION
## What's changed?

Amending `BooleanChecksNotInverted` not to alter Python chained comparisons like this:
```diff
-         if not (1 <= value <= 6):
+         if 1 <= value > 6:
```

## What's your motivation?

Wrong code is produced.