### PR TITLE
Less eager changes in WriteOctalValuesAsDecimal

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimal.java
+++ b/src/main/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimal.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.staticanalysis.csharp.CSharpFileChecker;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.singleton;
 
@@ -42,24 +43,17 @@ public class WriteOctalValuesAsDecimal extends Recipe {
     @Getter
     final Set<String> tags = singleton("RSPEC-S1314");
 
+    private static final Pattern OCTAL_LITERAL = Pattern.compile("0[0-7_]*[0-7][lL]?");
+
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(Preconditions.not(new CSharpFileChecker<>()), new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitLiteral(J.Literal literal, ExecutionContext ctx) {
                 String src = literal.getValueSource();
-                if (src != null && src.startsWith("0")) {
-                    if (src.length() >= 2 &&
-                        src.charAt(1) != 'x' && src.charAt(1) != 'X' &&
-                        src.charAt(1) != 'b' && src.charAt(1) != 'B' &&
-                        src.charAt(1) != '.' &&
-                        src.charAt(src.length() - 1) != 'L' && src.charAt(src.length() - 1) != 'l' &&
-                        src.charAt(src.length() - 1) != 'F' && src.charAt(src.length() - 1) != 'f' &&
-                        src.charAt(src.length() - 1) != 'D' && src.charAt(src.length() - 1) != 'd' &&
-                        !src.contains(".")) {
-                        assert literal.getValue() != null;
-                        return literal.withValueSource(literal.getValue().toString());
-                    }
+                if (src != null && literal.getValue() != null && OCTAL_LITERAL.matcher(src).matches()) {
+                    String suffix = src.endsWith("l") || src.endsWith("L") ? src.substring(src.length() - 1) : "";
+                    return literal.withValueSource(literal.getValue() + suffix);
                 }
                 return super.visitLiteral(literal, ctx);
             }

--- a/src/test/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimalTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimalTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.python.Assertions.python;
 
 @SuppressWarnings("OctalInteger")
 class WriteOctalValuesAsDecimalTest implements RewriteTest {
@@ -64,6 +65,71 @@ class WriteOctalValuesAsDecimalTest implements RewriteTest {
                       double t = 0.01;
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void octalLongPreservesSuffix() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  long a = 010L;
+                  long b = 010l;
+              }
+              """,
+            """
+              class Test {
+                  long a = 8L;
+                  long b = 8l;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeFloatingPointWithLeadingZero() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  float a = 010f;
+                  float b = 010F;
+                  double c = 010d;
+                  double d = 010D;
+                  double e = 0.010;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void pythonComplexLiteral() {
+        rewriteRun(
+          //language=py
+          python(
+            """
+              def f(parameter: complex = 0j):
+                  pass
+              """
+          )
+        );
+    }
+
+    @Test
+    void pythonExplicitOctalUnchanged() {
+        rewriteRun(
+          //language=py
+          python(
+            """
+              a = 0o755
+              b = 0
               """
           )
         );


### PR DESCRIPTION
## What's changed?

Minor improvement to the `WriteOctalValuesAsDecimal`:
- Preserving the actual "spelling" - e.g. l vs. L, of the prefix in case of long literals.
- Also simplifying the gating logic.
- Also not altering Python's `script.chmod(0o755)`.

## What's your motivation?

I've stumbled upon the minor shortcomings when analyzing the `0j` (complex numbers in Python) failure with this recipe - as addressed by https://github.com/openrewrite/rewrite/pull/8547