### PR TITLE
Do not apply diamond operator when nested inference would fail

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseDiamondOperator.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseDiamondOperator.java
@@ -228,7 +228,9 @@ public class UseDiamondOperator extends Recipe {
             if (paramTypes != null && (java9 || newClass.getBody() == null) && newClass.getClazz() instanceof J.ParameterizedType) {
                 J.ParameterizedType newClassType = (J.ParameterizedType) newClass.getClazz();
                 if (newClassType.getTypeParameters() != null) {
-                    if (paramTypes.size() != newClassType.getTypeParameters().size() || hasAnnotations(newClassType)) {
+                    if (paramTypes.size() != newClassType.getTypeParameters().size() ||
+                            hasAnnotations(newClassType) ||
+                            breaksNestedTypeInference(newClass)) {
                         return newClass;
                     }
                     for (int i = 0; i < paramTypes.size(); i++) {
@@ -243,6 +245,71 @@ public class UseDiamondOperator extends Recipe {
                 }
             }
             return newClass;
+        }
+
+        /**
+         * A recursively bounded type parameter (such as {@code T extends Comparable<T>}) imposes an equality
+         * constraint that javac cannot solve when a constructor argument is itself an expression awaiting
+         * inference, as both would have to be inferred in the same round.
+         */
+        private static boolean breaksNestedTypeInference(J.NewClass newClass) {
+            JavaType.Parameterized type = TypeUtils.asParameterized(newClass.getType());
+            if (type == null) {
+                return false;
+            }
+            boolean recursivelyBounded = false;
+            for (JavaType declared : type.getType().getTypeParameters()) {
+                if (declared instanceof JavaType.GenericTypeVariable) {
+                    JavaType.GenericTypeVariable generic = (JavaType.GenericTypeVariable) declared;
+                    for (JavaType bound : generic.getBounds()) {
+                        if (mentionsTypeVariable(bound, generic.getName(), 0)) {
+                            recursivelyBounded = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (!recursivelyBounded) {
+                return false;
+            }
+            for (Expression argument : newClass.getArguments()) {
+                if (argument instanceof J.MethodInvocation) {
+                    JavaType.Method methodType = ((J.MethodInvocation) argument).getMethodType();
+                    if (methodType != null) {
+                        Optional<JavaType.Method> declared = findDeclaredMethod(
+                                methodType.getDeclaringType(), methodType.getName(), methodType.getParameterTypes());
+                        // An absent declaration means the parameter types were themselves inferred
+                        if (!declared.isPresent() || mentionsTypeVariable(declared.get().getReturnType(), null, 0)) {
+                            return true;
+                        }
+                    }
+                }
+                if (argument instanceof J.NewClass && ((J.NewClass) argument).getClazz() instanceof J.ParameterizedType) {
+                    List<Expression> typeParameters = ((J.ParameterizedType) ((J.NewClass) argument).getClazz()).getTypeParameters();
+                    if (typeParameters != null && typeParameters.size() == 1 && typeParameters.get(0) instanceof J.Empty) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private static boolean mentionsTypeVariable(JavaType type, @Nullable String name, int depth) {
+            if (depth > 4) {
+                return false;
+            }
+            if (type instanceof JavaType.GenericTypeVariable) {
+                return name == null || name.equals(((JavaType.GenericTypeVariable) type).getName());
+            }
+            JavaType.Parameterized parameterized = TypeUtils.asParameterized(type);
+            if (parameterized != null) {
+                for (JavaType typeParameter : parameterized.getTypeParameters()) {
+                    if (mentionsTypeVariable(typeParameter, name, depth + 1)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         private static boolean hasAnnotations(J type) {

--- a/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseDiamondOperatorTest.java
@@ -712,6 +712,161 @@ class UseDiamondOperatorTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1012")
+    @Test
+    void doNotChangeRecursivelyBoundTypeParameterWithNestedDiamondArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Wrapper<T> {
+                  Wrapper(Object target, String key) {}
+              }
+
+              class Container<T extends Number & Comparable<T>> {
+                  Container(String id, Wrapper<T> wrapper) {}
+              }
+
+              class Test {
+                  void test() {
+                      Container<Integer> panel = new Container<Integer>("id", new Wrapper<>(null, "key"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1012")
+    @Test
+    void doNotChangeRecursivelyBoundTypeParameterWithGenericMethodArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Wrapper<T> {
+                  Wrapper(Object target, String key) {}
+              }
+
+              class Container<T extends Comparable<T>> {
+                  Container(String id, Wrapper<T> wrapper) {}
+              }
+
+              class Test {
+                  static <X> Wrapper<X> wrapper() {
+                      return null;
+                  }
+
+                  void test() {
+                      Container<Integer> panel = new Container<Integer>("id", wrapper());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1012")
+    @Test
+    void nestedDiamondArgumentWithoutRecursiveBound() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Wrapper<T> {
+                  Wrapper(Object target, String key) {}
+              }
+
+              class Container<T> {
+                  Container(String id, Wrapper<T> wrapper) {}
+              }
+
+              class Test {
+                  void test() {
+                      Container<Integer> panel = new Container<Integer>("id", new Wrapper<>(null, "key"));
+                  }
+              }
+              """,
+            """
+              class Wrapper<T> {
+                  Wrapper(Object target, String key) {}
+              }
+
+              class Container<T> {
+                  Container(String id, Wrapper<T> wrapper) {}
+              }
+
+              class Test {
+                  void test() {
+                      Container<Integer> panel = new Container<>("id", new Wrapper<>(null, "key"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1012")
+    @Test
+    void doNotChangeEnumMapWithNestedDiamondArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              enum Day { MONDAY }
+
+              class Test {
+                  void test() {
+                      EnumMap<Day, String> map = new EnumMap<Day, String>(new HashMap<>());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1012")
+    @Test
+    void enumMapWithNonGenericMethodArgument() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.*;
+
+              enum Day { MONDAY }
+
+              class Test {
+                  static Map<Day, String> source() {
+                      return null;
+                  }
+
+                  void test() {
+                      EnumMap<Day, String> map = new EnumMap<Day, String>(source());
+                  }
+              }
+              """,
+            """
+              import java.util.*;
+
+              enum Day { MONDAY }
+
+              class Test {
+                  static Map<Day, String> source() {
+                      return null;
+                  }
+
+                  void test() {
+                      EnumMap<Day, String> map = new EnumMap<>(source());
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void anonymousClassArgBeyondVarargsParameterWithoutVarargsFlag() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #1012

## The reported repro does not actually reproduce

The example in the issue compiles fine on javac:

```java
class Container<T> { Container(String id, Wrapper<T> wrapper) {} }
class Wrapper<T> { Wrapper(Object target, String key) {} }

Container<Integer> panel = new Container<>("id", new Wrapper<>(null, "key")); // compiles
```

javac has handled nested diamond poly expressions since Java 8, so the fix proposed in the issue — bail out whenever any argument uses a diamond — would suppress a large number of valid rewrites without addressing the real cause.

## The actual trigger

The failure needs **two** conditions together:

1. the instantiated class declares a **recursively bounded** (f-bounded) type parameter, and
2. an argument is itself an expression awaiting inference.

Reducing the reporter's `NumberTextFieldPanel` (Wicket's `NumberTextField<T extends Number & Comparable<T>>`) reproduces their exact compiler error:

```java
class Container<T extends Number & Comparable<T>> { Container(String id, Wrapper<T> w) {} }

Container<Integer> c = new Container<>("id", new Wrapper<>(null, "k"));
// error: cannot infer type arguments for Container<>
//   reason: inferred type does not conform to equality constraint(s)
- //     inferred: T#1
- //     equality constraints(s): T#2
```

The f-bound imposes an equality constraint that javac cannot solve while the nested diamond is still being inferred in the same round. Verified against javac that each condition is individually necessary:

| case | compiles |
|---|---|
| f-bound + nested diamond arg | ❌ |
| f-bound + generic-method arg | ❌ |
| f-bound + *explicit* inner type args | ✅ |
| f-bound + non-generic method arg | ✅ |
| f-bound, no poly arg at all | ✅ |
| nested diamond, no f-bound | ✅ |
| lambda arg | ✅ |

This is not limited to user code — it hits the JDK too, since `EnumMap<K extends Enum<K>, V>` is f-bounded:

```java
EnumMap<Day, String> a = new EnumMap<>(source());        // compiles
EnumMap<Day, String> b = new EnumMap<>(new HashMap<>()); // does NOT compile
```

## The fix

`maybeRemoveParams` now bails only when a recursively bounded type parameter is combined with an argument that genuinely requires inference — a diamond `new X<>(...)`, or an invocation of a *generic* method. Non-generic method arguments and explicitly typed arguments are still simplified, so `new EnumMap<>(source())` keeps being rewritten.

## Tests

Five tests pin both directions: the three failing shapes stay unchanged, and the issue's own (compilable) example plus `new EnumMap<>(source())` still get the diamond. Full suite passes; the 7 unrelated Python failures are pre-existing on `main`.