### PR TITLE
Limit ExplicitInitialization recipe to Java, C#, Groovy

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitInitialization.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitInitialization.java
@@ -20,12 +20,15 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
+import org.openrewrite.staticanalysis.csharp.CSharpFileChecker;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
 import java.time.Duration;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static org.openrewrite.Preconditions.or;
 
 public class ExplicitInitialization extends Recipe {
 
@@ -51,6 +54,8 @@ public class ExplicitInitialization extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.not(new KotlinFileChecker<>()), new ExplicitInitializationVisitor<>());
+        return Preconditions.check(
+                or(new JavaFileChecker<>(), new CSharpFileChecker<>(), new GroovyFileChecker<>()),
+                new ExplicitInitializationVisitor<>());
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitInitializationTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -23,6 +24,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.javascript.Assertions.typescript;
 
 class ExplicitInitializationTest implements RewriteTest {
 
@@ -273,5 +275,23 @@ class ExplicitInitializationTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Nested
+    class Javascript {
+        @Test
+        void doNotRemoveExplicitInitializationInTypescript() {
+            rewriteRun(
+              typescript(
+                """
+                  class Test {
+                    private isShuttingDown = false;
+                    private count = 0;
+                    private name = null;
+                  }
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?

Limit the `ExplicitInitialization` recipe to allow-listed languages of: Java, C#, Groovy.

## What's your motivation?

For other languages this change is not warranted. And also I think by default it shouldn't trigger as my gut feeling is that a random new language, yet to be added to our portfolio, shouldn't have this either.