### PR TITLE
Exclude Go from RemoveUnusedLocalVariables

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariables.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.staticanalysis.go.GoFileChecker;
 import org.openrewrite.staticanalysis.javascript.JavascriptFileChecker;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
@@ -103,8 +104,8 @@ public class RemoveUnusedLocalVariables extends Recipe {
             ignoreVariableNames.addAll(Arrays.asList(ignoreVariablesNamed));
         }
 
-        TreeVisitor<?, ExecutionContext> notJsNorKt = and(not(new JavascriptFileChecker<>()), not(new KotlinFileChecker<>()));
-        return Preconditions.check(notJsNorKt, new JavaIsoVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> notJsNorKtNorGo = and(not(new JavascriptFileChecker<>()), not(new KotlinFileChecker<>()), not(new GoFileChecker<>()));
+        return Preconditions.check(notJsNorKtNorGo, new JavaIsoVisitor<ExecutionContext>() {
             private Cursor getCursorToParentScope(Cursor cursor) {
                 return cursor.dropParentUntil(is ->
                         is instanceof J.ClassDeclaration ||

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveUnusedLocalVariablesTest.java
@@ -22,6 +22,8 @@ import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.openrewrite.golang.Assertions.go;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
 import static org.openrewrite.javascript.Assertions.typescript;
@@ -1381,6 +1383,28 @@ class RemoveUnusedLocalVariablesTest implements RewriteTest {
                 """
                   class Foo {
                     bar: string;
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
+    class Go {
+        @Test
+        void doNotChangeStructFields() {
+            assumeTrue(GoEngineTestListener.isAvailable(), "rewrite-go-rpc engine unavailable");
+            rewriteRun(
+              go(
+                """
+                  package main
+
+                  import "sync"
+
+                  type BaseCache struct {
+                      CacheName    string
+                      KvStoreItems sync.Map
                   }
                   """
               )


### PR DESCRIPTION
## What's changed?

Excluding Go code from `RemoveUnusedLocalVariables` recipe.

## What's your motivation?

- Unused variables are invalid code in Go, enforced by the compiler
- Also the recipe tends to remove type declaration fields as they are modelled as variable declarations:
```diff
                type BaseCache struct {
-                   Text    string
-                   NotText sync.Map
                }
```