### PR TITLE
Python: fix whitespace handling for SimplifyBooleanReturn

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanReturn.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyBooleanReturn.java
@@ -82,19 +82,19 @@ public class SimplifyBooleanReturn extends Recipe {
                             return i;
                         }
 
-                        Expression ifCondition = i.getIfCondition().getTree();
+                        Expression ifCondition = i.getIfCondition().getTree().withPrefix(return_.getExpression().getPrefix());
 
                         if (isLiteralTrue(return_.getExpression())) {
                             if (singleFollowingStatement.map(this::isLiteralFalse).orElse(false) && i.getElsePart() == null) {
                                 doAfterVisit(new DeleteStatement<>(followingStatements().get(0)));
-                                return maybeAutoFormat(return_, return_.withExpression(ifCondition), ctx, parent);
+                                return maybeAutoFormat(return_, return_.withPrefix(i.getPrefix()).withExpression(ifCondition), ctx, parent);
                             }
                             if (!singleFollowingStatement.isPresent() &&
                                     getReturnExprIfOnlyStatementInElseThen(i).map(this::isLiteralFalse).orElse(false)) {
                                 if (i.getElsePart() != null) {
                                     doAfterVisit(new DeleteStatement<>(i.getElsePart().getBody()));
                                 }
-                                return maybeAutoFormat(return_, return_.withExpression(ifCondition), ctx, parent);
+                                return maybeAutoFormat(return_, return_.withPrefix(i.getPrefix()).withExpression(ifCondition), ctx, parent);
                             }
                         } else if (isLiteralFalse(return_.getExpression())) {
                             boolean returnThenPart = false;

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanReturnTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyBooleanReturnTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.python.Assertions.python;
 
 @SuppressWarnings("ALL")
 class SimplifyBooleanReturnTest implements RewriteTest {
@@ -335,5 +336,47 @@ class SimplifyBooleanReturnTest implements RewriteTest {
               )
             );
         }
+    }
+
+    @Test
+    void pythonImpliedElse() {
+        rewriteRun(
+          //language=python
+          python(
+            """
+              def is_ip(address):
+                  if re.match(regexp, address):
+                      return True
+
+                  return False
+              """,
+            """
+              def is_ip(address):
+                  return re.match(regexp, address)
+              """
+          )
+        );
+    }
+
+    @Test
+    void pythonInClass() {
+        rewriteRun(
+          //language=python
+          python(
+            """
+              class A:
+                  def is_ip(self, address):
+                      if re.match(regexp, address):
+                          return True
+
+                      return False
+              """,
+            """
+              class A:
+                  def is_ip(self, address):
+                      return re.match(regexp, address)
+              """
+          )
+        );
     }
 }


### PR DESCRIPTION
## What's changed?

An amendment `SimplifyBooleanReturn` not to mangle whitespace in case of Python changes.

## What's your motivation?

Otherwise it converts:
```python
if some_check(a):
    return True
```
to
```python
    returnsome_check(a)
```

which has two problems:
- invalid indent
- lack of prefix in the expression

