### PR TITLE
Go: NoRedundantJumpStatements not to alter return statements with exp…

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NoRedundantJumpStatements.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoRedundantJumpStatements.java
@@ -90,7 +90,8 @@ public class NoRedundantJumpStatements extends Recipe {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
                 JavaType.Method methodType = m.getMethodType();
                 if (m.getBody() != null && methodType != null && JavaType.Primitive.Void == methodType.getReturnType()) {
-                    return m.withBody(m.getBody().withStatements(ListUtils.mapLast(m.getBody().getStatements(), s -> s instanceof J.Return ? null : s)));
+                    return m.withBody(m.getBody().withStatements(ListUtils.mapLast(m.getBody().getStatements(),
+                            s -> s instanceof J.Return && ((J.Return) s).getExpression() == null ? null : s)));
                 }
 
                 return m;

--- a/src/test/java/org/openrewrite/staticanalysis/NoRedundantJumpStatementsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoRedundantJumpStatementsTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.openrewrite.golang.Assertions.go;
 import static org.openrewrite.java.Assertions.java;
 
 @SuppressWarnings({"UnnecessaryContinue", "UnnecessaryReturnStatement"})
@@ -58,6 +60,27 @@ class NoRedundantJumpStatementsTest implements RewriteTest {
                           }
                       }
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveGoReturnWithExpression() {
+        assumeTrue(GoEngineTestListener.isAvailable(), "rewrite-go-rpc engine unavailable");
+        rewriteRun(
+          spec -> spec.recipe(new NoRedundantJumpStatements()),
+          go(
+            """
+              package main
+
+              func doWork() {
+                  println("work")
+              }
+
+              func wrapper() {
+                  return doWork()
               }
               """
           )


### PR DESCRIPTION
…ressions

## What's changed?

An amendment to `NoRedundantJumpStatements` recipe to cater for special Go feature.

## What's your motivation?

- In Go a void method can have a return statement with an expression, whose return type is also void.
- Without the fix, it would remove the return statements and change the program semantics
