### PR TITLE
Gate ReplaceStringConcatenationWithStringValueOf to Java+Groovy only

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceStringConcatenationWithStringValueOf.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceStringConcatenationWithStringValueOf.java
@@ -17,6 +17,7 @@ package org.openrewrite.staticanalysis;
 
 import lombok.Getter;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
@@ -25,6 +26,8 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.MethodCall;
 import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
 import java.time.Duration;
 import java.util.Set;
@@ -52,7 +55,9 @@ public class ReplaceStringConcatenationWithStringValueOf extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(
+                Preconditions.or(new JavaFileChecker<>(), new GroovyFileChecker<>()),
+                new JavaVisitor<ExecutionContext>() {
             @Override
             public <T extends J> J visitParentheses(J.Parentheses<T> parens, ExecutionContext ctx) {
                 J p = super.visitParentheses(parens, ctx);
@@ -80,6 +85,6 @@ public class ReplaceStringConcatenationWithStringValueOf extends Recipe {
                 }
                 return super.visitBinary(binary, ctx);
             }
-        };
+        });
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceStringConcatenationWithStringValueOfTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceStringConcatenationWithStringValueOfTest.java
@@ -21,7 +21,9 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings("StringConcatenationMissingWhitespace")
 class ReplaceStringConcatenationWithStringValueOfTest implements RewriteTest {
@@ -165,6 +167,45 @@ class ReplaceStringConcatenationWithStringValueOfTest implements RewriteTest {
               class Test {
                   void method() {
                       String s = String.valueOf(System.currentTimeMillis());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceInGroovy() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+            """
+              class Test {
+                  void method() {
+                      String s = "" + 1
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void method() {
+                      String s = String.valueOf(1)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeKotlin() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              class Test {
+                  fun method() {
+                      val s = "" + 1
                   }
               }
               """


### PR DESCRIPTION
## What's changed?

Add a precondition to `ReplaceStringConcatenationWithStringValueOf` to narrow down the execution to Java and Groovy.

## What's your motivation?

- This is a Java peculiarity which isn't relevant to other languages
- Moreover, my gut feeling is that any subsequent new language is unlikely to need this either, thus using allowlisting for Java and Groovy as its wingman