### PR TITLE
NoValueOfOnStringType: keep String.valueOf when the argument can be null

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NoValueOfOnStringType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoValueOfOnStringType.java
@@ -64,11 +64,38 @@ public class NoValueOfOnStringType extends Recipe {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 if (VALUE_OF.matches(mi) && mi.getArguments().size() == 1) {
                     Expression argument = mi.getArguments().get(0);
-                    if ((TypeUtils.isString(argument.getType()) && !(argument instanceof J.MethodInvocation)) || removeValueOfForStringConcatenation(argument)) {
+                    if ((TypeUtils.isString(argument.getType()) && isNeverNull(argument)) || removeValueOfForStringConcatenation(argument)) {
                         return maybeParenthesize(argument.withPrefix(mi.getPrefix()), updateCursor(mi));
                     }
                 }
                 return mi;
+            }
+
+            /**
+             * {@code String.valueOf(s)} only equals {@code s} when {@code s} is not null; for a null {@code String}
+             * it yields {@code "null"} instead. Removing the call is therefore only safe for arguments that cannot
+             * be null. Method invocations were already excluded for this reason; identifiers, field accesses and
+             * casts are no safer, so require the argument to be demonstrably non-null instead.
+             *
+             * @param argument The argument of the valueOf method.
+             * @return True if the argument can never be null.
+             */
+            private boolean isNeverNull(Expression argument) {
+                Expression e = argument;
+                while (e instanceof J.Parentheses) {
+                    J tree = ((J.Parentheses<?>) e).getTree();
+                    if (!(tree instanceof Expression)) {
+                        return false;
+                    }
+                    e = (Expression) tree;
+                }
+                if (e instanceof J.Literal) {
+                    return ((J.Literal) e).getValue() != null;
+                }
+                // String concatenation always produces a non-null String.
+                return e instanceof J.Binary &&
+                        ((J.Binary) e).getOperator() == J.Binary.Type.Addition &&
+                        TypeUtils.isString(e.getType());
             }
 
             /**
@@ -79,7 +106,9 @@ public class NoValueOfOnStringType extends Recipe {
              * @return True if the method can be removed.
              */
             private boolean removeValueOfForStringConcatenation(Expression argument) {
-                if (TypeUtils.asPrimitive(argument.getType()) != null) {
+                // A String argument is safe here too: concatenation renders a null operand as "null",
+                // exactly as String#valueOf would.
+                if (TypeUtils.asPrimitive(argument.getType()) != null || TypeUtils.isString(argument.getType())) {
                     J parent = getCursor().getParent() != null ? getCursor().getParent().firstEnclosing(J.class) : null;
                     if (parent instanceof J.Binary) {
                         J.Binary b = (J.Binary) parent;

--- a/src/main/java/org/openrewrite/staticanalysis/NoValueOfOnStringType.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoValueOfOnStringType.java
@@ -99,15 +99,15 @@ public class NoValueOfOnStringType extends Recipe {
             }
 
             /**
-             * If the String#valueOf method is within a binary expression and the argument is a primitive, the valueOf
-             * can be removed if the binary expression's type is a String.
+             * If the String#valueOf method is within a binary expression and the argument is a primitive or a String,
+             * the valueOf can be removed if the binary expression's type is a String. A String argument is safe here
+             * even when it is null, because concatenation renders a null operand as {@code "null"} exactly as
+             * String#valueOf would.
              *
              * @param argument The argument of the valueOf method.
              * @return True if the method can be removed.
              */
             private boolean removeValueOfForStringConcatenation(Expression argument) {
-                // A String argument is safe here too: concatenation renders a null operand as "null",
-                // exactly as String#valueOf would.
                 if (TypeUtils.asPrimitive(argument.getType()) != null || TypeUtils.isString(argument.getType())) {
                     J parent = getCursor().getParent() != null ? getCursor().getParent().firstEnclosing(J.class) : null;
                     if (parent instanceof J.Binary) {

--- a/src/test/java/org/openrewrite/staticanalysis/NoValueOfOnStringTypeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoValueOfOnStringTypeTest.java
@@ -295,6 +295,79 @@ class NoValueOfOnStringTypeTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1009")
+    @Test
+    void doNotRemoveValueOfOnNullInitializedConstant() {
+        // String.valueOf(null String) is "null"; passing the constant directly throws in replace(..).
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  private static final String INCIDENT_OPEN_TASK = null;
+
+                  String replaceDummyValues(String templateBody) {
+                      return templateBody.replace("$INCIDENT_OPEN_TASK", String.valueOf(INCIDENT_OPEN_TASK));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1009")
+    @Test
+    void doNotRemoveValueOfOnNullableStringVariables() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String field;
+
+                  String returned(String parameter) {
+                      return String.valueOf(parameter);
+                  }
+
+                  String assigned() {
+                      String local = String.valueOf(field);
+                      return local;
+                  }
+
+                  int argument(String parameter) {
+                      return "text".indexOf(String.valueOf(parameter));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1009")
+    @Test
+    void stillRemovesValueOfOnStringWithinConcatenation() {
+        // Concatenation renders a null operand as "null" already, so removal is safe here.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  String method(String parameter) {
+                      return "prefix" + String.valueOf(parameter);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  String method(String parameter) {
+                      return "prefix" + parameter;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void doNotRemoveValueOfForNullableStrings() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #1009

## The problem

`String.valueOf(s)` equals `s` only when `s` is not null — for a null `String` it produces `"null"`. The recipe removed the call for any `String`-typed argument that wasn't a method invocation, so a nullable variable lost its conversion:

```java
private static final String INCIDENT_OPEN_TASK = null;

templateBody.replace("$INCIDENT_OPEN_TASK", String.valueOf(INCIDENT_OPEN_TASK));
// became
templateBody.replace("$INCIDENT_OPEN_TASK", INCIDENT_OPEN_TASK);
```

Running both:

```
with valueOf : x=null
without      : THREW java.lang.NullPointerException
```

Method invocations were already excluded, and the reason is the same one that applies here — the value may be null. Identifiers, field accesses and casts are no safer. This also lines up the behavior with the recipe's own description, which says the simplification applies "when the argument to `String#valueOf(arg)` is a string literal".

## The change

For `String` arguments, require the expression to be demonstrably non-null — a non-null literal, or a string concatenation.

The one thing I wanted to avoid was over-correcting. Inside a concatenation the removal is safe even for nulls, because `+` already renders a null operand as `"null"`:

```
"p" + String.valueOf(f)   ->  pnull
"p" + f                   ->  pnull
```

My first attempt blocked that too, which would have lost a legitimate simplification. So `removeValueOfForStringConcatenation` now accepts `String` arguments alongside primitives, and that case keeps working.

## Tests

- Three added, tagged to #1009: the reported constant, nullable variables in return/assignment/argument positions, and a positive test that concatenation is still simplified. All 13 existing tests are unchanged and still pass.

Full suite locally on JDK 21: 2277 tests, 0 failures.