### PR TITLE
Go: don't convert octal literals when used for file permissions

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimal.java
+++ b/src/main/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimal.java
@@ -23,6 +23,7 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeTree;
@@ -69,13 +70,16 @@ public class WriteOctalValuesAsDecimal extends Recipe {
 
     private static boolean isGoFileMode(J.Literal literal, Cursor cursor) {
         Object parent = cursor.getParentTreeCursor().getValue();
+        // os.FileMode(0600) conversion, however the engine models it (call, cast, ...)
+        if (parent instanceof Expression && isGoFileModeType(((Expression) parent).getType())) {
+            return true;
+        }
         if (parent instanceof J.MethodInvocation) {
             J.MethodInvocation mi = (J.MethodInvocation) parent;
             int i = mi.getArguments().indexOf(literal);
             if (i < 0) {
                 return false;
             }
-            // os.FileMode(0600) conversion, which carries no attributed method type
             if ("FileMode".equals(mi.getSimpleName())) {
                 return true;
             }

--- a/src/main/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimal.java
+++ b/src/main/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimal.java
@@ -16,14 +16,20 @@
 package org.openrewrite.staticanalysis;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.staticanalysis.csharp.CSharpFileChecker;
 
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -51,12 +57,46 @@ public class WriteOctalValuesAsDecimal extends Recipe {
             @Override
             public J visitLiteral(J.Literal literal, ExecutionContext ctx) {
                 String src = literal.getValueSource();
-                if (src != null && literal.getValue() != null && OCTAL_LITERAL.matcher(src).matches()) {
+                if (src != null && literal.getValue() != null && OCTAL_LITERAL.matcher(src).matches() &&
+                        !isGoFileMode(literal, getCursor())) {
                     String suffix = src.endsWith("l") || src.endsWith("L") ? src.substring(src.length() - 1) : "";
                     return literal.withValueSource(literal.getValue() + suffix);
                 }
                 return super.visitLiteral(literal, ctx);
             }
         });
+    }
+
+    private static boolean isGoFileMode(J.Literal literal, Cursor cursor) {
+        Object parent = cursor.getParentTreeCursor().getValue();
+        if (parent instanceof J.MethodInvocation) {
+            J.MethodInvocation mi = (J.MethodInvocation) parent;
+            int i = mi.getArguments().indexOf(literal);
+            if (i < 0) {
+                return false;
+            }
+            // os.FileMode(0600) conversion, which carries no attributed method type
+            if ("FileMode".equals(mi.getSimpleName())) {
+                return true;
+            }
+            if (mi.getMethodType() != null) {
+                List<JavaType> params = mi.getMethodType().getParameterTypes();
+                if (!params.isEmpty()) {
+                    return isGoFileModeType(i < params.size() ? params.get(i) : params.get(params.size() - 1));
+                }
+            }
+        } else if (parent instanceof J.VariableDeclarations.NamedVariable) {
+            Object grandparent = cursor.getParentTreeCursor().getParentTreeCursor().getValue();
+            if (grandparent instanceof J.VariableDeclarations) {
+                TypeTree typeExpression = ((J.VariableDeclarations) grandparent).getTypeExpression();
+                return typeExpression != null && isGoFileModeType(typeExpression.getType());
+            }
+        }
+        return false;
+    }
+
+    private static boolean isGoFileModeType(@Nullable JavaType type) {
+        // os.FileMode is an alias resolved to io/fs.FileMode
+        return TypeUtils.isOfClassType(type, "io/fs.FileMode") || TypeUtils.isOfClassType(type, "os.FileMode");
     }
 }

--- a/src/test/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimalTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/WriteOctalValuesAsDecimalTest.java
@@ -20,6 +20,8 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.openrewrite.golang.Assertions.go;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.python.Assertions.python;
 
@@ -130,6 +132,59 @@ class WriteOctalValuesAsDecimalTest implements RewriteTest {
             """
               a = 0o755
               b = 0
+              """
+          )
+        );
+    }
+
+    @Test
+    void goConvertsPlainOctal() {
+        assumeTrue(GoEngineTestListener.isAvailable(), "rewrite-go-rpc engine unavailable");
+        rewriteRun(
+          go(
+            """
+              package main
+
+              func f(n int) {}
+
+              func test() {
+                  f(010)
+              }
+              """,
+            """
+              package main
+
+              func f(n int) {}
+
+              func test() {
+                  f(8)
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void goDoNotChangeFilePermissions() {
+        assumeTrue(GoEngineTestListener.isAvailable(), "rewrite-go-rpc engine unavailable");
+        rewriteRun(
+          go(
+            """
+              package main
+
+              import "os"
+
+              func mode(perm os.FileMode) {}
+
+              func test() {
+                  os.OpenFile("f", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+                  os.WriteFile("f", nil, 0640)
+                  os.Mkdir("d", 0755)
+                  mode(0755)
+                  var m os.FileMode = 0644
+                  m = os.FileMode(0600)
+                  _ = m
+              }
               """
           )
         );


### PR DESCRIPTION
## What's changed?

Making a special case for `WriteOctalValuesAsDecimal` not to alter these octal literals in Go which pertain to Unix file permissions.

## What's your motivation?

Prevent this kind of changes, which don't impact correctness, but surely impact readability/maintainability:
```diff
- os.OpenFile("f", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+ os.OpenFile("f", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 384)
```