### PR TITLE
RemoveRedundantTypeCast: keep casts on signature-polymorphic methods

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -67,6 +67,13 @@ public class RemoveRedundantTypeCast extends Recipe {
                     return visited;
                 }
 
+                // A signature-polymorphic method (JLS 15.12.3) has no fixed return type at the call
+                // site; the enclosing cast is what gives it one, so removing the cast reverts the
+                // call to `Object` and breaks compilation.
+                if (isSignaturePolymorphic(typeCast.getExpression())) {
+                    return visited;
+                }
+
                 Cursor parent = getCursor().dropParentUntil(is -> is instanceof J.VariableDeclarations ||
                                                                   is instanceof J.Lambda ||
                                                                   is instanceof J.Return ||
@@ -228,6 +235,20 @@ public class RemoveRedundantTypeCast extends Recipe {
                     return parentheses.getTree().withPrefix(parentheses.getPrefix());
                 }
                 return parentheses;
+            }
+
+            private boolean isSignaturePolymorphic(Expression expression) {
+                Expression expr = expression;
+                while (expr instanceof J.Parentheses) {
+                    expr = (Expression) ((J.Parentheses<?>) expr).getTree();
+                }
+                if (!(expr instanceof J.MethodInvocation)) {
+                    return false;
+                }
+                JavaType.Method methodType = ((J.MethodInvocation) expr).getMethodType();
+                return methodType != null &&
+                        (TypeUtils.isOfClassType(methodType.getDeclaringType(), "java.lang.invoke.MethodHandle") ||
+                                TypeUtils.isOfClassType(methodType.getDeclaringType(), "java.lang.invoke.VarHandle"));
             }
 
             private boolean returnsDeclaredTypeParameter(Expression expression) {

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -67,9 +67,6 @@ public class RemoveRedundantTypeCast extends Recipe {
                     return visited;
                 }
 
-                // A signature-polymorphic method (JLS 15.12.3) has no fixed return type at the call
-                // site; the enclosing cast is what gives it one, so removing the cast reverts the
-                // call to `Object` and breaks compilation.
                 if (isSignaturePolymorphic(typeCast.getExpression())) {
                     return visited;
                 }
@@ -237,11 +234,9 @@ public class RemoveRedundantTypeCast extends Recipe {
                 return parentheses;
             }
 
+            /// Signature-polymorphic methods (JLS 15.12.3) take their return type from the enclosing cast, so removing it breaks compilation.
             private boolean isSignaturePolymorphic(Expression expression) {
-                Expression expr = expression;
-                while (expr instanceof J.Parentheses) {
-                    expr = (Expression) ((J.Parentheses<?>) expr).getTree();
-                }
+                Expression expr = expression.unwrap();
                 if (!(expr instanceof J.MethodInvocation)) {
                     return false;
                 }

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -930,4 +930,46 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1024")
+    @Test
+    void doNotRemoveCastOnMethodHandleInvoke() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.lang.invoke.MethodHandle;
+
+              class Example {
+                  String hello(MethodHandle handle) throws Throwable {
+                      return (String) handle.invoke();
+                  }
+
+                  void assign(MethodHandle handle) throws Throwable {
+                      String s = (String) handle.invokeExact();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/1024")
+    @Test
+    void doNotRemoveCastOnVarHandleAccessor() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.lang.invoke.VarHandle;
+
+              class Example {
+                  String read(VarHandle handle, Object target) {
+                      return (String) handle.get(target);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Fixes #1024

`MethodHandle#invoke` / `invokeExact` and the `VarHandle` accessors are signature-polymorphic (JLS 15.12.3): the call site has no fixed signature, and the enclosing cast is what supplies the return type. The recipe compared the attributed expression type against the cast type, but that attributed type only exists *because* of the cast, so the check always succeeded and the cast was always removed — leaving code that no longer compiles:

```
error: incompatible types: Object cannot be converted to String
        return handle.invoke();
```

Now a cast whose expression is a method invocation declared on `java.lang.invoke.MethodHandle` or `java.lang.invoke.VarHandle` is preserved.