### PR TITLE
Inline precondition-wrapped nested visitor classes

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
+++ b/src/main/java/org/openrewrite/staticanalysis/EqualsToContentEquals.java
@@ -30,6 +30,9 @@ import org.openrewrite.java.tree.TypeUtils;
 import static java.util.Collections.singletonList;
 
 public class EqualsToContentEquals extends Recipe {
+    private static final MethodMatcher EQUALS_MATCHER = new MethodMatcher("String equals(Object)");
+    private static final MethodMatcher TOSTRING_MATCHER = new MethodMatcher("java.lang.* toString()");
+
     private static final TreeVisitor<?, ExecutionContext> PRECONDITION = Preconditions.or(
             new UsesType<>("java.lang.CharSequence", false),
             new UsesType<>("java.lang.StringBuffer", false),
@@ -44,31 +47,26 @@ public class EqualsToContentEquals extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(PRECONDITION, new EqualsToContentEqualsVisitor());
-    }
-
-    private static class EqualsToContentEqualsVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private static final MethodMatcher EQUALS_MATCHER = new MethodMatcher("String equals(Object)");
-        private static final MethodMatcher TOSTRING_MATCHER = new MethodMatcher("java.lang.* toString()");
-
-        @Override
-        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
-            J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
-            if (!EQUALS_MATCHER.matches(m)) {
-                return m;
+        return Preconditions.check(PRECONDITION, new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
+                if (!EQUALS_MATCHER.matches(m)) {
+                    return m;
+                }
+                Expression equalsArgument = m.getArguments().get(0);
+                if (!TOSTRING_MATCHER.matches(equalsArgument)) {
+                    return m;
+                }
+                J.MethodInvocation inv = (J.MethodInvocation) equalsArgument;
+                Expression toStringSelect = inv.getSelect();
+                if (toStringSelect == null || !TypeUtils.isAssignableTo("java.lang.CharSequence", toStringSelect.getType())) {
+                    return m;
+                }
+                // Strip out the toString() on the argument and replace with contentEquals
+                return m.withArguments(singletonList(toStringSelect))
+                        .withName(m.getName().withSimpleName("contentEquals"));
             }
-            Expression equalsArgument = m.getArguments().get(0);
-            if (!TOSTRING_MATCHER.matches(equalsArgument)) {
-                return m;
-            }
-            J.MethodInvocation inv = (J.MethodInvocation) equalsArgument;
-            Expression toStringSelect = inv.getSelect();
-            if (toStringSelect == null || !TypeUtils.isAssignableTo("java.lang.CharSequence", toStringSelect.getType())) {
-                return m;
-            }
-            // Strip out the toString() on the argument and replace with contentEquals
-            return m.withArguments(singletonList(toStringSelect))
-                    .withName(m.getName().withSimpleName("contentEquals"));
-        }
+        });
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/NoPrimitiveWrappersForToStringOrCompareTo.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoPrimitiveWrappersForToStringOrCompareTo.java
@@ -36,6 +36,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 
 public class NoPrimitiveWrappersForToStringOrCompareTo extends Recipe {
+    private static final MethodMatcher VALUE_OF_NUMBER_MATCHER = new MethodMatcher("java.lang.Number valueOf(*)", true);
+    private static final MethodMatcher VALUE_OF_BOOLEAN_MATCHER = new MethodMatcher("java.lang.Boolean valueOf(*)", true);
+
     private static final MethodMatcher NUMBER_TO_STRING_MATCHER = new MethodMatcher("java.lang.Number toString()", true);
     private static final MethodMatcher BOOLEAN_TO_STRING_MATCHER = new MethodMatcher("java.lang.Boolean toString()", true);
 
@@ -63,63 +66,57 @@ public class NoPrimitiveWrappersForToStringOrCompareTo extends Recipe {
                         new UsesMethod<>(BOOLEAN_COMPARE_TO_MATCHER),
                         new UsesMethod<>(BOOLEAN_TO_STRING_MATCHER)
                 ),
-                new NoPrimitiveWrapperVisitor()
-        );
-    }
-
-    private static class NoPrimitiveWrapperVisitor extends JavaIsoVisitor<ExecutionContext> {
-
-        private static final MethodMatcher VALUE_OF_NUMBER_MATCHER = new MethodMatcher("java.lang.Number valueOf(*)", true);
-        private static final MethodMatcher VALUE_OF_BOOLEAN_MATCHER = new MethodMatcher("java.lang.Boolean valueOf(*)", true);
-
-        @Override
-        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-            J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
-            JavaType.Class clazz = mi.getMethodType() != null ? TypeUtils.asClass(mi.getMethodType().getDeclaringType()) : null;
-            if (clazz != null && "java.lang".equals(clazz.getPackageName())) {
-                if (NUMBER_TO_STRING_MATCHER.matches(mi) || BOOLEAN_TO_STRING_MATCHER.matches(mi)) {
-                    Expression arg = null;
-                    if (mi.getSelect() instanceof J.NewClass) {
-                        arg = getSingleArg(((J.NewClass) mi.getSelect()).getArguments());
-                    } else if (mi.getSelect() instanceof J.MethodInvocation) {
-                        J.MethodInvocation selectMethod = (J.MethodInvocation) mi.getSelect();
-                        if (VALUE_OF_NUMBER_MATCHER.matches(selectMethod) || VALUE_OF_BOOLEAN_MATCHER.matches(selectMethod)) {
-                            arg = getSingleArg(selectMethod.getArguments());
+                new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                JavaType.Class clazz = mi.getMethodType() != null ? TypeUtils.asClass(mi.getMethodType().getDeclaringType()) : null;
+                if (clazz != null && "java.lang".equals(clazz.getPackageName())) {
+                    if (NUMBER_TO_STRING_MATCHER.matches(mi) || BOOLEAN_TO_STRING_MATCHER.matches(mi)) {
+                        Expression arg = null;
+                        if (mi.getSelect() instanceof J.NewClass) {
+                            arg = getSingleArg(((J.NewClass) mi.getSelect()).getArguments());
+                        } else if (mi.getSelect() instanceof J.MethodInvocation) {
+                            J.MethodInvocation selectMethod = (J.MethodInvocation) mi.getSelect();
+                            if (VALUE_OF_NUMBER_MATCHER.matches(selectMethod) || VALUE_OF_BOOLEAN_MATCHER.matches(selectMethod)) {
+                                arg = getSingleArg(selectMethod.getArguments());
+                            }
                         }
-                    }
-                    if (arg != null && !TypeUtils.isString(arg.getType()) && mi.getSelect() != null) {
-                        JavaType.FullyQualified fq = mi.getMethodType().getDeclaringType();
-                        mi = mi.withSelect(new J.Identifier(Tree.randomId(), mi.getSelect().getPrefix(), Markers.EMPTY, emptyList(), fq.getClassName(), fq, null));
-                        //noinspection ArraysAsListWithZeroOrOneArgument
-                        mi = mi.withArguments(Arrays.asList(arg));
-                    }
-                } else if (NUMBER_COMPARE_TO_MATCHER.matches(mi) || BOOLEAN_COMPARE_TO_MATCHER.matches(mi)) {
-                    Expression arg = null;
-                    if (mi.getSelect() instanceof J.NewClass) {
-                        arg = getSingleArg(((J.NewClass) mi.getSelect()).getArguments());
-                    } else if (mi.getSelect() instanceof J.MethodInvocation) {
-                        J.MethodInvocation selectMethod = (J.MethodInvocation) mi.getSelect();
-                        if (VALUE_OF_NUMBER_MATCHER.matches(selectMethod) || VALUE_OF_BOOLEAN_MATCHER.matches(selectMethod)) {
-                            arg = getSingleArg(selectMethod.getArguments());
+                        if (arg != null && !TypeUtils.isString(arg.getType()) && mi.getSelect() != null) {
+                            JavaType.FullyQualified fq = mi.getMethodType().getDeclaringType();
+                            mi = mi.withSelect(new J.Identifier(Tree.randomId(), mi.getSelect().getPrefix(), Markers.EMPTY, emptyList(), fq.getClassName(), fq, null));
+                            //noinspection ArraysAsListWithZeroOrOneArgument
+                            mi = mi.withArguments(Arrays.asList(arg));
                         }
-                    }
+                    } else if (NUMBER_COMPARE_TO_MATCHER.matches(mi) || BOOLEAN_COMPARE_TO_MATCHER.matches(mi)) {
+                        Expression arg = null;
+                        if (mi.getSelect() instanceof J.NewClass) {
+                            arg = getSingleArg(((J.NewClass) mi.getSelect()).getArguments());
+                        } else if (mi.getSelect() instanceof J.MethodInvocation) {
+                            J.MethodInvocation selectMethod = (J.MethodInvocation) mi.getSelect();
+                            if (VALUE_OF_NUMBER_MATCHER.matches(selectMethod) || VALUE_OF_BOOLEAN_MATCHER.matches(selectMethod)) {
+                                arg = getSingleArg(selectMethod.getArguments());
+                            }
+                        }
 
-                    if (arg != null && !TypeUtils.isString(arg.getType()) && mi.getSelect() != null) {
-                        JavaType.FullyQualified fq = mi.getMethodType().getDeclaringType();
-                        mi = mi.withSelect(new J.Identifier(Tree.randomId(), mi.getSelect().getPrefix(), Markers.EMPTY, emptyList(), fq.getClassName(), fq, null));
-                        mi = mi.withArguments(ListUtils.concat(arg, mi.getArguments()));
-                        mi = maybeAutoFormat(mi, mi.withName(mi.getName().withSimpleName("compare")), ctx);
+                        if (arg != null && !TypeUtils.isString(arg.getType()) && mi.getSelect() != null) {
+                            JavaType.FullyQualified fq = mi.getMethodType().getDeclaringType();
+                            mi = mi.withSelect(new J.Identifier(Tree.randomId(), mi.getSelect().getPrefix(), Markers.EMPTY, emptyList(), fq.getClassName(), fq, null));
+                            mi = mi.withArguments(ListUtils.concat(arg, mi.getArguments()));
+                            mi = maybeAutoFormat(mi, mi.withName(mi.getName().withSimpleName("compare")), ctx);
+                        }
                     }
                 }
+                return mi;
             }
-            return mi;
-        }
 
-        private @Nullable Expression getSingleArg(@Nullable List<Expression> args) {
-            if (args != null && args.size() == 1 && !(args.get(0) instanceof J.Empty)) {
-                return args.get(0);
+            private @Nullable Expression getSingleArg(@Nullable List<Expression> args) {
+                if (args != null && args.size() == 1 && !(args.get(0) instanceof J.Empty)) {
+                    return args.get(0);
+                }
+                return null;
             }
-            return null;
         }
+        );
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveHashCodeCallsFromArrayInstances.java
@@ -49,26 +49,24 @@ public class RemoveHashCodeCallsFromArrayInstances extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesMethod<>(HASHCODE_MATCHER), new RemoveHashCodeCallsFromArrayInstancesVisitor());
-    }
+        return Preconditions.check(new UsesMethod<>(HASHCODE_MATCHER), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(methodInvocation, ctx);
 
-    private static class RemoveHashCodeCallsFromArrayInstancesVisitor extends JavaIsoVisitor<ExecutionContext> {
-        @Override
-        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
-            J.MethodInvocation mi = super.visitMethodInvocation(methodInvocation, ctx);
-
-            if (HASHCODE_MATCHER.matches(mi)) {
-                Expression select = mi.getSelect();
-                if (select != null && select.getType() instanceof JavaType.Array) {
-                    maybeAddImport("java.util.Arrays");
-                    return JavaTemplate.builder("Arrays.hashCode(#{anyArray(java.lang.Object)})")
-                            .imports("java.util.Arrays")
-                            .build()
-                            .apply(getCursor(), mi.getCoordinates().replace(), select);
+                if (HASHCODE_MATCHER.matches(mi)) {
+                    Expression select = mi.getSelect();
+                    if (select != null && select.getType() instanceof JavaType.Array) {
+                        maybeAddImport("java.util.Arrays");
+                        return JavaTemplate.builder("Arrays.hashCode(#{anyArray(java.lang.Object)})")
+                                .imports("java.util.Arrays")
+                                .build()
+                                .apply(getCursor(), mi.getCoordinates().replace(), select);
+                    }
                 }
-            }
 
-            return mi;
-        }
+                return mi;
+            }
+        });
     }
 }

--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceTextBlockWithString.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceTextBlockWithString.java
@@ -50,58 +50,56 @@ public class ReplaceTextBlockWithString extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesJavaVersion<>(13), new ReplaceTextBlockWithStringVisitor());
-    }
+        return Preconditions.check(new UsesJavaVersion<>(13), new JavaVisitor<ExecutionContext>() {
 
-    private static class ReplaceTextBlockWithStringVisitor extends JavaVisitor<ExecutionContext> {
-
-        @Override
-        public @Nullable J visitLiteral(J.Literal literal, ExecutionContext ctx) {
-            if (literal.getType() == Primitive.String &&
-                literal.getValue() != null &&
-                literal.getValueSource() != null &&
-                literal.getValueSource().startsWith("\"\"\"")) {
-                // Split the literal into lines, including trailing empty lines
-                String[] lines = ((String) literal.getValue()).split("\n", -1);
-                // Add trailing "\n" to each line but the last one
-                // If there is only one line and it's empty, then add "\n" to it as well
-                boolean lastLineIsEmpty = lines[lines.length - 1].isEmpty();
-                int n = lastLineIsEmpty && lines.length == 1 ? 1 : lines.length - 1;
-                for (int i = 0; i < n; i++) {
-                    lines[i] += "\\n";
+            @Override
+            public @Nullable J visitLiteral(J.Literal literal, ExecutionContext ctx) {
+                if (literal.getType() == Primitive.String &&
+                    literal.getValue() != null &&
+                    literal.getValueSource() != null &&
+                    literal.getValueSource().startsWith("\"\"\"")) {
+                    // Split the literal into lines, including trailing empty lines
+                    String[] lines = ((String) literal.getValue()).split("\n", -1);
+                    // Add trailing "\n" to each line but the last one
+                    // If there is only one line and it's empty, then add "\n" to it as well
+                    boolean lastLineIsEmpty = lines[lines.length - 1].isEmpty();
+                    int n = lastLineIsEmpty && lines.length == 1 ? 1 : lines.length - 1;
+                    for (int i = 0; i < n; i++) {
+                        lines[i] += "\\n";
+                    }
+                    // Take all lines except the last one if it's empty
+                    // If there is only one line and it's empty, take it as well
+                    int linesNumber = !lastLineIsEmpty || lines.length == 1 ? lines.length : lines.length - 1;
+                    Expression[] literals = new Expression[linesNumber];
+                    // Add a prefix (possibly containing a comment) of the original literal
+                    literals[0] = toLiteral(lines[0]).withPrefix(literal.getPrefix());
+                    // Add newlines before rest string literals
+                    for (int i = 1; i < linesNumber; i++) {
+                        literals[i] = toLiteral(lines[i]).withPrefix(Space.build("\n", emptyList()));
+                    }
+                    // Format the resulting expression
+                    Expression j = ChainStringBuilderAppendCalls.additiveExpression(literals);
+                    //noinspection DataFlowIssue
+                    return j == null ? null : autoFormat(j, ctx);
                 }
-                // Take all lines except the last one if it's empty
-                // If there is only one line and it's empty, take it as well
-                int linesNumber = !lastLineIsEmpty || lines.length == 1 ? lines.length : lines.length - 1;
-                Expression[] literals = new Expression[linesNumber];
-                // Add a prefix (possibly containing a comment) of the original literal
-                literals[0] = toLiteral(lines[0]).withPrefix(literal.getPrefix());
-                // Add newlines before rest string literals
-                for (int i = 1; i < linesNumber; i++) {
-                    literals[i] = toLiteral(lines[i]).withPrefix(Space.build("\n", emptyList()));
-                }
-                // Format the resulting expression
-                Expression j = ChainStringBuilderAppendCalls.additiveExpression(literals);
-                //noinspection DataFlowIssue
-                return j == null ? null : autoFormat(j, ctx);
+                return literal;
             }
-            return literal;
-        }
 
-        private J.Literal toLiteral(String str) {
-            return new J.Literal(
-                    Tree.randomId(),
-                    Space.EMPTY,
-                    Markers.EMPTY,
-                    str,
-                    quote(str),
-                    emptyList(),
-                    Primitive.String);
-        }
+            private J.Literal toLiteral(String str) {
+                return new J.Literal(
+                        Tree.randomId(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        str,
+                        quote(str),
+                        emptyList(),
+                        Primitive.String);
+            }
 
-        private String quote(String str) {
-            return "\"" + str.replace("\"", "\\\"") + "\"";
-        }
+            private String quote(String str) {
+                return "\"" + str.replace("\"", "\\\"") + "\"";
+            }
+        });
     }
 
 }

--- a/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCloseInTryWithResources.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UnnecessaryCloseInTryWithResources.java
@@ -34,6 +34,8 @@ import java.util.Set;
 import static java.util.Collections.singleton;
 
 public class UnnecessaryCloseInTryWithResources extends Recipe {
+    private static final MethodMatcher AUTO_CLOSEABLE_METHOD_MATCHER = new MethodMatcher("java.lang.AutoCloseable close()", true);
+
     @Getter
     final String displayName = "Unnecessary close in try-with-resources";
 
@@ -57,45 +59,41 @@ public class UnnecessaryCloseInTryWithResources extends Recipe {
                         new KotlinFileChecker<>(),
                         new GroovyFileChecker<>()
                 ),
-                new UnnecessaryAutoCloseableVisitor()
-        );
-    }
-
-    private static class UnnecessaryAutoCloseableVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private static final MethodMatcher AUTO_CLOSEABLE_METHOD_MATCHER = new MethodMatcher("java.lang.AutoCloseable close()", true);
-
-        @Override
-        public J.Try visitTry(J.Try aTry, ExecutionContext ctx) {
-            J.Try tr = super.visitTry(aTry, ctx);
-            if (tr.getResources() != null) {
-                String[] resourceNames = new String[tr.getResources().size()];
-                for (int i = 0; i < tr.getResources().size(); i++) {
-                    J.Try.Resource tryResource = tr.getResources().get(i);
-                    if (tryResource.getVariableDeclarations() instanceof J.VariableDeclarations) {
-                        J.VariableDeclarations varDecls = (J.VariableDeclarations) tryResource.getVariableDeclarations();
-                        resourceNames[i] = varDecls.getVariables().get(0).getSimpleName();
-                    } else if (tryResource.getVariableDeclarations() instanceof J.Identifier) {
-                        J.Identifier identifier = (J.Identifier) tryResource.getVariableDeclarations();
-                        resourceNames[i] = identifier.getSimpleName();
+                new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Try visitTry(J.Try aTry, ExecutionContext ctx) {
+                J.Try tr = super.visitTry(aTry, ctx);
+                if (tr.getResources() != null) {
+                    String[] resourceNames = new String[tr.getResources().size()];
+                    for (int i = 0; i < tr.getResources().size(); i++) {
+                        J.Try.Resource tryResource = tr.getResources().get(i);
+                        if (tryResource.getVariableDeclarations() instanceof J.VariableDeclarations) {
+                            J.VariableDeclarations varDecls = (J.VariableDeclarations) tryResource.getVariableDeclarations();
+                            resourceNames[i] = varDecls.getVariables().get(0).getSimpleName();
+                        } else if (tryResource.getVariableDeclarations() instanceof J.Identifier) {
+                            J.Identifier identifier = (J.Identifier) tryResource.getVariableDeclarations();
+                            resourceNames[i] = identifier.getSimpleName();
+                        }
                     }
-                }
 
-                tr = tr.withBody(tr.getBody().withStatements(ListUtils.map(tr.getBody().getStatements(), statement -> {
-                    if (statement instanceof J.MethodInvocation) {
-                        J.MethodInvocation mi = (J.MethodInvocation) statement;
-                        if (AUTO_CLOSEABLE_METHOD_MATCHER.matches(mi) && mi.getSelect() instanceof J.Identifier) {
-                            String selectName = ((J.Identifier) mi.getSelect()).getSimpleName();
-                            for (String resourceName : resourceNames) {
-                                if (resourceName.equals(selectName)) {
-                                    return null;
+                    tr = tr.withBody(tr.getBody().withStatements(ListUtils.map(tr.getBody().getStatements(), statement -> {
+                        if (statement instanceof J.MethodInvocation) {
+                            J.MethodInvocation mi = (J.MethodInvocation) statement;
+                            if (AUTO_CLOSEABLE_METHOD_MATCHER.matches(mi) && mi.getSelect() instanceof J.Identifier) {
+                                String selectName = ((J.Identifier) mi.getSelect()).getSimpleName();
+                                for (String resourceName : resourceNames) {
+                                    if (resourceName.equals(selectName)) {
+                                        return null;
+                                    }
                                 }
                             }
                         }
-                    }
-                    return statement;
-                })));
+                        return statement;
+                    })));
+                }
+                return tr;
             }
-            return tr;
         }
+        );
     }
 }


### PR DESCRIPTION
- Follow-up to #1026 and #1027, which inlined the nested visitors returned directly from `getVisitor()`. This does the same for five visitors that are wrapped in `Preconditions.check(..)`, declaring them anonymously in place and hoisting their `private static final` constants onto the recipe class.

- The [`InlineNestedVisitorClass`](https://github.com/openrewrite/rewrite-rewrite/pull/91) recipe deliberately does not handle the precondition-wrapped shape yet — inlining a large visitor under `Preconditions.check(..)` can hurt readability — so this phases the pattern out here with a small scope (all five visitors are under 55 lines) while leaving it in place elsewhere for now. `RemoveInstanceOfPatternMatch` is intentionally untouched: its visitor is 174 lines and carries Javadoc that inlining would drop.

Beyond the class declarations and the hoisted constants the diff is a pure re-indent; `./gradlew build` passes.