### PR TITLE
Drop rewrite-analysis from ReplaceCollectionToArrayArgWithEmptyArray

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArray.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceCollectionToArrayArgWithEmptyArray.java
@@ -17,12 +17,13 @@ package org.openrewrite.staticanalysis;
 
 import lombok.Getter;
 import org.openrewrite.*;
-import org.openrewrite.analysis.InvocationMatcher;
-import org.openrewrite.analysis.search.UsesInvocation;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.MethodCall;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
 
@@ -50,20 +51,23 @@ public class ReplaceCollectionToArrayArgWithEmptyArray extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                new UsesInvocation<>(ReplaceCollectionToArrayArgWithEmptyArrayVisitor.COLLECTION_TO_ARRAY),
+                new UsesMethod<>(ReplaceCollectionToArrayArgWithEmptyArrayVisitor.COLLECTION_TO_ARRAY),
                 new ReplaceCollectionToArrayArgWithEmptyArrayVisitor<>()
         );
     }
 
     private static class ReplaceCollectionToArrayArgWithEmptyArrayVisitor<P> extends JavaIsoVisitor<P> {
-        private static final InvocationMatcher COLLECTION_TO_ARRAY =
-                InvocationMatcher.fromMethodMatcher("java.util.Collection toArray(..)");
+        private static final MethodMatcher COLLECTION_TO_ARRAY =
+                new MethodMatcher("java.util.Collection toArray(..)");
 
         @Override
         public J.NewArray visitNewArray(J.NewArray newArray, P p) {
             boolean isInitializerEmpty = newArray.getInitializer() == null ||
                     (newArray.getInitializer().size() == 1 && newArray.getInitializer().get(0) instanceof J.Empty);
-            if (COLLECTION_TO_ARRAY.advanced().isFirstArgument(getCursor()) && isInitializerEmpty) {
+            Tree parent = getCursor().getParentTreeCursor().getValue();
+            MethodCall call = parent instanceof MethodCall ? (MethodCall) parent : null;
+            if (isInitializerEmpty && call != null && !call.getArguments().isEmpty() &&
+                    call.getArguments().get(0) == newArray && COLLECTION_TO_ARRAY.matches(call)) {
                 J.NewArray newArrayZero = newArray.withDimensions(ListUtils.mapFirst(newArray.getDimensions(), d -> {
                     if (d.getIndex() instanceof J.Literal && Integer.valueOf(0).equals(((J.Literal) d.getIndex()).getValue())) {
                         return d;


### PR DESCRIPTION
This recipe was the only user of `rewrite-analysis` that did not need its dataflow engine, so it can rely on `rewrite-java` alone.

`UsesInvocation` is swapped for `UsesMethod` — its own Javadoc calls it "equivalent to `UsesMethod` but for any `InvocationMatcher`", and its `@implNote` says it only exists because `MethodMatcher` has no base interface; since the matcher here is a plain `MethodMatcher`, `UsesMethod` applies directly and is faster, using the indexed `TypesInUse.hasMethodUse(..)` instead of iterating `getUsedMethods()`. `InvocationMatcher.advanced().isFirstArgument(..)` is inlined to the cursor walk it expands to (parent tree cursor is a `MethodCall`, first argument is identity-equal to the array), matched with `MethodMatcher.matches(MethodCall)`, which delegates to `matches(getMethodType())` exactly as the `InvocationMatcher` default did.

No behavior change, and the existing `ReplaceCollectionToArrayArgWithEmptyArrayTest` (4 tests) passes unchanged. The `rewrite-analysis` dependency stays in `build.gradle.kts` for `ReplaceStackWithDeque`, `ReplaceLegacyCollection`, and `FindNewExceptionWithoutCause`, which do use its dataflow and taint analysis.