### PR TITLE
Only run data flow analysis on `Stack` variables in `ReplaceStackWithDeque`

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ReplaceStackWithDeque.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ReplaceStackWithDeque.java
@@ -55,6 +55,16 @@ public class ReplaceStackWithDeque extends Recipe {
             @Override
             public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext ctx) {
                 J.VariableDeclarations.NamedVariable v = super.visitVariable(variable, ctx);
+                if (v.getInitializer() == null) {
+                    return v;
+                }
+
+                Expression initializer = (Expression) new ChangeType("java.util.Stack", "java.util.ArrayDeque", false)
+                        .getVisitor().visitNonNull(v.getInitializer(), ctx, getCursor().getParentOrThrow());
+                if (initializer == v.getInitializer()) {
+                    // Not a `Stack`, so skip the data flow analysis below, which is costly on every variable in the file
+                    return v;
+                }
 
                 DataFlowSpec returned = new DataFlowSpec() {
                     @Override
@@ -68,9 +78,8 @@ public class ReplaceStackWithDeque extends Recipe {
                     }
                 };
 
-                if (v.getInitializer() != null && FindLocalFlowPaths.noneMatch(getCursor(), returned)) {
-                    v = v.withInitializer((Expression) new ChangeType("java.util.Stack", "java.util.ArrayDeque", false)
-                            .getVisitor().visitNonNull(v.getInitializer(), ctx, getCursor().getParentOrThrow()));
+                if (FindLocalFlowPaths.noneMatch(getCursor(), returned)) {
+                    v = v.withInitializer(initializer);
                     getCursor().putMessageOnFirstEnclosing(J.VariableDeclarations.class, "replace", true);
                 }
 

--- a/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ReplaceStackWithDequeTest.java
@@ -209,4 +209,45 @@ class ReplaceStackWithDequeTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-analysis/issues/113")
+    @Test
+    void doNotFailOnDataFlowThroughNestedMethodInvocations() {
+        // Regression: dataflow was run for every initialized variable in the file, not just the `Stack`.
+        // On `Optional.ofNullable(a).orElse(opt.get())` the flow engine ping-ponged between the
+        // "argument to select" and "select to argument" steps until the stack overflowed.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.Optional;
+              import java.util.Stack;
+
+              class Test {
+                  String test(Optional<String> opt) {
+                      Stack<Integer> stack = new Stack<>();
+                      stack.push(1);
+                      String a = "x";
+                      return Optional.ofNullable(a).orElse(opt.get());
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayDeque;
+              import java.util.Deque;
+              import java.util.Optional;
+              import java.util.Stack;
+
+              class Test {
+                  String test(Optional<String> opt) {
+                      Deque<Integer> stack = new ArrayDeque<>();
+                      stack.push(1);
+                      String a = "x";
+                      return Optional.ofNullable(a).orElse(opt.get());
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed

`ReplaceStackWithDeque.visitVariable` ran `FindLocalFlowPaths` for **every** initialized variable in any file that mentions `java.util.Stack`, and only then applied `ChangeType` to the initializer — a no-op for variables that aren't a `Stack`. Swapping the order (apply `ChangeType` first, bail out when it leaves the initializer untouched) is equivalent and confines the analysis to the variables the recipe can actually rewrite.

## Why

This is how the crash surfaced. `org.openrewrite.staticanalysis.ReplaceStackWithDeque` has been failing with `java.lang.StackOverflowError` on `spring-projects/spring-data-mongodb`, file `spring-data-mongodb/src/main/java/org/springframework/data/mongodb/core/convert/MongoExampleMapper.java`, recurring since at least 2026-08-17 in the "Java best practices" and "Common static analysis issues" flagship runs on `dev` (`ALL`, `Open Source`, `Netflix + Spring + Apache`, `Netflix + Spring`). Confirmed in run `20260825041417-SSuzc`; absent on 2026-08-26, so it is input/attribution dependent and a clean run isn't evidence of a fix.

The `SourcesFileErrors` data table for that run gives ~1000 frames alternating between exactly two call sites:

```
java.lang.StackOverflowError
  org.openrewrite.Cursor.getParentTreeCursor(Cursor.java:253)
  org.openrewrite.analysis.trait.expr.VarAccessBase.viewOf(VarAccess.java:221)
  ...
  org.openrewrite.analysis.dataflow.DataFlowNode.of(DataFlowNode.java:63)
  org.openrewrite.analysis.dataflow.analysis.ForwardFlow.computeVariableAssignment(ForwardFlow.java:458)
  org.openrewrite.analysis.dataflow.analysis.ForwardFlow.computeVariableAssignment(ForwardFlow.java:495)
  org.openrewrite.analysis.dataflow.analysis.ForwardFlow.computeVariableAssignment(ForwardFlow.java:466)
  org.openrewrite.analysis.dataflow.analysis.ForwardFlow.computeVariableAssignment(ForwardFlow.java:495)
  org.openrewrite.analysis.dataflow.analysis.ForwardFlow.computeVariableAssignment(ForwardFlow.java:466)
  ...
```

- `ForwardFlow.computeVariableAssignment` recurses from an argument into the call's select (`:466`) and from the select back into an argument (`:495`) with no visited set, so when `isFlowStep(..)` holds in both directions it never terminates. Root cause filed as openrewrite/rewrite-analysis#113 with the analysis of which model groups produce the two directions.

The added test reproduces the production stack trace exactly (502 frames at `:466`, 501 at `:495`) on `main`, and passes here. The `Stack` in it only satisfies the recipe's `UsesType` precondition — the overflow comes from the unrelated `String a`, which is also what happens in `MongoExampleMapper`.

## Scope

- This narrows the blast radius; it is not the engine fix. A `Stack` whose flow reaches such an expression can still overflow, and any other recipe using `FindLocalFlowPaths` remains exposed until openrewrite/rewrite-analysis#113 is fixed. A caller can't work around it themselves — `DataFlowSpec.isFlowStep` is `final`, so a spec cannot suppress the external models that create the cycle.

- openrewrite/rewrite-static-analysis#87 names this recipe but is a different defect (`ControlFlowIllegalStateException` out of `ControlFlow.createFakeIteratorVariableDeclarations`, not `ForwardFlow`), so it is not the tracking issue for this and is not closed by this PR.
