### PR TITLE
Don't rewrite MinimumSwitchCases when the selector's type is unresolved

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -236,6 +236,8 @@ public class MinimumSwitchCases extends Recipe {
             }
 
             private boolean hasUnresolvableIdentifierCasePattern(J.Switch switch_) {
+                // Enum case labels resolve specially (JLS 14.11.1); that lookup doesn't apply once spliced outside the switch, so an unresolved selector type makes any label untrustworthy.
+                boolean selectorTypeUnresolved = isUnresolved(switch_.getSelector().getTree().getType());
                 for (Statement statement : switch_.getCases().getStatements()) {
                     if (statement instanceof J.Case) {
                         J.Case aCase = (J.Case) statement;
@@ -243,16 +245,18 @@ public class MinimumSwitchCases extends Recipe {
                             Expression pattern = aCase.getPattern();
                             // Identifiers (like enum constants or static fields) need type info
                             // to be properly qualified in an if statement
-                            if (pattern instanceof J.Identifier) {
-                                JavaType patternType = pattern.getType();
-                                if (patternType == null || patternType instanceof JavaType.Unknown) {
-                                    return true;
-                                }
+                            if (pattern instanceof J.Identifier &&
+                                    (selectorTypeUnresolved || isUnresolved(pattern.getType()))) {
+                                return true;
                             }
                         }
                     }
                 }
                 return false;
+            }
+
+            private boolean isUnresolved(@Nullable JavaType type) {
+                return type == null || type instanceof JavaType.Unknown;
             }
 
             private List<Statement> getStatements(J.Case aCase) {

--- a/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
+++ b/src/main/java/org/openrewrite/staticanalysis/MinimumSwitchCases.java
@@ -226,16 +226,14 @@ public class MinimumSwitchCases extends Recipe {
                         }
                     }
                 }
-                // Don't transform if any case has an identifier pattern without type info
-                // (we can't properly qualify it in the if statement)
-                if (hasUnresolvableIdentifierCasePattern(switch_)) {
+                if (hasUnresolvableCasePattern(switch_)) {
                     return false;
                 }
                 return switch_.getCases().getStatements().stream()
                                .reduce(0, (a, b) -> a + ((J.Case) b).getCaseLabels().size(), Integer::sum) < 3;
             }
 
-            private boolean hasUnresolvableIdentifierCasePattern(J.Switch switch_) {
+            private boolean hasUnresolvableCasePattern(J.Switch switch_) {
                 // Enum case labels resolve specially (JLS 14.11.1); that lookup doesn't apply once spliced outside the switch, so an unresolved selector type makes any label untrustworthy.
                 boolean selectorTypeUnresolved = isUnresolved(switch_.getSelector().getTree().getType());
                 for (Statement statement : switch_.getCases().getStatements()) {
@@ -245,8 +243,13 @@ public class MinimumSwitchCases extends Recipe {
                             Expression pattern = aCase.getPattern();
                             // Identifiers (like enum constants or static fields) need type info
                             // to be properly qualified in an if statement
-                            if (pattern instanceof J.Identifier &&
-                                    (selectorTypeUnresolved || isUnresolved(pattern.getType()))) {
+                            if (pattern instanceof J.Identifier) {
+                                if (selectorTypeUnresolved || isUnresolved(pattern.getType())) {
+                                    return true;
+                                }
+                            } else if (selectorTypeUnresolved && pattern instanceof J.Literal &&
+                                    ((J.Literal) pattern).getValue() instanceof String) {
+                                // Without a resolved selector type we would emit `==` rather than `equals()`
                                 return true;
                             }
                         }

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -1044,6 +1044,132 @@ class MinimumSwitchCasesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doNotRewriteWhenSelectorTypeIsUnresolved() {
+        // Unresolved selector type: case labels may really be an unrelated same-named symbol (here, a statically imported constant), so the recipe must not transform it.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none()),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              public class Constants {
+                  public static final String RED = "red";
+                  public static final String BLUE = "blue";
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              import static com.example.Constants.RED;
+              import static com.example.Constants.BLUE;
+
+              class Test {
+                  void test(Unresolved u) {
+                      switch (u.getColor()) {
+                          case RED:
+                              doSomething();
+                              break;
+                          case BLUE:
+                              doSomethingElse();
+                              break;
+                      }
+                  }
+                  void doSomething() {}
+                  void doSomethingElse() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void rewritesWhenSelectorTypeIsResolvedDespiteShadowingStaticImport() {
+        // Same shadowing shape as doNotRewriteWhenSelectorTypeIsUnresolved, but with a resolvable selector type: the recipe should still transform and correctly qualify the enum constants.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package com.example;
+
+              public class Constants {
+                  public static final String RED = "red";
+                  public static final String BLUE = "blue";
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              public class Widget {
+                  public enum Color {
+                      RED,
+                      BLUE
+                  }
+
+                  private final Color color;
+
+                  public Widget(Color color) {
+                      this.color = color;
+                  }
+
+                  public Color getColor() {
+                      return color;
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              import static com.example.Constants.RED;
+              import static com.example.Constants.BLUE;
+
+              class Test {
+                  void test(Widget w) {
+                      switch (w.getColor()) {
+                          case RED:
+                              doSomething();
+                              break;
+                          case BLUE:
+                              doSomethingElse();
+                              break;
+                      }
+                  }
+                  void doSomething() {}
+                  void doSomethingElse() {}
+              }
+              """,
+            """
+              package com.example;
+
+              import static com.example.Constants.RED;
+              import static com.example.Constants.BLUE;
+
+              class Test {
+                  void test(Widget w) {
+                      if (w.getColor() == Widget.Color.RED) {
+                          doSomething();
+                      } else if (w.getColor() == Widget.Color.BLUE) {
+                          doSomethingElse();
+                      }
+                  }
+                  void doSomething() {}
+                  void doSomethingElse() {}
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/6")
     @Test
     void preserveDefaultCaseComments() {

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -20,6 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -1048,7 +1049,7 @@ class MinimumSwitchCasesTest implements RewriteTest {
     void doNotRewriteWhenSelectorTypeIsUnresolved() {
         // Unresolved selector type: case labels may really be an unrelated same-named symbol (here, a statically imported constant), so the recipe must not transform it.
         rewriteRun(
-          spec -> spec.typeValidationOptions(org.openrewrite.test.TypeValidation.none()),
+          spec -> spec.typeValidationOptions(TypeValidation.all().identifiers(false).methodDeclarations(false)),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/MinimumSwitchCasesTest.java
@@ -1089,6 +1089,73 @@ class MinimumSwitchCasesTest implements RewriteTest {
     }
 
     @Test
+    void doNotRewriteStringLiteralCasesWhenSelectorTypeIsUnresolved() {
+        // An unresolved selector type reads as not-a-String, which would produce `==` instead of `equals()`.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.all().identifiers(false).methodDeclarations(false)),
+          //language=java
+          java(
+            """
+              class Test {
+                  void test(Unresolved u) {
+                      switch (u.getColor()) {
+                          case "red":
+                              doSomething();
+                              break;
+                          case "blue":
+                              doSomethingElse();
+                              break;
+                      }
+                  }
+                  void doSomething() {}
+                  void doSomethingElse() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void rewritesNonStringLiteralCasesWhenSelectorTypeIsUnresolved() {
+        // `==` is correct for any integral selector, so an unresolved type is no reason to skip these.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.all().identifiers(false).methodDeclarations(false)),
+          //language=java
+          java(
+            """
+              class Test {
+                  void test(Unresolved u) {
+                      switch (u.getCode()) {
+                          case 1:
+                              doSomething();
+                              break;
+                          case 2:
+                              doSomethingElse();
+                              break;
+                      }
+                  }
+                  void doSomething() {}
+                  void doSomethingElse() {}
+              }
+              """,
+            """
+              class Test {
+                  void test(Unresolved u) {
+                      if (u.getCode() == 1) {
+                          doSomething();
+                      } else if (u.getCode() == 2) {
+                          doSomethingElse();
+                      }
+                  }
+                  void doSomething() {}
+                  void doSomethingElse() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void rewritesWhenSelectorTypeIsResolvedDespiteShadowingStaticImport() {
         // Same shadowing shape as doNotRewriteWhenSelectorTypeIsUnresolved, but with a resolvable selector type: the recipe should still transform and correctly qualify the enum constants.
         rewriteRun(


### PR DESCRIPTION
 ## What's changed?                                                                                                                                                                            
                                                                                                                                                                                             
  MinimumSwitchCases no longer rewrites a switch statement into an ==/equals() chain when the selector's own type can't be resolved (e.g. an incomplete classpath). Previously it only bailed  out when a case label's own type was unresolved; now it also bails out when the selector's type is unresolved, since in that situation the case labels' resolved types can't be trusted      either.                                                                                                                                                                                    
                                                                                                                                                                                             
 ## What's your motivation?                                                                                                                                                                    
                                                                                                                                                                                             
  Enum switch case labels are resolved specially, only among the switch's own enum constants, ignoring anything else in scope (JLS 14.11.1). That special lookup no longer applies once the  label is spliced into a plain == expression outside the switch. When the selector's type is unresolved, a case label identifier that otherwise looks resolved may really be a same-named   symbol from elsewhere in scope, such as a statically imported constant, rather than the switch's true value. That produced type-incorrect code like x.getFoo() == UNRELATED_STRING_CONSTANT   instead of the recipe correctly skipping the transform.                                                                                                                                    
                                                                                                                                                                                             
## Anything in particular you'd like reviewers to focus on?                                                                                                                                   
                                                                                                                                                                                             
  Worth a close look at whether bailing out on any unresolved selector type is too broad, versus only bailing when there's an actual name collision with something else in scope. I went with  the broader, more conservative check since the narrower one would need reliable visibility into what else is in scope, which is harder to establish soundly from a single-file recipe  pass.                                                                                                                                                                                      
                                                                                                                                                                                             
## Have you considered any alternatives or workarounds?                                                                                                                                       
                                                                                                                                                                                             
  Considered only bailing when a case label identifier's name matches a statically imported or otherwise in-scope symbol, but that requires more scope analysis than the recipe currently      does and seemed more likely to have its own gaps.                                                                                                                                          
                                                                                                                                                                                             
 ## Any additional context                                                                                                                                                                     
                                                                                                                                                                                             
  Added MinimumSwitchCasesTest#doNotRewriteWhenSelectorTypeIsUnresolved (no rewrite when selector type is unresolved and case labels shadow an unrelated static import) and                  
  #rewritesWhenSelectorTypeIsResolvedDespiteShadowingStaticImport (same shadowing shape, but with a resolvable selector type, confirming the rewrite still happens correctly) to cover both    the bug and the non-regression case.                                                                                                                                                       
                                                                                                                                                                                             
 ## Checklist                                                                                                                                                                                  
                                                                                                                                                                                             
  - [x] I've added unit tests to cover both positive and negative cases                                                                                                                      
  - [X] I've read and applied the recipe conventions and best practices                                                                                                                      
  - [X] I've run ./gradlew build locally, and committed any resulting changes to recipes.csv                                                                                                 
  - [x] I've formatted the lines I changed, without reformatting code I didn't touch    