### PR TITLE
Keep casts on `null` arguments that select an inherited overload

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCast.java
@@ -16,12 +16,14 @@
 package org.openrewrite.staticanalysis;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -100,8 +102,16 @@ public class RemoveRedundantTypeCast extends Recipe {
                 // `log(String, Throwable)` selected by `(Object) value`). Bail out before
                 // any other branch decides the cast is redundant.
                 if (parentValue instanceof MethodCall) {
-                    JavaType.Method methodType = ((MethodCall) parentValue).getMethodType();
+                    MethodCall methodCall = (MethodCall) parentValue;
+                    JavaType.Method methodType = methodCall.getMethodType();
                     if (methodType == null || hasMethodOverloading(methodType)) {
+                        return visited;
+                    }
+                    // `null` is applicable to every reference parameter, so a cast on `null` is what picks
+                    // the overload. `hasMethodOverloading` only sees the declaring type, which misses
+                    // overloads inherited from a supertype or declared on the receiver's own type.
+                    if (J.Literal.isLiteralValue(typeCast.getExpression(), null) &&
+                            selectsOverload(methodCall, methodType, typeCast)) {
                         return visited;
                     }
                 }
@@ -244,6 +254,63 @@ public class RemoveRedundantTypeCast extends Recipe {
                 return methodType != null &&
                         (TypeUtils.isOfClassType(methodType.getDeclaringType(), "java.lang.invoke.MethodHandle") ||
                                 TypeUtils.isOfClassType(methodType.getDeclaringType(), "java.lang.invoke.VarHandle"));
+            }
+
+            /// Whether some other method visible at the call site accepts `null` at the same argument
+            /// position with a different type, which is what the cast is there to disambiguate.
+            private boolean selectsOverload(MethodCall call, JavaType.Method methodType, J.TypeCast typeCast) {
+                int index = -1;
+                List<Expression> arguments = call.getArguments();
+                for (int i = 0; i < arguments.size(); i++) {
+                    if (arguments.get(i) == typeCast) {
+                        index = i;
+                        break;
+                    }
+                }
+                if (index < 0 || index >= methodType.getParameterTypes().size()) {
+                    return false;
+                }
+                // Resolution starts at the type named at the call site, not at the declaring type: an
+                // anonymous class delegates to its supertype's constructors, and a subtype can declare
+                // overloads of a method it inherits.
+                JavaType.FullyQualified searchFrom = null;
+                if (call instanceof J.NewClass && ((J.NewClass) call).getClazz() != null) {
+                    searchFrom = TypeUtils.asFullyQualified(((J.NewClass) call).getClazz().getType());
+                } else if (call instanceof J.MethodInvocation && ((J.MethodInvocation) call).getSelect() != null) {
+                    searchFrom = TypeUtils.asFullyQualified(((J.MethodInvocation) call).getSelect().getType());
+                }
+                return declaresCompetingOverload(searchFrom == null ? methodType.getDeclaringType() : searchFrom,
+                        methodType, index, new HashSet<>());
+            }
+
+            private boolean declaresCompetingOverload(JavaType.@Nullable FullyQualified type, JavaType.Method methodType,
+                                                      int index, Set<String> seen) {
+                if (type == null || !seen.add(type.getFullyQualifiedName())) {
+                    return false;
+                }
+                JavaType parameterType = methodType.getParameterTypes().get(index);
+                for (JavaType.Method candidate : type.getMethods()) {
+                    if (candidate.getName().equals(methodType.getName()) &&
+                            candidate.getParameterTypes().size() == methodType.getParameterTypes().size()) {
+                        JavaType candidateType = candidate.getParameterTypes().get(index);
+                        // A primitive parameter is not a candidate for `null`; an identical one is an override.
+                        if (!(candidateType instanceof JavaType.Primitive) && !TypeUtils.isOfType(candidateType, parameterType)) {
+                            return true;
+                        }
+                    }
+                }
+                if (methodType.isConstructor()) {
+                    return false;
+                }
+                if (declaresCompetingOverload(type.getSupertype(), methodType, index, seen)) {
+                    return true;
+                }
+                for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
+                    if (declaresCompetingOverload(anInterface, methodType, index, seen)) {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             private boolean returnsDeclaredTypeParameter(Expression expression) {

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveRedundantTypeCastTest.java
@@ -281,6 +281,145 @@ class RemoveRedundantTypeCastTest implements RewriteTest {
         );
     }
 
+    @Test
+    void keepCastOnNullArgumentToOverloadInheritedFromSupertype() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            //language=java
+            .dependsOn(
+              """
+                package org.example;
+
+                public enum Platform {
+                    ANY
+                }
+                """,
+              """
+                package org.example;
+
+                public class Capabilities {
+                    public void setCapability(String key, String value) {}
+                }
+                """,
+              """
+                package org.example;
+
+                public class MutableCapabilities extends Capabilities {
+                    public void setCapability(String key, Platform value) {}
+                }
+                """
+            )
+          ),
+          //language=java
+          java(
+            """
+              import org.example.MutableCapabilities;
+              import org.example.Platform;
+
+              class Test {
+                  void method(MutableCapabilities cap) {
+                      cap.setCapability("platform", (Platform) null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepCastOnNullArgumentToOverloadDeclaredOnSubtype() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            //language=java
+            .dependsOn(
+              """
+                package org.example;
+
+                public class Handler {
+                    public void handle(String key, Object value) {}
+                }
+                """,
+              """
+                package org.example;
+
+                public class LoggingHandler extends Handler {
+                    public void handle(String key, String value) {}
+                }
+                """
+            )
+          ),
+          //language=java
+          java(
+            """
+              import org.example.LoggingHandler;
+
+              class Test {
+                  void method(LoggingHandler handler) {
+                      handler.handle("key", (Object) null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepCastOnNullArgumentToAnonymousClassConstructor() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            //language=java
+            .dependsOn(
+              """
+                package org.example;
+
+                public class StringEntity {
+                    public StringEntity(String body, String contentType) {}
+                    public StringEntity(String body, Runnable onClose) {}
+                }
+                """
+            )
+          ),
+          //language=java
+          java(
+            """
+              import org.example.StringEntity;
+
+              class Test {
+                  Object entity = new StringEntity("data", (Runnable) null) {
+                  };
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeCastOnNullArgumentWhenNotOverloaded() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  void accept(Object o) {
+                  }
+                  void method() {
+                      accept((String) null);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void accept(Object o) {
+                  }
+                  void method() {
+                      accept(null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/899")
     @Test
     void keepObjectCastDisambiguatingVarargsFromThrowableOverload() {


### PR DESCRIPTION
`RemoveRedundantTypeCast` removes casts that are not redundant: a cast on a `null` argument that is selecting an overload. The result does not compile, or — worse — compiles and calls a different method.

## What I saw

Running the recipe over public repositories:

```java
// org.apache.hc.core5.http.io.entity.StringEntity
- new StringEntity(req.getData(), (ContentType) null)
+ new StringEntity(req.getData(), null)
```
```
error: reference to StringEntity is ambiguous
  both constructor StringEntity(String,String) and constructor StringEntity(String,Charset) match
```

```java
// org.openqa.selenium.MutableCapabilities
- cap.setCapability(CapabilityType.PROXY, (Object) null)
+ cap.setCapability(CapabilityType.PROXY, null)
```

`null` is applicable to every reference parameter, so a cast on `null` is precisely what picks the overload. Removing it is never safe when a competing overload is in scope.

## Why the existing guard misses it

The recipe already bails when `hasMethodOverloading(methodType)` is true, but that helper only inspects the methods **declared on the resolved method's declaring type**:

```java
.map(JavaType.Method::getDeclaringType)
.map(JavaType.FullyQualified::getMethods)
```

so an overload is invisible when it is

- inherited from a supertype,
- declared on the receiver's own subtype (resolution starts at the type named at the call site, which the helper never sees), or
- reached through an anonymous class, whose own `getMethods()` holds nothing and whose supertype's constructors are where the overloads live.

The two cases above are the first and third of those. Both `StringEntity` and `MutableCapabilities` resolve fine now for a different reason — the `JavaType.Class` filter that used to sit in front of `getMethods()` was removed in a previous change — but the hierarchy gap remains, and these shapes still reproduce on `main`.

## The change

`hasMethodOverloading` is left alone. Its contract — "does this type declare overloads?" — is what `LambdaBlockToExpression` wants, and an upward-only walk could not answer the subtype case anyway, since resolution has to begin at the type named at the call site.

Instead, a guard local to this recipe, scoped to the one situation where the stronger check is warranted: the cast expression is the `null` literal and the cast sits in argument position. It searches from the call-site type (`J.NewClass#getClazz()`, or `J.MethodInvocation#getSelect()`, falling back to the declaring type) up through supertypes and interfaces for another method of the same name and arity whose parameter at that index is a reference type differing from the resolved one. Primitive parameters are skipped, since `null` is not applicable to them; identical ones are overrides rather than overloads; constructors do not walk upward, because constructors are not inherited.

Scoping it to `null` means non-null cast removal is untouched.

## Tests

Three regression tests covering the shapes that reproduce — an overload inherited from a supertype, one declared on the receiver's subtype, and an anonymous class constructor — plus `removeCastOnNullArgumentWhenNotOverloaded` as a negative control, which passes before and after and pins that a genuinely redundant `null` cast is still removed.

Reverting the recipe change and re-running the suite fails exactly the three new positive tests:

```
RemoveRedundantTypeCastTest > keepCastOnNullArgumentToOverloadDeclaredOnSubtype() FAILED
RemoveRedundantTypeCastTest > keepCastOnNullArgumentToOverloadInheritedFromSupertype() FAILED
RemoveRedundantTypeCastTest > keepCastOnNullArgumentToAnonymousClassConstructor() FAILED
41 tests completed, 3 failed
```

With the change, `RemoveRedundantTypeCastTest` (41) and `LambdaBlockToExpressionTest` (5) both pass.
