### PR TITLE
NoDoubleBraceInitialization: don't retarget invocations inside nested anonymous classes

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/NoDoubleBraceInitialization.java
+++ b/src/main/java/org/openrewrite/staticanalysis/NoDoubleBraceInitialization.java
@@ -149,6 +149,17 @@ public class NoDoubleBraceInitialization extends Recipe {
             private final J.Identifier identifier;
 
             @Override
+            public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+                // Don't descend into an anonymous class body, such as a nested double brace initialization.
+                // A method invocation without a select in there resolves against that instance, not against
+                // the variable being initialized here.
+                if (newClass.getBody() != null) {
+                    return newClass;
+                }
+                return super.visitNewClass(newClass, ctx);
+            }
+
+            @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
                 if (mi.getSelect() == null || (mi.getSelect() instanceof J.Identifier && "this".equals(((J.Identifier) mi.getSelect()).getSimpleName()))) {

--- a/src/test/java/org/openrewrite/staticanalysis/NoDoubleBraceInitializationTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/NoDoubleBraceInitializationTest.java
@@ -437,6 +437,98 @@ class NoDoubleBraceInitializationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/352")
+    @Test
+    void nestedDoubleBraceInitializationKeepsItsOwnReceiver() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.LinkedHashMap;
+
+              class A {
+                  void example() {
+                      LinkedHashMap<String, Object> expectedMap = new LinkedHashMap<>() {{
+                          put("a", 1);
+                          put("testArrayList", new ArrayList<>() {{
+                              add(1);
+                          }});
+                      }};
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayList;
+              import java.util.LinkedHashMap;
+
+              class A {
+                  void example() {
+                      LinkedHashMap<String, Object> expectedMap = new LinkedHashMap<>();
+                      expectedMap.put("a", 1);
+                      expectedMap.put("testArrayList", new ArrayList<>() {
+                          {
+                              add(1);
+                          }
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/352")
+    @Test
+    void enclosingMethodCallInsideAnonymousClassKeepsNoSelect() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class A {
+                  String helper() {
+                      return "H";
+                  }
+
+                  void example() {
+                      Map<String, String> map = new HashMap<String, String>() {{
+                          put("a", new Object() {
+                              @Override
+                              public String toString() {
+                                  return helper();
+                              }
+                          }.toString());
+                      }};
+                  }
+              }
+              """,
+            """
+              import java.util.HashMap;
+              import java.util.Map;
+
+              class A {
+                  String helper() {
+                      return "H";
+                  }
+
+                  void example() {
+                      Map<String, String> map = new HashMap<String, String>();
+                      map.put("a", new Object() {
+                          @Override
+                          public String toString() {
+                              return helper();
+                          }
+                      }.toString());
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void implicitReceiver() {
         rewriteRun(


### PR DESCRIPTION
- Fixes #352

## The problem

`AddSelectVisitor` gives the initialized variable as a select to every method invocation that has none. It walks the whole subtree, so it also rewrites invocations inside a *nested* anonymous class, where they resolve against that instance instead:

```java
LinkedHashMap<String, Object> expectedMap = new LinkedHashMap<>() {{
    put("a", 1);
    put("testArrayList", new ArrayList<>() {{
        add(1);
    }});
}};
```

became

```java
expectedMap.put("testArrayList", new ArrayList<>() {
    {
        expectedMap.add(1);
    }
});
```

The inner `add(1)` belongs to the `ArrayList`, not to the map, and the result no longer compiles:

```
A.java:10: error: cannot find symbol
                expectedMap.add(1);
  symbol:   method add(int)
  location: variable expectedMap of type LinkedHashMap<String,Object>
```

It isn't limited to nested double brace initialization. Any invocation without a select inside an anonymous class body is retargeted, including a call to a method of the enclosing class:

```java
-                return helper();
+                return map.helper();
```

## The change

`AddSelectVisitor` no longer descends into an anonymous class body. This mirrors how `FallThroughVisitor.AddBreak` declines to descend into nested switches.

The body is skipped as a whole rather than only its statements, because arguments to an anonymous class constructor are calls on the enclosing instance too, so giving them the collection as a select would be equally wrong.

The nested initialization is then left as it was. That is the existing behavior for a collection in argument position — `isSupportedDoubleBraceInitialization` already declines when the parent is a method invocation — so this PR does not attempt to unwrap it, it only stops it from being corrupted.

## Tests

- Two added, tagged to #352: the reported nested case, and a call to an enclosing class method inside an anonymous class. Both fail without the change. All 15 existing tests are untouched and still pass.

Full suite locally on JDK 21: 2338 tests, the only failures being 7 pre-existing `Failed to start RPC process: rewrite-go-rpc` errors that occur identically on unmodified `main` in this environment.