### PR TITLE
DeclarationSiteTypeVariance: skip @Override methods when the supertype is unresolved

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVariance.java
+++ b/src/main/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVariance.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -35,6 +36,7 @@ import static org.openrewrite.java.tree.J.Wildcard.Bound.Super;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class DeclarationSiteTypeVariance extends Recipe {
+    private static final AnnotationMatcher OVERRIDE = new AnnotationMatcher("@java.lang.Override");
 
     @Option(displayName = "Variant types",
             description = "A list of well-known classes that have in/out type variance.",
@@ -86,7 +88,12 @@ public class DeclarationSiteTypeVariance extends Recipe {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                if (m.getMethodType() != null && m.getMethodType().isOverride()) {
+                // An `@Override` method may implement a declaration outside the source set, whose signature
+                // cannot be changed. `isOverride()` only recognizes that when the supertype is resolvable, so
+                // fall back to the annotation.
+                // https://github.com/openrewrite/rewrite-static-analysis/issues/277
+                if ((m.getMethodType() != null && m.getMethodType().isOverride()) ||
+                        m.getLeadingAnnotations().stream().anyMatch(OVERRIDE::matches)) {
                     return m;
                 }
                 return m.withParameters(ListUtils.map(m.getParameters(), param -> {

--- a/src/test/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVarianceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/DeclarationSiteTypeVarianceTest.java
@@ -17,10 +17,12 @@ package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.TypeValidation;
 
 import java.util.List;
 
@@ -195,6 +197,31 @@ class DeclarationSiteTypeVarianceTest implements RewriteTest {
               import java.util.function.Function;
               class Test {
                   void test(Function<? super In, Out> f) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/277")
+    @Test
+    void overriddenMethodOfUnresolvedSuperclass() {
+        // The supertype is outside the source set, so `isOverride()` cannot see the declaration being
+        // implemented; the `@Override` annotation is the only remaining signal.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              import java.util.function.Function;
+
+              interface In {}
+              interface Out {}
+
+              class A extends SomeExternalClassThatCannotBeChanged {
+                  @Override
+                  public void test(Function<In, Out> f) {
                   }
               }
               """


### PR DESCRIPTION
- Fixes #277

## The problem

The recipe already declines to touch overrides:

```java
if (m.getMethodType() != null && m.getMethodType().isOverride()) {
    return m;
}
```

but `isOverride()` works by locating the overridden declaration, so it returns `false` when the supertype is not resolvable. That is exactly the case the issue describes, where the super implementation lives outside the source set being modified:

```java
class A extends SomeExternalClassThatCannotBeChanged {
    @Override
    public void test(Function<In, Out> f) {
    }
}
```

becomes

```java
    public void test(Function<? super In, ? extends Out> f) {
```

which no longer matches the declaration it is meant to override.

## The change

Fall back to the `@Override` annotation when the type information is not conclusive. If the author wrote `@Override` then the method implements something whose signature is not ours to change, whether or not that declaration can be resolved.

This follows @timtebeek's suggestion on the issue to be safe by not changing methods that override another method, and the reporter's own question about keying on `@Override`. It uses `AnnotationMatcher("@java.lang.Override")`, as `MissingOverrideAnnotation`, `RemoveMethodsOnlyCallSuper` and `CovariantEquals` already do.

The annotation is a fallback rather than a replacement, so methods that override without the annotation are still recognized by the existing check.

## Tests

- One added, tagged to #277: an `@Override` method whose superclass is not on the source set or classpath. It fails without the change. The existing `overriddenMethods` test, where the interface is present and `isOverride()` already succeeds, is untouched and still passes, as do the other 7.

Full suite locally on JDK 21: 2337 tests, the only failures being 7 pre-existing `Failed to start RPC process: rewrite-go-rpc` errors that occur identically on unmodified `main` in this environment.