### PR TITLE
FinalizeMethodArguments only for Java, Groovy

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/FinalizeMethodArguments.java
+++ b/src/main/java/org/openrewrite/staticanalysis/FinalizeMethodArguments.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
@@ -29,6 +30,8 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.java.JavaFileChecker;
 
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +52,7 @@ public class FinalizeMethodArguments extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(Preconditions.or(new JavaFileChecker<>(), new GroovyFileChecker<>()), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
                 J.MethodDeclaration declarations = super.visitMethodDeclaration(methodDeclaration, ctx);
@@ -86,7 +89,7 @@ public class FinalizeMethodArguments extends Recipe {
                     }
                 }
             }
-        };
+        });
     }
 
     private static boolean isWrongKind(final J.MethodDeclaration methodDeclaration) {

--- a/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/FinalizeMethodArgumentsTest.java
@@ -22,6 +22,8 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
+import static org.openrewrite.golang.Assertions.go;
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
 
 class FinalizeMethodArgumentsTest implements RewriteTest {
@@ -274,6 +276,43 @@ class FinalizeMethodArgumentsTest implements RewriteTest {
                   accumulator += add;
                   return accumulator;
                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void finalizeGroovyParameters() {
+        rewriteRun(
+          //language=groovy
+          groovy(
+            """
+              class Test {
+                  void greet(String name) {
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void greet(final String name) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeGo() {
+        rewriteRun(
+          //language=go
+          go(
+            """
+              package main
+
+              func RandomString(n int) string {
+                  return ""
               }
               """
           )


### PR DESCRIPTION
## What's changed?

Marking `FinalizeMethodArguments` to run only for Java and Groovy sources.

## What's your motivation?

Only these languages have `final` method arguments.