### PR TITLE
JavaScript: safety guard for Identifier cast in ExplicitThis

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitThis.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitThis.java
@@ -95,7 +95,7 @@ public class ExplicitThis extends Recipe {
                     return id;
                 }
 
-                if (isPartOfDeclaration()) {
+                if (isPartOfDeclaration() || isMethodInvocationName()) {
                     return id;
                 }
 
@@ -172,6 +172,15 @@ public class ExplicitThis extends Recipe {
                 }
                 J.VariableDeclarations.NamedVariable namedVar = parent.getValue();
                 return namedVar.getName() == getCursor().getValue();
+            }
+
+            private boolean isMethodInvocationName() {
+                Cursor parent = getCursor().getParent();
+                if (parent == null || !(parent.getValue() instanceof J.MethodInvocation)) {
+                    return false;
+                }
+                J.MethodInvocation methodInvocation = parent.getValue();
+                return methodInvocation.getName() == getCursor().getValue();
             }
 
             private ExplicitThis.@Nullable ClassContext getCurrentClassContext() {

--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitThisTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitThisTest.java
@@ -15,12 +15,14 @@
  */
 package org.openrewrite.staticanalysis;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.javascript.Assertions.typescript;
 
 class ExplicitThisTest implements RewriteTest {
 
@@ -489,4 +491,22 @@ class ExplicitThisTest implements RewriteTest {
         );
     }
 
+    @Nested
+    class Typescript {
+        @Test
+        void doNotCrashWhenInvokingFunctionTypedField() {
+            rewriteRun(
+              typescript(
+                """
+                  class C {
+                    handler = () => 1;
+                    run() {
+                      this.handler();
+                    }
+                  }
+                  """
+              )
+            );
+        }
+    }
 }


### PR DESCRIPTION
**What**: Adding a safety guard for the `(Identifier)` cast in `ExplicitThis`.
**Why**: The recipe might crash for JS/TS sources:
```
java.lang.ClassCastException: class org.openrewrite.java.tree.J$FieldAccess cannot be cast to class org.openrewrite.java.tree.J$Identifier (org.openrewrite.java.tree.J$FieldAccess and org.openrewrite.java.tree.J$Identifier are in unnamed module of loader 'app')
  org.openrewrite.java.JavaVisitor.visitMethodInvocation(JavaVisitor.java:916)
  org.openrewrite.staticanalysis.ExplicitThis$1.visitMethodInvocation(ExplicitThis.java:138)
  org.openrewrite.staticanalysis.ExplicitThis$1.visitMethodInvocation(ExplicitThis.java:53)
  org.openrewrite.staticanalysis.ExplicitThis_1_JavaScriptVisitor.visitMethodInvocation(ExplicitThis_1_JavaScriptVisitor.zig:233)
``` 