### PR TITLE
exclude JS sources from ExplicitLambdaArgumentTypes

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypes.java
+++ b/src/main/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypes.java
@@ -18,6 +18,7 @@ package org.openrewrite.staticanalysis;
 import lombok.Getter;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
@@ -25,6 +26,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.staticanalysis.javascript.JavascriptFileChecker;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +49,7 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(Preconditions.not(new JavascriptFileChecker<>()), new JavaIsoVisitor<ExecutionContext>() {
 
             @Override
             public J.Lambda visitLambda(J.Lambda lambda, ExecutionContext ctx) {
@@ -233,7 +235,7 @@ public class ExplicitLambdaArgumentTypes extends Recipe {
                 }
                 return JContainer.build(Space.EMPTY, typeExpressions, Markers.EMPTY);
             }
-        };
+        });
     }
 
 }

--- a/src/test/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypesTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/ExplicitLambdaArgumentTypesTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.javascript.Assertions.typescript;
 
 @SuppressWarnings({
   "ComparatorCombinators",
@@ -694,6 +695,23 @@ class ExplicitLambdaArgumentTypesTest implements RewriteTest {
                       a.forEach((A it) -> { });
                   }
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotFailOnTypeScriptArrowFunction() {
+        rewriteRun(
+          typescript(
+            """
+              namespace com.example {
+                export class Foo {}
+              }
+              function run(cb: (x: com.example.Foo) => void) {}
+              run(x => {
+                console.log(x);
+              });
               """
           )
         );


### PR DESCRIPTION
## What's changed?

Making `ExplicitLambdaArgumentTypes` not touch JavaScript/TypeScript files.

## What's your motivation?

- Current implementation doesn't fit JS/TS syntax
- Typically it's seen as counter-productive in JS/TS sources