### PR TITLE
UseLambdaForFunctionalInterface to handle empty variable declarations…

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -77,6 +77,9 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                     }
                 }
                 J.VariableDeclarations result = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
+                if (result.getVariables().isEmpty()) {
+                    return result;
+                }
                 Expression newInitializer = result.getVariables().get(0).getInitializer();
                 if (replacementType != null && newInitializer instanceof J.Lambda) {
                     TypeTree resolved = resolveDiamond(replacementType, (J.Lambda) newInitializer);

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.staticanalysis;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -33,6 +34,7 @@ import java.util.EnumSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.javascript.Assertions.javascript;
 
 @SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef", "WriteOnlyObject", "Convert2Diamond", "Convert2MethodRef", "ResultOfMethodCallIgnored", "StatementWithEmptyBody", "ConstantValue", "NonFinalFieldInEnum", "LoopConditionNotUpdatedInsideLoop"})
 class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
@@ -1659,6 +1661,26 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
             spec -> spec.mapBeforeRecipe(UseLambdaForFunctionalInterfaceTest::asBytecodeAttribution)
           )
         );
+    }
+
+    @Nested
+    class JavaScript {
+        @Test
+        void doNotCrashOnOptionalCatchBinding() {
+            rewriteRun(
+              javascript(
+                """
+                  function load() {
+                    try {
+                      doWork();
+                    } catch {
+                      return null;
+                    }
+                  }
+                  """
+              )
+            );
+        }
     }
 
     /// Rewrite the type attribution the way a source derived from bytecode records it: `default` is not an


### PR DESCRIPTION
… in catch

## What's changed?

Add a guard in `UseLambdaForFunctionalInterface` against a VariableDeclarations with empty list of variables.

## What's your motivation?

Otherwise it'd fail with:
```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
  java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
  java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
  java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
  java.base/java.util.Objects.checkIndex(Objects.java:365)
  java.base/java.util.ArrayList.get(ArrayList.java:428)
  org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface$1.visitVariableDeclarations(UseLambdaForFunctionalInterface.java:80)
    ..."
  ```
for some JS/TS code bases, including the ones which have `catch {}` with no distinctions.