### PR TITLE
Narrow down TypecastParenPadStyle to Java only

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/TypecastParenPad.java
+++ b/src/main/java/org/openrewrite/staticanalysis/TypecastParenPad.java
@@ -26,7 +26,7 @@ import org.openrewrite.java.style.SpacesStyle;
 import org.openrewrite.java.style.TypecastParenPadStyle;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
+import org.openrewrite.staticanalysis.java.JavaFileChecker;
 import org.openrewrite.style.Style;
 
 public class TypecastParenPad extends Recipe {
@@ -41,7 +41,7 @@ public class TypecastParenPad extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         //noinspection NotNullFieldNotInitialized
         return Preconditions.check(
-                Preconditions.not(new GroovyFileChecker<>()),
+                new JavaFileChecker<>(),
                 new JavaIsoVisitor<ExecutionContext>() {
                     SpacesStyle spacesStyle;
                     TypecastParenPadStyle typecastParenPadStyle;

--- a/src/test/java/org/openrewrite/staticanalysis/TypecastParenPadTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/TypecastParenPadTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class TypecastParenPadTest implements RewriteTest {
 
@@ -72,6 +73,20 @@ class TypecastParenPadTest implements RewriteTest {
                   void m(Object o) {
                       int l = ( o as String).length()
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeForKotlin() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              fun m(o: Any) {
+                  val l = (o as String).length
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Limit the execution of `TypecastParenPad` recipe to Java only.

## What's your motivation?

- This is the only (?) language which uses parens for type casts.
- The implementation is Java specific anyway.
- Otherwise the recipe attempts to amend casts in other languages which use a different syntax.