### PR TITLE
Fix init of RemoveInstanceOfPatternMatch

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatch.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.UsesJavaVersion;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.staticanalysis.groovy.GroovyFileChecker;
 
 import java.time.Duration;
@@ -65,14 +66,19 @@ public class RemoveInstanceOfPatternMatch extends Recipe {
         private VariableUsage variableUsage;
 
         @Override
-        public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-            // Analyze variable usage in the whole compilation unit and
-            // run the compilation unit transformation.
-            // Maybe it's better to use messages instead of the private field
-            variableUsage = VariableUsageAnalyzer.analyze(cu);
-            J.CompilationUnit result = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
-            variableUsage = null;
-            return result;
+        public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+            // Only J.CompilationUnit carries `instanceof` pattern matching; other
+            // source files (e.g. Kotlin's K.CompilationUnit) start from an empty
+            // usage so the visitor never dereferences a null field.
+            if (tree instanceof JavaSourceFile) {
+                variableUsage = tree instanceof J.CompilationUnit ?
+                        VariableUsageAnalyzer.analyze((J.CompilationUnit) tree) :
+                        new VariableUsage();
+                J result = super.visit(tree, ctx);
+                variableUsage = null;
+                return result;
+            }
+            return super.visit(tree, ctx);
         }
 
         @Override

--- a/src/test/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/RemoveInstanceOfPatternMatchTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.version;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class RemoveInstanceOfPatternMatchTest implements RewriteTest {
 
@@ -1021,6 +1022,29 @@ class RemoveInstanceOfPatternMatchTest implements RewriteTest {
                   }
               }
               """),
+            14));
+    }
+
+    @Test
+    void doNotChangeKotlin() {
+        rewriteRun(
+          version(
+            kotlin(
+              """
+              package com.talk2duck.gradle.buildcache
+
+              import org.gradle.caching.BuildCacheEntryReader
+              import org.gradle.caching.BuildCacheEntryWriter
+
+              class S3BuildCacheService {
+                  fun check(obj: Any) {
+                      if (obj is String) {
+                          println(obj)
+                      }
+                  }
+              }
+              """
+            ),
             14));
     }
 


### PR DESCRIPTION
## What's changed?

Fix the initialization of internal data structures in `RemoveInstanceOfPatternMatch`.

## What's your motivation?

Fixing NPE observed for some non-Java sources as they "follow" Java visitors, but `visitCompilationUnit(J.CompilationUnit)` is never called for them:
```
Cannot read field "conditions" because "this.variableUsage" is null
Detail:

java.lang.NullPointerException: Cannot read field "conditions" because "this.variableUsage" is null
  org.openrewrite.staticanalysis.RemoveInstanceOfPatternMatch$RemoveInstanceOfPatternMatchVisitor.visitIdentifier(RemoveInstanceOfPatternMatch.java:99)
  org.openrewrite.staticanalysis.RemoveInstanceOfPatternMatch$RemoveInstanceOfPatternMatchVisitor.visitIdentifier(RemoveInstanceOfPatternMatch.java:63)
  org.openrewrite.staticanalysis.RemoveInstanceOfPatternMatch_RemoveInstanceOfPatternMatchVisitor_KotlinVisitor.visitIdentifier(RemoveInstanceOfPatternMatch_RemoveInstanceOfPatternMatchVisitor_KotlinVisitor.zig:119)
```