### PR TITLE
Fix ClassCastException in InterruptedExceptionHandling on Kotlin sources

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/InterruptedExceptionHandling.java
+++ b/src/main/java/org/openrewrite/staticanalysis/InterruptedExceptionHandling.java
@@ -58,12 +58,10 @@ public class InterruptedExceptionHandling extends Recipe {
                     if (isMultiCatch) {
                         J.Identifier varId = c.getParameter().getTree().getVariables().get(0).getName();
                         return JavaTemplate.builder("if (#{any()} instanceof InterruptedException) { Thread.currentThread().interrupt(); }")
-                                .contextSensitive()
                                 .build()
                                 .apply(updateCursor(c), c.getBody().getCoordinates().firstStatement(), varId);
                     }
                     return JavaTemplate.builder("Thread.currentThread().interrupt();")
-                            .contextSensitive()
                             .build()
                             .apply(updateCursor(c), c.getBody().getCoordinates().firstStatement());
                 }

--- a/src/test/java/org/openrewrite/staticanalysis/InterruptedExceptionHandlingTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/InterruptedExceptionHandlingTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings({"EmptyCatchBlock", "CatchMayIgnoreException", "InterruptedExceptionSwallowed"})
 class InterruptedExceptionHandlingTest implements RewriteTest {
@@ -224,6 +225,42 @@ class InterruptedExceptionHandlingTest implements RewriteTest {
                           }
                       }
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void kotlinClassWithPrimaryConstructorAndSupertype() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              class Test(val name: String) : Runnable {
+                  override fun run() {
+                      execute {
+                          try {
+                              Thread.sleep(1000)
+                          } catch (e: InterruptedException) {
+                          }
+                      }
+                  }
+                  fun execute(block: () -> Unit) = block()
+              }
+              """,
+            """
+              class Test(val name: String) : Runnable {
+                  override fun run() {
+                      execute {
+                          try {
+                              Thread.sleep(1000)
+                          } catch (e: InterruptedException) {
+                              Thread.currentThread().interrupt()
+                          }
+                      }
+                  }
+                  fun execute(block: () -> Unit) = block()
               }
               """
           )


### PR DESCRIPTION
## What's changed?

Removing `contextSensitive` from template usages in `InterruptedExceptionHandling`.

## What's your motivation?

- They are not needed
- With them present, the recipe might crash for Kotlin sources:
```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.J$Block.getStatements()" because the return value of "org.openrewrite.java.tree.J$ClassDeclaration.getBody()" is null
  org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration0(KotlinPrinter.java:759)
  org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration(KotlinPrinter.java:731)
  org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visitClassDeclaration(KotlinPrinter.java:557)
  org.openrewrite.java.tree.J$ClassDeclaration.acceptJava(J.java:1382)
  org.openrewrite.java.tree.J.accept(J.java:55)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:242)
  org.openrewrite.kotlin.internal.KotlinPrinter$KotlinJavaPrinter.visit(KotlinPrinter.java:570)
  org.openrewrite.kotlin.internal.KotlinPrinter.visit(KotlinPrinter.java:56)
  org.openrewrite.kotlin.internal.KotlinPrinter.visit(KotlinPrinter.java:40)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:154)
  org.openrewrite.Tree.print(Tree.java:86)
  org.openrewrite.Tree.print(Tree.java:82)
  org.openrewrite.Tree.printTrimmed(Tree.java:119)
```