### PR TITLE
Resolve org.openrewrite build plugins from the Code Genome Project

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,18 @@ rootProject.name = "rewrite-static-analysis"
 pluginManagement {
     repositories {
         mavenLocal()
+        maven {
+            name = "codegenome"
+            url = uri("https://artifacts.codegenomeproject.org/maven")
+            credentials {
+                username = providers.gradleProperty("codegenomeUsername").orNull ?: System.getenv("CODEGENOME_USERNAME")
+                password = providers.gradleProperty("codegenomePassword").orNull ?: System.getenv("CODEGENOME_TOKEN")
+            }
+            content {
+                includeGroupAndSubgroups("org.openrewrite")
+                includeGroupAndSubgroups("io.moderne")
+            }
+        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
## Background / problem

- `rewrite-build-gradle-plugin` 2.23.2 depends on rewrite releases published only to the Code Genome Project, but this repository resolves its plugin classpath from the Gradle Plugin Portal alone, so configuration fails with `Could not find org.openrewrite:rewrite-java:8.91.4` before any convention plugin runs. This is item (d) of moderneinc/customer-requests#2788.

## Solution

- Registers the Code Genome Project in `pluginManagement.repositories`, scoped to the `org.openrewrite` and `io.moderne` groups, with credentials from the `codegenomeUsername` and `codegenomePassword` Gradle properties or the `CODEGENOME_USERNAME` and `CODEGENOME_TOKEN` environment variables, which CI already provides through `gh-automation`. Applied by `io.moderne.recipe.AddCodeGenomePluginRepository`; the same block is already green in openrewrite/rewrite-logging-frameworks#304.

## Test plan

- [ ] CI configures and builds


Use this link to re-run the recipe: https://dev.moderne.io/recipes/io.moderne.recipe.AddCodeGenomePluginRepository?organizationId=VXNlcnMva2V2aW5AbW9kZXJuZS5pby9NK08%3D