### PR TITLE
Fix UseLambdaForFunctionalInterface for varargs

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
+++ b/src/main/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterface.java
@@ -246,7 +246,11 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 if (methodType == null) {
                     return false;
                 }
-                if (!TypeUtils.isOfClassType(methodType.getParameterTypes().get(argumentIndex), lambdaFqn)) {
+                JavaType parameterType = parameterTypeAt(methodType, argumentIndex);
+                if (parameterType == null) {
+                    return false;
+                }
+                if (!TypeUtils.isOfClassType(parameterType, lambdaFqn)) {
                     return true;
                 }
 
@@ -256,8 +260,8 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                     if (methodType.getName().equals(maybeAmbiguous.getName()) &&
                         methodType.getParameterTypes().size() == maybeAmbiguous.getParameterTypes().size()) {
                         if (areMethodsAmbiguous(
-                                getSamCompatible(methodType.getParameterTypes().get(argumentIndex)),
-                                getSamCompatible(maybeAmbiguous.getParameterTypes().get(argumentIndex)))) {
+                                getSamCompatible(parameterType),
+                                getSamCompatible(parameterTypeAt(maybeAmbiguous, argumentIndex)))) {
                             count++;
                         }
                     }
@@ -267,6 +271,22 @@ public class UseLambdaForFunctionalInterface extends Recipe {
                 }
 
                 return hasGenerics(lambda);
+            }
+
+            private @Nullable JavaType parameterTypeAt(JavaType.Method methodType, int argumentIndex) {
+                List<JavaType> parameterTypes = methodType.getParameterTypes();
+                if (parameterTypes.isEmpty()) {
+                    return null;
+                }
+                int index = Math.min(argumentIndex, parameterTypes.size() - 1);
+                JavaType parameterType = parameterTypes.get(index);
+                if (index == parameterTypes.size() - 1) {
+                    JavaType.Array array = TypeUtils.asArray(parameterType);
+                    if (array != null) {
+                        return array.getElemType();
+                    }
+                }
+                return parameterType;
             }
 
             private boolean areMethodsAmbiguous(JavaType.@Nullable Method m1, JavaType.@Nullable Method m2) {

--- a/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/UseLambdaForFunctionalInterfaceTest.java
@@ -116,6 +116,68 @@ class UseLambdaForFunctionalInterfaceTest implements RewriteTest {
         );
     }
 
+    @Test
+    void varargsArgumentAfterFixedArguments() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  interface I { int run(); }
+                  static void of(Object... args) {}
+                  void test(Object first) {
+                      of(first, new I() {
+                          @Override public int run() {
+                              return 0;
+                          }
+                      });
+                  }
+              }
+              """,
+            """
+              class Test {
+                  interface I { int run(); }
+                  static void of(Object... args) {}
+                  void test(Object first) {
+                      of(first, (I) () -> 0);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void functionalInterfaceVarargsNeedsNoCast() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class Test {
+                  interface I { int run(); }
+                  static void of(I... args) {}
+                  void test() {
+                      of(new I() {
+                          @Override public int run() {
+                              return 0;
+                          }
+                      });
+                  }
+              }
+              """,
+            """
+              class Test {
+                  interface I { int run(); }
+                  static void of(I... args) {}
+                  void test() {
+                      of(() -> 0);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/194")
     @SuppressWarnings("ConstantConditions")
     @Test


### PR DESCRIPTION
## What's changed?

Fix `UseLambdaForFunctionalInterface` handling of varargs.

## What's your motivation?

Otherwise it might fail with:
```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
  java.base/java.util.Arrays$ArrayList.get(Arrays.java:4225)
  org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface$1.methodArgumentRequiresCast(UseLambdaForFunctionalInterface.java:249)
  org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface$1.maybeAddCast(UseLambdaForFunctionalInterface.java:160)
  org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface$1.convertToLambda(UseLambdaForFunctionalInterface.java:149)
  org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface$1.visitNewClass(UseLambdaForFunctionalInterface.java:98)
  org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface$1.visitNewClass(UseLambdaForFunctionalInterface.java:54)
  org.openrewrite.java.tree.J$NewClass.acceptJava(J.java:4839)
  org.openrewrite.java.tree.J.accept(J.java:55)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:242)
  org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:328)
  org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1350)
  org.openrewrite.java.JavaVisitor.lambda$visitContainer$35(JavaVisitor.java:1400)
  org.openrewrite.internal.ListUtils.map(ListUtils.java:245)
  org.openrewrite.internal.ListUtils.map(ListUtils.java:269)
  org.openrewrite.java.JavaVisitor.visitContainer(JavaVisitor.java:1400)
  org.openrewrite.java.JavaVisitor.visitMethodInvocation(JavaVisitor.java:917)
```