### PR TITLE
SimplifyElseBranch not to produce el if for Python

### DIFF
--- a/src/main/java/org/openrewrite/staticanalysis/SimplifyElseBranch.java
+++ b/src/main/java/org/openrewrite/staticanalysis/SimplifyElseBranch.java
@@ -19,14 +19,21 @@ import lombok.Getter;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.ReflectionUtils;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.python.tree.Py;
+
+import java.util.List;
 
 import static org.openrewrite.java.format.ShiftFormat.indent;
 
 public class SimplifyElseBranch extends Recipe {
+
+    private static final boolean IS_PYTHON_AVAILABLE = ReflectionUtils.isClassAvailable("org.openrewrite.python.tree.Py");
 
     @Getter
     final String displayName = "Simplify `else` branch if it only has a single `if`";
@@ -46,10 +53,20 @@ public class SimplifyElseBranch extends Recipe {
                     if (block.getStatements().size() == 1) {
                         Statement firstStatement = block.getStatements().get(0);
                         if (firstStatement instanceof J.If) {
+                            List<Comment> comments = ListUtils.concatAll(block.getComments(), firstStatement.getComments());
+                            if (IS_PYTHON_AVAILABLE && getCursor().firstEnclosing(Py.CompilationUnit.class) != null) {
+                                // Python renders `else` + `if` as a single `elif` keyword, so the `if` keeps an empty
+                                // prefix and any comments move ahead of it, onto the `elif` line
+                                Space elsePrefix = elseStatement.getPrefix();
+                                Space withComments = elsePrefix.withComments(ListUtils.concatAll(elsePrefix.getComments(),
+                                        ListUtils.map(comments, c -> c.withSuffix(elsePrefix.getWhitespace()))));
+                                J.If ifStatement = firstStatement.withPrefix(Space.EMPTY);
+                                return elseStatement.withPrefix(withComments).withBody(indent(ifStatement, getCursor(), -1));
+                            }
                             // Combine comments from the block and the if statement
                             J.If ifStatement = firstStatement
                                     .withPrefix(Space.SINGLE_SPACE)
-                                    .withComments(ListUtils.concatAll(block.getComments(), firstStatement.getComments()));
+                                    .withComments(comments);
                             return elseStatement.withBody(indent(ifStatement, getCursor(), -1));
                         }
                     }

--- a/src/test/java/org/openrewrite/staticanalysis/SimplifyElseBranchTest.java
+++ b/src/test/java/org/openrewrite/staticanalysis/SimplifyElseBranchTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.python.Assertions.python;
 
 class SimplifyElseBranchTest implements RewriteTest {
 
@@ -344,4 +345,71 @@ class SimplifyElseBranchTest implements RewriteTest {
               """
           )
         );
-    }}
+    }
+
+    @Test
+    void simplifyElseBranchPython() {
+        rewriteRun(
+          //language=python
+          python(
+            """
+              def a(password):
+                  if len(password) < 6:
+                      print("Password is too short.")
+                  else:
+                      if len(password) > 12:
+                          print("Password is too long.")
+              """,
+            """
+              def a(password):
+                  if len(password) < 6:
+                      print("Password is too short.")
+                  elif len(password) > 12:
+                      print("Password is too long.")
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyElseBranchPythonWithComments() {
+        rewriteRun(
+          //language=python
+          python(
+            """
+              def a(password):
+                  if len(password) < 6:
+                      print("Password is too short.")
+                  else:
+                      # Comment 1
+                      if len(password) > 12:
+                          print("Password is too long.")
+              """,
+            """
+              def a(password):
+                  if len(password) < 6:
+                      print("Password is too short.")
+                  # Comment 1
+                  elif len(password) > 12:
+                      print("Password is too long.")
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeExistingElifPython() {
+        rewriteRun(
+          //language=python
+          python(
+            """
+              def a(password):
+                  if len(password) < 6:
+                      print("Password is too short.")
+                  elif len(password) > 12:
+                      print("Password is too long.")
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Fixing `SimplifyElseBrancxh` recipe not to produce `el if` for Python code. `elif` should be produced instead.

## What's your motivation?

`el if` is invalid Python. And comes from the fact how this construction is modelled in LST. J.Else + J.If.